### PR TITLE
feat: add offline mode support for tags command

### DIFF
--- a/crates/package-manager/src/lib.rs
+++ b/crates/package-manager/src/lib.rs
@@ -9,7 +9,7 @@ mod storage;
 
 pub use manager::Manager;
 pub use oci_client::Reference;
-pub use storage::{ImageEntry, InsertResult, KnownPackage, StateInfo, WitInterface};
+pub use storage::{CachedTags, ImageEntry, InsertResult, KnownPackage, StateInfo, WitInterface};
 
 /// Format a byte size as a human-readable string (B, KB, MB, GB).
 #[must_use]

--- a/crates/package-manager/src/manager/mod.rs
+++ b/crates/package-manager/src/manager/mod.rs
@@ -1,7 +1,9 @@
 use oci_client::Reference;
 
 use crate::network::Client;
-use crate::storage::{ImageEntry, InsertResult, KnownPackage, StateInfo, Store, WitInterface};
+use crate::storage::{
+    CachedTags, ImageEntry, InsertResult, KnownPackage, StateInfo, Store, WitInterface,
+};
 
 /// A cache on disk
 #[derive(Debug)]
@@ -110,6 +112,14 @@ impl Manager {
     /// List all tags for a given reference from the registry.
     pub async fn list_tags(&self, reference: &Reference) -> anyhow::Result<Vec<String>> {
         self.client.list_tags(reference).await
+    }
+
+    /// Get cached tags for a given reference from the local database.
+    /// Returns a tuple of (release_tags, signature_tags, attestation_tags).
+    /// Returns None if no cached tags are available.
+    pub fn get_cached_tags(&self, reference: &Reference) -> anyhow::Result<Option<CachedTags>> {
+        self.store
+            .get_cached_tags(reference.registry(), reference.repository())
     }
 
     /// Re-scan known package tags to update derived data (e.g., tag types).

--- a/crates/package-manager/src/storage/mod.rs
+++ b/crates/package-manager/src/storage/mod.rs
@@ -4,6 +4,7 @@ mod store;
 mod wit_parser;
 
 pub use config::StateInfo;
+pub use models::CachedTags;
 pub use models::ImageEntry;
 pub use models::InsertResult;
 pub use models::KnownPackage;

--- a/crates/package-manager/src/storage/models/mod.rs
+++ b/crates/package-manager/src/storage/models/mod.rs
@@ -4,7 +4,7 @@ mod migration;
 mod wit_interface;
 
 pub use image_entry::{ImageEntry, InsertResult};
-pub use known_package::KnownPackage;
 pub(crate) use known_package::TagType;
+pub use known_package::{CachedTags, KnownPackage};
 pub(crate) use migration::Migrations;
 pub use wit_interface::WitInterface;

--- a/crates/package-manager/src/storage/store.rs
+++ b/crates/package-manager/src/storage/store.rs
@@ -3,7 +3,9 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use super::config::StateInfo;
-use super::models::{ImageEntry, InsertResult, KnownPackage, Migrations, TagType, WitInterface};
+use super::models::{
+    CachedTags, ImageEntry, InsertResult, KnownPackage, Migrations, TagType, WitInterface,
+};
 use super::wit_parser::extract_wit_metadata;
 use futures_concurrency::prelude::*;
 use oci_client::{Reference, client::ImageData};
@@ -269,6 +271,16 @@ impl Store {
         }
 
         Ok(updated_count)
+    }
+
+    /// Get cached tags for a specific registry and repository.
+    /// Returns a tuple of (release_tags, signature_tags, attestation_tags).
+    pub(crate) fn get_cached_tags(
+        &self,
+        registry: &str,
+        repository: &str,
+    ) -> anyhow::Result<Option<CachedTags>> {
+        KnownPackage::get_cached_tags(&self.conn, registry, repository)
     }
 
     /// Get all WIT interfaces.


### PR DESCRIPTION
## Summary

Implement offline fallback for the `wasm package tags` command. When network is unavailable, the command now falls back to cached tags from previously pulled packages.

## Changes

- Add `CachedTags` type alias for `(release_tags, signature_tags, attestation_tags)`
- Add `get_cached_tags` method to `KnownPackage`, `Store`, and `Manager`
- Update CLI tags command to try network first, fall back to cache
- Display "(cached)" indicator when showing cached tags
- Add test for `get_cached_tags` functionality

## Testing

All existing tests pass. Added new test `test_known_package_get_cached_tags` to verify the cache lookup behavior.

Part of #71