### PR TITLE
Address PR review feedback for frontend spacing consistency and docs accuracy

### DIFF
--- a/.config/impeccable/.impeccable.md
+++ b/.config/impeccable/.impeccable.md
@@ -33,18 +33,20 @@ The tool should feel like a sharp, reliable instrument that stays out of the way
 
 ### Color System
 
-All frontend color tokens have light and dark variants, driven by CSS custom
-properties (see `layout.rs`). The accent color is constant across themes.
+All frontend colors use OKLCH, rooted in the Wasm logo purple (hue 280).
+Neutrals use hue 290 for a violet tint. All text tokens pass WCAG AA (4.5:1)
+against `bg`. See `layout.rs` for the full token list.
 
-| Token          | Light     | Dark      | Usage                                        |
-|----------------|-----------|-----------|----------------------------------------------|
-| Accent         | `#512FEB` | `#512FEB` | Primary interactive color, links, highlights |
-| Text primary   | Gray 900  | Gray 100  | Body text, headings                          |
-| Text secondary | Gray 600  | Gray 400  | Descriptions, metadata                       |
-| Text muted     | Gray 500  | Gray 500  | Timestamps, help text                        |
-| Border         | Gray 200  | Gray 800  | Card borders, dividers                       |
-| Background     | White     | Gray 950  | Page background                              |
-| Code bg        | Gray 100  | Gray 900  | Inline code backgrounds                      |
+| Token          | Light                     | Dark                      | Usage                                        |
+|----------------|---------------------------|---------------------------|----------------------------------------------|
+| Accent         | `oklch(0.49 0.257 280)`   | `oklch(0.70 0.16 280)`    | Primary interactive color, links, highlights |
+| Text primary   | `oklch(0.20 0.03 290)`    | `oklch(0.94 0.01 290)`    | Body text, headings                          |
+| Text secondary | `oklch(0.40 0.03 290)`    | `oklch(0.78 0.025 290)`   | Descriptions, metadata                       |
+| Text muted     | `oklch(0.54 0.025 290)`   | `oklch(0.66 0.03 290)`    | Timestamps, help text                        |
+| Text faint     | `oklch(0.56 0.02 290)`    | `oklch(0.62 0.025 290)`   | Version numbers, counts, minor labels        |
+| Border         | `oklch(0.91 0.018 290)`   | `oklch(0.32 0.04 290)`    | Card borders, dividers                       |
+| Background     | `oklch(1 0 290)`          | `oklch(0.185 0.025 290)`  | Page background                              |
+| Surface        | `oklch(0.975 0.006 290)`  | `oklch(0.23 0.03 290)`    | Inline code backgrounds, hover surfaces      |
 
 **CLI colors**: Green (success/checkmarks), Yellow (active/progress bars),
 Dim (secondary info like versions and sizes).

--- a/.config/impeccable/.impeccable.md
+++ b/.config/impeccable/.impeccable.md
@@ -82,3 +82,30 @@ Dark Gray (help text, disabled), Magenta/Blue/Green (WIT syntax highlighting).
 5. **Accessible by default** — Standard accessibility best practices: sufficient
    color contrast, semantic HTML, keyboard navigation, respect for user
    preferences (color, motion).
+
+### Learned Preferences
+
+- **Strip, don't add.** When something feels wrong, the answer is almost always
+  to remove elements rather than add new ones. The header bar was removed
+  entirely in favor of a minimal transparent nav. The subtitle was removed. The
+  CTA was demoted from a button to a text link. Less is more — always.
+- **No chrome.** Background colors on nav bars, colored headers, decorative
+  borders — all rejected. The nav should be invisible: just a wordmark and a
+  few text links floating at the top. No background, no border, no visual weight.
+- **Hierarchy through spacing, not decoration.** Sections are separated by
+  generous whitespace (`mb-10`, `pb-16`), not borders or background bands. Group
+  related elements tightly and separate groups with breathing room.
+- **Text links over buttons for secondary actions.** "Publish a component →" is a
+  text link, not a button. Only the search submit gets button treatment. Keep
+  visual weight proportional to importance.
+- **Cards over rows.** Package listings use a responsive card grid
+  (1 / 2 / 3 columns), not a vertical list of rows. Reference: zed.dev/extensions.
+- **Search is the hero.** The search bar is the primary interactive element on
+  the landing page — autofocused, prominent, with the package count baked into
+  the placeholder text. Everything else supports discovery.
+- **Monospace for identity.** Package names (`wasi:http`), commands
+  (`wasm install`), and versions use monospace. This isn't decoration — it
+  signals "this is something you type."
+- **Dark mode is not an afterthought.** Every color token must pass WCAG AA in
+  both themes. The accent purple needs to be lighter in dark mode
+  (`oklch(0.70 0.16 280)`) to maintain contrast. Test both themes.

--- a/.github/skills/oklch-colors/SKILL.md
+++ b/.github/skills/oklch-colors/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: oklch-colors
+description: 'OKLCH color space reference for CSS. Use when: choosing colors, building palettes, converting hex/rgb/hsl to oklch, checking perceived lightness, creating accessible color scales, working with P3 or wide-gamut colors.'
+---
+
+OKLCH captures perceived Lightness, Chroma, Hue, and Alpha. Values are human-readable and differences are predictable just by reading them. It represents wide-gamut colors (P3, Rec2020) that HSL and RGB cannot.
+
+OKLCH improves on LCH by fixing a bug in the blue chroma range and providing better [gamut correction](https://bottosson.github.io/posts/gamutclipping/).
+
+## Syntax
+
+```css
+.c { color: oklch(0.8 0.12 100 / 100%); }
+/*                ^   ^    ^     ^
+                  |   |    |     |
+          lightness   |    |     |
+               chroma |    |     |
+                     hue   |     |
+                       alpha     */
+```
+
+- **Lightness** `0–1`: Perceived brightness. `0` = black, `1` = white. Equal steps look equal.
+- **Chroma** `0–0.4`: Color intensity. `0` = gray, higher = more vivid. Most usable colors sit between `0.05–0.2`.
+- **Hue** `0–360`: Color wheel angle. `0` = pink/red, `90` = yellow, `150` = green, `225` = blue, `300` = purple.
+- **Alpha** `0%–100%`: Opacity. Optional, defaults to 100%.
+
+## Quick Reference
+
+```css
+.bw {
+  color: oklch(0 0 0);       /* black */
+  color: oklch(1 0 0);       /* white */
+  color: oklch(0.5 0 0);     /* gray (any hue at chroma 0 is gray) */
+}
+.colors {
+  color: oklch(0.8 0.12 100);  /* yellow */
+  color: oklch(0.6 0.12 100);  /* darker yellow — only lightness changed */
+  color: oklch(0.8 0.05 100);  /* grayish yellow — only chroma changed */
+  color: oklch(0.8 0.12 225);  /* blue, same perceived lightness as the yellow */
+}
+.opacity {
+  color: oklch(0.8 0.12 100 / 50%);  /* 50% transparent yellow */
+}
+```
+
+## Key Advantages
+
+- **Perceptually uniform**: Equal lightness steps *look* equal. Two colors at `L=0.7` appear equally bright regardless of hue — not true in HSL.
+- **Predictable manipulation**: Darken by subtracting from L, desaturate by reducing C, shift hue by changing H. Each axis is independent.
+- **Wide gamut**: Represents P3 and Rec2020 colors that sRGB hex/rgb cannot.
+- **Better than LCH**: Fixes the blue hue shift bug present in CIE LCH.
+
+## Building Accessible Scales
+
+To create a color scale with guaranteed contrast:
+
+```css
+/* Same hue (250 = violet), decreasing lightness */
+--violet-100: oklch(0.95 0.03 250);  /* lightest, backgrounds */
+--violet-300: oklch(0.80 0.08 250);  /* borders, subtle accents */
+--violet-500: oklch(0.65 0.15 250);  /* primary accent */
+--violet-700: oklch(0.45 0.15 250);  /* dark foreground on light bg */
+--violet-900: oklch(0.25 0.10 250);  /* darkest, text on light bg */
+```
+
+Each 0.15 lightness step gives roughly 3:1 contrast between adjacent levels.
+
+## Common Patterns
+
+**Tinted neutrals** — warm or cool grays with a subtle hue:
+```css
+--neutral-warm: oklch(0.95 0.01 60);   /* warm off-white */
+--neutral-cool: oklch(0.95 0.01 250);  /* cool off-white */
+```
+
+**Semantic colors** — consistent lightness for equal visual weight:
+```css
+--success: oklch(0.72 0.17 145);  /* green */
+--warning: oklch(0.80 0.16 75);   /* amber */
+--error:   oklch(0.65 0.20 25);   /* red */
+--info:    oklch(0.70 0.12 240);  /* blue */
+```
+
+**Dark mode counterparts** — same hue/chroma, higher lightness:
+```css
+/* Light mode accent */
+--accent: oklch(0.55 0.20 285);
+/* Dark mode — raise lightness to maintain contrast on dark bg */
+--accent: oklch(0.75 0.15 285);
+```
+
+## Tooling
+
+- **Color picker**: [oklch.com](https://oklch.com)
+- **Palette generator**: [huetone.ardov.me](https://huetone.ardov.me)
+- **Figma plugin**: [OkColor](https://www.figma.com/community/plugin/1173638098109123591/okcolor)
+- **Batch conversion**: `npx convert-to-oklch ./src/**/*.css`

--- a/crates/wasm-frontend/src/layout.rs
+++ b/crates/wasm-frontend/src/layout.rs
@@ -15,8 +15,8 @@ use crate::nav;
 
 /// Accent color used throughout the UI.
 ///
-/// RGB: R81 G47 B235 → `#512FEB`.
-pub(crate) const ACCENT_COLOR: &str = "#512FEB";
+/// Wasm logo purple in OKLCH: L=0.49, C=0.257, H=280.
+pub(crate) const ACCENT_COLOR: &str = "oklch(0.49 0.257 280)";
 
 /// Render a complete HTML document with the given title and body content.
 ///
@@ -74,31 +74,35 @@ pub(crate) fn document(title: &str, body_content: &str) -> String {
     }}
   </script>
   <style>
+    /* Color system: OKLCH, rooted in Wasm logo purple (hue 280).
+       Neutrals use hue 290 for a violet tint. All text tokens
+       pass WCAG AA (4.5:1) against bg. */
     :root {{
-      --color-bg: #ffffff;
+      --color-bg: oklch(1 0 290);
       --color-accent: {ACCENT_COLOR};
-      --color-accent-hover: #6a4bf0;
-      --color-surface: #f8f7fb;
-      --color-surface-muted: #f1eff6;
-      --color-border: #e4e0ed;
-      --color-border-light: #eeeaf5;
-      --color-fg: #1a1625;
-      --color-fg-secondary: #534e63;
-      --color-fg-muted: #7c7691;
-      --color-fg-faint: #a9a3bc;
+      --color-accent-hover: oklch(0.42 0.257 280);
+      --color-surface: oklch(0.975 0.006 290);
+      --color-surface-muted: oklch(0.955 0.01 290);
+      --color-border: oklch(0.91 0.018 290);
+      --color-border-light: oklch(0.94 0.014 290);
+      --color-fg: oklch(0.20 0.03 290);
+      --color-fg-secondary: oklch(0.40 0.03 290);
+      --color-fg-muted: oklch(0.54 0.025 290);
+      --color-fg-faint: oklch(0.56 0.02 290);
     }}
     @media (prefers-color-scheme: dark) {{
       :root {{
-        --color-bg: #13111d;
-        --color-accent-hover: #9678ff;
-        --color-surface: #1e1b2e;
-        --color-surface-muted: #252238;
-        --color-border: #352f4a;
-        --color-border-light: #2d2842;
-        --color-fg: #eae8f0;
-        --color-fg-secondary: #b8b3c8;
-        --color-fg-muted: #8e88a3;
-        --color-fg-faint: #6b6580;
+        --color-bg: oklch(0.185 0.025 290);
+        --color-accent: oklch(0.70 0.16 280);
+        --color-accent-hover: oklch(0.76 0.13 280);
+        --color-surface: oklch(0.23 0.03 290);
+        --color-surface-muted: oklch(0.26 0.035 290);
+        --color-border: oklch(0.32 0.04 290);
+        --color-border-light: oklch(0.29 0.038 290);
+        --color-fg: oklch(0.94 0.01 290);
+        --color-fg-secondary: oklch(0.78 0.025 290);
+        --color-fg-muted: oklch(0.66 0.03 290);
+        --color-fg-faint: oklch(0.62 0.025 290);
       }}
     }}
     /* Consistent focus ring for keyboard navigation */

--- a/crates/wasm-frontend/src/layout.rs
+++ b/crates/wasm-frontend/src/layout.rs
@@ -29,6 +29,7 @@ pub(crate) fn document(title: &str, body_content: &str) -> String {
         "Home" => "/",
         "All Packages" => "/all",
         "About" => "/about",
+        "Docs" => "/docs",
         "Search" => "/search",
         _ => "",
     };
@@ -118,7 +119,7 @@ pub(crate) fn document(title: &str, body_content: &str) -> String {
 </head>
 <body class="bg-page text-fg min-h-screen flex flex-col leading-relaxed">
   {nav}
-  <main class="flex-1 w-full max-w-5xl mx-auto px-4 sm:px-6 py-10">
+  <main class="flex-1 w-full max-w-5xl mx-auto px-4 sm:px-6 pb-10">
     {body_content}
   </main>
   {footer}

--- a/crates/wasm-frontend/src/lib.rs
+++ b/crates/wasm-frontend/src/lib.rs
@@ -34,6 +34,7 @@ fn app() -> Router {
         .route("/all", get(all_packages))
         .route("/search", get(search))
         .route("/about", get(about))
+        .route("/docs", get(docs))
         .route("/health", get(health))
         .route("/{namespace}/{name}", get(package_redirect))
         .route("/{namespace}/{name}/{version}", get(package_detail))
@@ -106,6 +107,12 @@ async fn all_packages(Query(params): Query<AllPackagesParams>) -> Response {
 /// About page (placeholder).
 async fn about() -> Response {
     let html = pages::about::render();
+    with_cache_control(html, "public, max-age=3600")
+}
+
+/// Documentation page.
+async fn docs() -> Response {
+    let html = pages::docs::render();
     with_cache_control(html, "public, max-age=3600")
 }
 

--- a/crates/wasm-frontend/src/nav.rs
+++ b/crates/wasm-frontend/src/nav.rs
@@ -10,53 +10,25 @@ pub(crate) fn render(current_path: &str) -> String {
     } else {
         ""
     };
+    let docs_aria = if current_path == "/docs" {
+        r#" aria-current="page""#
+    } else {
+        ""
+    };
     let about_aria = if current_path == "/about" {
         r#" aria-current="page""#
     } else {
         ""
     };
 
-    let is_home = current_path == "/";
-    let search_desktop = if is_home {
-        ""
-    } else {
-        r#"<form action="/search" method="get" class="hidden sm:flex flex-1 max-w-md mx-4">
-      <input type="search" name="q" placeholder="Search packages…" aria-label="Search packages" class="w-full px-3 py-1.5 rounded-l text-sm bg-white/15 text-white placeholder:text-white/60 border border-white/20 focus:bg-white/25 focus:border-white/40 focus:outline-none transition-colors">
-      <button type="submit" class="px-3 py-1.5 rounded-r text-sm font-medium bg-white/20 border border-l-0 border-white/20 hover:bg-white/30 transition-colors">Search</button>
-    </form>"#
-    };
-    let search_mobile = if is_home {
-        ""
-    } else {
-        r#"<form action="/search" method="get" class="flex mb-2">
-          <input type="search" name="q" placeholder="Search packages…" aria-label="Search packages" class="flex-1 px-3 py-2 rounded-l text-sm bg-white/15 text-white placeholder:text-white/60 border border-white/20 focus:bg-white/25 focus:border-white/40 focus:outline-none transition-colors">
-          <button type="submit" class="px-3 py-2 rounded-r text-sm font-medium bg-white/20 border border-l-0 border-white/20 hover:bg-white/30 transition-colors">Search</button>
-        </form>"#
-    };
-
     format!(
-        r#"<header class="bg-accent text-white">
-  <nav class="max-w-5xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-4" aria-label="Main">
-    <a href="/" class="text-xl font-bold tracking-tight hover:text-white/80 transition-colors shrink-0">wasm</a>
-    {search_desktop}
-    <div class="hidden sm:flex gap-6 text-sm font-medium shrink-0">
-      <a href="/all" class="underline-offset-4 hover:underline transition-colors"{all_aria}>All Packages</a>
-      <a href="/about" class="underline-offset-4 hover:underline transition-colors"{about_aria}>About</a>
-    </div>
-    <details class="sm:hidden relative">
-      <summary class="list-none cursor-pointer p-2 -mr-2 rounded hover:bg-white/10 transition-colors" aria-label="Toggle menu">
-        <span class="sr-only">Toggle menu</span>
-        <svg class="w-5 h-5 inline-block" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/>
-        </svg>
-      </summary>
-      <div class="absolute right-0 mt-2 w-56 bg-accent border border-white/20 rounded-md shadow-lg px-3 py-2 space-y-1 text-sm font-medium z-10">
-        {search_mobile}
-        <a href="/all" class="block py-2 px-2 rounded hover:bg-white/10 transition-colors"{all_aria}>All Packages</a>
-        <a href="/about" class="block py-2 px-2 rounded hover:bg-white/10 transition-colors"{about_aria}>About</a>
-      </div>
-    </details>
-  </nav>
-</header>"#,
+        r#"<nav class="w-full max-w-5xl mx-auto px-4 sm:px-6 pt-6 pb-2 flex items-center justify-between" aria-label="Main">
+  <a href="/" class="text-lg font-bold tracking-tight text-fg hover:text-accent transition-colors">wasm</a>
+  <div class="flex gap-5 text-sm">
+    <a href="/all" class="text-fg-muted hover:text-fg transition-colors"{all_aria}>Packages</a>
+    <a href="/docs" class="text-fg-muted hover:text-fg transition-colors"{docs_aria}>Docs</a>
+    <a href="/about" class="text-fg-muted hover:text-fg transition-colors"{about_aria}>About</a>
+  </div>
+</nav>"#,
     )
 }

--- a/crates/wasm-frontend/src/nav.rs
+++ b/crates/wasm-frontend/src/nav.rs
@@ -16,14 +16,29 @@ pub(crate) fn render(current_path: &str) -> String {
         ""
     };
 
+    let is_home = current_path == "/";
+    let search_desktop = if is_home {
+        ""
+    } else {
+        r#"<form action="/search" method="get" class="hidden sm:flex flex-1 max-w-md mx-4">
+      <input type="search" name="q" placeholder="Search packages…" aria-label="Search packages" class="w-full px-3 py-1.5 rounded-l text-sm bg-white/15 text-white placeholder:text-white/60 border border-white/20 focus:bg-white/25 focus:border-white/40 focus:outline-none transition-colors">
+      <button type="submit" class="px-3 py-1.5 rounded-r text-sm font-medium bg-white/20 border border-l-0 border-white/20 hover:bg-white/30 transition-colors">Search</button>
+    </form>"#
+    };
+    let search_mobile = if is_home {
+        ""
+    } else {
+        r#"<form action="/search" method="get" class="flex mb-2">
+          <input type="search" name="q" placeholder="Search packages…" aria-label="Search packages" class="flex-1 px-3 py-2 rounded-l text-sm bg-white/15 text-white placeholder:text-white/60 border border-white/20 focus:bg-white/25 focus:border-white/40 focus:outline-none transition-colors">
+          <button type="submit" class="px-3 py-2 rounded-r text-sm font-medium bg-white/20 border border-l-0 border-white/20 hover:bg-white/30 transition-colors">Search</button>
+        </form>"#
+    };
+
     format!(
         r#"<header class="bg-accent text-white">
   <nav class="max-w-5xl mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-4" aria-label="Main">
     <a href="/" class="text-xl font-bold tracking-tight hover:text-white/80 transition-colors shrink-0">wasm</a>
-    <form action="/search" method="get" class="hidden sm:flex flex-1 max-w-md mx-4">
-      <input type="search" name="q" placeholder="Search packages…" aria-label="Search packages" class="w-full px-3 py-1.5 rounded-l text-sm bg-white/15 text-white placeholder:text-white/60 border border-white/20 focus:bg-white/25 focus:border-white/40 focus:outline-none transition-colors">
-      <button type="submit" class="px-3 py-1.5 rounded-r text-sm font-medium bg-white/20 border border-l-0 border-white/20 hover:bg-white/30 transition-colors">Search</button>
-    </form>
+    {search_desktop}
     <div class="hidden sm:flex gap-6 text-sm font-medium shrink-0">
       <a href="/all" class="underline-offset-4 hover:underline transition-colors"{all_aria}>All Packages</a>
       <a href="/about" class="underline-offset-4 hover:underline transition-colors"{about_aria}>About</a>
@@ -36,10 +51,7 @@ pub(crate) fn render(current_path: &str) -> String {
         </svg>
       </summary>
       <div class="absolute right-0 mt-2 w-56 bg-accent border border-white/20 rounded-md shadow-lg px-3 py-2 space-y-1 text-sm font-medium z-10">
-        <form action="/search" method="get" class="flex mb-2">
-          <input type="search" name="q" placeholder="Search packages…" aria-label="Search packages" class="flex-1 px-3 py-2 rounded-l text-sm bg-white/15 text-white placeholder:text-white/60 border border-white/20 focus:bg-white/25 focus:border-white/40 focus:outline-none transition-colors">
-          <button type="submit" class="px-3 py-2 rounded-r text-sm font-medium bg-white/20 border border-l-0 border-white/20 hover:bg-white/30 transition-colors">Search</button>
-        </form>
+        {search_mobile}
         <a href="/all" class="block py-2 px-2 rounded hover:bg-white/10 transition-colors"{all_aria}>All Packages</a>
         <a href="/about" class="block py-2 px-2 rounded hover:bg-white/10 transition-colors"{about_aria}>About</a>
       </div>

--- a/crates/wasm-frontend/src/pages/about.rs
+++ b/crates/wasm-frontend/src/pages/about.rs
@@ -8,7 +8,7 @@ use crate::layout;
 #[must_use]
 pub(crate) fn render() -> String {
     let body = Division::builder()
-        .class("max-w-[65ch]")
+        .class("pt-8 max-w-[65ch]")
         .heading_1(|h1| h1.class("text-3xl font-bold tracking-tight mb-6").text("About"))
         .paragraph(|p| {
             p.class("text-fg-secondary leading-relaxed")

--- a/crates/wasm-frontend/src/pages/all.rs
+++ b/crates/wasm-frontend/src/pages/all.rs
@@ -67,7 +67,7 @@ fn render_error(err: &ApiError, offset: u32, limit: u32) -> String {
     let mut body = Division::builder();
 
     body.division(|div| {
-        div.class("pb-6 border-b border-border mb-6")
+        div.class("pt-8 pb-6 border-b border-border mb-6")
             .heading_1(|h1| {
                 h1.class("text-3xl font-bold tracking-tight")
                     .text("All Packages")

--- a/crates/wasm-frontend/src/pages/all.rs
+++ b/crates/wasm-frontend/src/pages/all.rs
@@ -22,7 +22,7 @@ fn render_packages(packages: &[KnownPackage], offset: u32, limit: u32) -> String
 
     // Page header with count
     body.division(|div| {
-        div.class("flex items-baseline justify-between pb-6 border-b border-border mb-6")
+        div.class("pt-8 flex items-baseline justify-between pb-6 border-b border-border mb-6")
             .heading_1(|h1| {
                 h1.class("text-3xl font-bold tracking-tight")
                     .text("All Packages")

--- a/crates/wasm-frontend/src/pages/docs.rs
+++ b/crates/wasm-frontend/src/pages/docs.rs
@@ -1,0 +1,23 @@
+//! Documentation page.
+
+use html::text_content::Division;
+
+use crate::layout;
+
+/// Render the documentation page.
+#[must_use]
+pub(crate) fn render() -> String {
+    let body = Division::builder()
+        .class("pt-8 max-w-[65ch]")
+        .heading_1(|h1| {
+            h1.class("text-3xl font-bold tracking-tight mb-6")
+                .text("Documentation")
+        })
+        .paragraph(|p| {
+            p.class("text-fg-secondary leading-relaxed")
+                .text("Documentation is coming soon.")
+        })
+        .build();
+
+    layout::document("Docs", &body.to_string())
+}

--- a/crates/wasm-frontend/src/pages/home.rs
+++ b/crates/wasm-frontend/src/pages/home.rs
@@ -125,7 +125,7 @@ fn split_by_kind(packages: &[KnownPackage]) -> (Vec<&KnownPackage>, Vec<&KnownPa
     (components, interfaces)
 }
 
-/// Render a section with a heading, a grid of package rows, and a "view all" link.
+/// Render a section with a heading, a grid of package cards, and a "view all" link.
 fn render_section(heading: &str, packages: &[&KnownPackage]) -> Section {
     let has_more = packages.len() > HOME_SECTION_LIMIT;
     let visible = packages.get(..HOME_SECTION_LIMIT).unwrap_or(packages);

--- a/crates/wasm-frontend/src/pages/home.rs
+++ b/crates/wasm-frontend/src/pages/home.rs
@@ -161,13 +161,13 @@ fn render_section(heading: &str, packages: &[&KnownPackage]) -> Section {
                 .text(format!("No {heading} found yet."))
         });
     } else {
-        // Package list — compact rows instead of card grid
-        let mut list = Division::builder();
-        list.class("divide-y divide-border-light");
+        // Package grid — card layout
+        let mut grid = Division::builder();
+        grid.class("grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4");
         for pkg in visible {
-            list.push(render_row(pkg));
+            grid.push(render_card(pkg));
         }
-        section.push(list.build());
+        section.push(grid.build());
 
         // "View all" link
         if has_more {
@@ -184,8 +184,8 @@ fn render_section(heading: &str, packages: &[&KnownPackage]) -> Section {
     section.build()
 }
 
-/// Render a single package as a compact row.
-fn render_row(pkg: &KnownPackage) -> Division {
+/// Render a single package as a card.
+fn render_card(pkg: &KnownPackage) -> Division {
     let display_name = match (&pkg.wit_namespace, &pkg.wit_name) {
         (Some(ns), Some(name)) => format!("{ns}:{name}"),
         _ => pkg.repository.clone(),
@@ -203,35 +203,35 @@ fn render_row(pkg: &KnownPackage) -> Division {
             .anchor(|a| {
                 a.href(format!("/{ns}/{name}"))
                     .class(
-                        "flex items-baseline gap-3 py-3 hover:bg-surface -mx-2 px-2 rounded transition-colors",
+                        "block border border-border rounded-lg p-4 hover:border-accent/40 hover:bg-surface transition-colors",
                     )
                     .span(|s| {
-                        s.class("font-semibold text-accent shrink-0")
+                        s.class("block font-semibold text-accent truncate")
                             .text(display_name)
                     })
                     .span(|s| {
-                        s.class("text-sm text-fg-faint shrink-0")
-                            .text(version.to_owned())
+                        s.class("block text-sm text-fg-muted mt-1 line-clamp-2")
+                            .text(description.to_owned())
                     })
                     .span(|s| {
-                        s.class("text-sm text-fg-muted truncate")
-                            .text(description.to_owned())
+                        s.class("block text-xs text-fg-faint mt-3 font-mono")
+                            .text(version.to_owned())
                     })
             })
             .build(),
         _ => Division::builder()
-            .class("flex items-baseline gap-3 py-3 -mx-2 px-2 rounded")
+            .class("border border-border rounded-lg p-4")
             .span(|s| {
-                s.class("font-semibold text-fg shrink-0")
+                s.class("block font-semibold text-fg truncate")
                     .text(display_name)
             })
             .span(|s| {
-                s.class("text-sm text-fg-faint shrink-0")
-                    .text(version.to_owned())
+                s.class("block text-sm text-fg-muted mt-1 line-clamp-2")
+                    .text(description.to_owned())
             })
             .span(|s| {
-                s.class("text-sm text-fg-muted truncate")
-                    .text(description.to_owned())
+                s.class("block text-xs text-fg-faint mt-3 font-mono")
+                    .text(version.to_owned())
             })
             .build(),
     }

--- a/crates/wasm-frontend/src/pages/home.rs
+++ b/crates/wasm-frontend/src/pages/home.rs
@@ -51,7 +51,7 @@ fn render_error(err: &ApiError) -> String {
     layout::document("Home", &body.build().to_string())
 }
 
-/// Render the hero area with heading, search form, and quick-install hint.
+/// Render the hero area with heading, search form, CTA, and quick-install hint.
 fn render_hero(total: usize) -> Division {
     let placeholder = if total > 0 {
         format!("Search {total} packages\u{2026}")
@@ -60,42 +60,50 @@ fn render_hero(total: usize) -> Division {
     };
 
     let mut hero = Division::builder();
-    hero.class("pb-12 border-b border-border mb-12");
+    hero.class("pt-8 pb-16 mb-10");
+
+    // Title and hint — grouped tightly
     hero.heading_1(|h1| {
         h1.class("text-3xl font-bold tracking-tight")
             .text("WebAssembly Package Registry")
     });
-
-    // Search — the primary action
-    hero.form(|form| {
-        form.action("/search")
-            .method("get")
-            .class("mt-6 flex max-w-lg")
-            .input(|input| {
-                input
-                    .type_("search")
-                    .name("q")
-                    .placeholder(placeholder)
-                    .aria_label("Search packages")
-                    .autofocus(true)
-                    .class("flex-1 px-4 py-2.5 rounded-l-md text-base border border-border bg-surface text-fg placeholder:text-fg-faint focus:border-accent focus:outline-none transition-colors")
-            })
-            .button(|btn| {
-                btn.type_("submit")
-                    .class("px-5 py-2.5 rounded-r-md text-sm font-medium bg-accent text-white hover:bg-accent-hover border border-accent transition-colors")
-                    .text("Search")
-            })
-    });
-
-    // Quick-install hint — communicates what this tool does
     hero.paragraph(|p| {
-        p.class("mt-4 text-sm text-fg-muted")
+        p.class("mt-2 text-sm text-fg-muted")
             .text("Get started: ")
             .code(|code| {
                 code.class(
                     "font-mono text-fg-secondary bg-surface-muted px-1.5 py-0.5 rounded text-xs",
                 )
                 .text("wasm install wasi:http")
+            })
+    });
+
+    // Search and CTA — grouped below with generous separation from title
+    hero.division(|row| {
+        row.class("mt-8 flex flex-col sm:flex-row gap-3 sm:items-center")
+            .form(|form| {
+                form.action("/search")
+                    .method("get")
+                    .class("flex flex-1 max-w-lg")
+                    .input(|input| {
+                        input
+                            .type_("search")
+                            .name("q")
+                            .placeholder(placeholder)
+                            .aria_label("Search packages")
+                            .autofocus(true)
+                            .class("flex-1 px-4 py-2.5 rounded-l-md text-base border border-border bg-surface text-fg placeholder:text-fg-faint focus:border-accent focus:outline-none transition-colors")
+                    })
+                    .button(|btn| {
+                        btn.type_("submit")
+                            .class("px-5 py-2.5 rounded-r-md text-sm font-medium bg-accent text-white hover:bg-accent-hover border border-accent transition-colors")
+                            .text("Search")
+                    })
+            })
+            .anchor(|a| {
+                a.href("/docs")
+                    .class("text-sm text-fg-muted hover:text-accent transition-colors shrink-0")
+                    .text("Publish a component \u{2192}")
             })
     });
 
@@ -132,11 +140,11 @@ fn render_section(heading: &str, packages: &[&KnownPackage]) -> Section {
     };
 
     let mut section = Section::builder();
-    section.class("mb-16");
+    section.class("mb-10");
 
     // Section header with icon, description, and count
     section.division(|div| {
-        div.class("mb-4")
+        div.class("mb-5")
             .division(|row| {
                 row.class("flex items-baseline justify-between")
                     .heading_2(|h2| {

--- a/crates/wasm-frontend/src/pages/home.rs
+++ b/crates/wasm-frontend/src/pages/home.rs
@@ -30,21 +30,8 @@ fn render_packages(packages: &[KnownPackage]) -> String {
     body.push(render_hero(packages.len()));
 
     // Package sections with generous separation
-    if let Some(section) = render_section("Interfaces", &interfaces) {
-        body.push(section);
-    }
-    if let Some(section) = render_section("Components", &components) {
-        body.push(section);
-    }
-
-    if packages.is_empty() {
-        body.division(|div| {
-            div.class("py-16 text-center").paragraph(|p| {
-                p.class("text-fg-muted")
-                    .text("No packages found. The registry may still be syncing.")
-            })
-        });
-    }
+    body.push(render_section("Interfaces", &interfaces));
+    body.push(render_section("Components", &components));
 
     layout::document("Home", &body.build().to_string())
 }
@@ -64,38 +51,65 @@ fn render_error(err: &ApiError) -> String {
     layout::document("Home", &body.build().to_string())
 }
 
-/// Render the hero area with title, subtitle, and package count.
+/// Render the hero area with heading, search form, and quick-install hint.
 fn render_hero(total: usize) -> Division {
+    let placeholder = if total > 0 {
+        format!("Search {total} packages\u{2026}")
+    } else {
+        "Search packages\u{2026}".to_owned()
+    };
+
     let mut hero = Division::builder();
     hero.class("pb-12 border-b border-border mb-12");
     hero.heading_1(|h1| {
         h1.class("text-3xl font-bold tracking-tight")
             .text("WebAssembly Package Registry")
     });
-    hero.paragraph(|p| {
-        p.class("text-fg-secondary mt-3 max-w-[50ch]")
-            .text("Browse WebAssembly components and WIT interfaces published to OCI registries.")
+
+    // Search — the primary action
+    hero.form(|form| {
+        form.action("/search")
+            .method("get")
+            .class("mt-6 flex max-w-lg")
+            .input(|input| {
+                input
+                    .type_("search")
+                    .name("q")
+                    .placeholder(placeholder)
+                    .aria_label("Search packages")
+                    .class("flex-1 px-4 py-2.5 rounded-l-md text-base border border-border bg-surface text-fg placeholder:text-fg-faint focus:border-accent focus:outline-none transition-colors")
+            })
+            .button(|btn| {
+                btn.type_("submit")
+                    .class("px-5 py-2.5 rounded-r-md text-sm font-medium bg-accent text-white hover:bg-accent-hover border border-accent transition-colors")
+                    .text("Search")
+            })
     });
-    if total > 0 {
-        hero.paragraph(|p| {
-            p.class("text-sm text-fg-faint mt-4")
-                .text(format!("{total} packages indexed"))
-        });
-    }
+
+    // Quick-install hint — communicates what this tool does
+    hero.paragraph(|p| {
+        p.class("mt-4 text-sm text-fg-muted")
+            .text("Get started: ")
+            .code(|code| {
+                code.class(
+                    "font-mono text-fg-secondary bg-surface-muted px-1.5 py-0.5 rounded text-xs",
+                )
+                .text("wasm install wasi:http")
+            })
+    });
+
     hero.build()
 }
 
-/// Split packages into (components, interfaces) based on WIT metadata.
+/// Split packages into (components, interfaces) based on package kind.
 fn split_by_kind(packages: &[KnownPackage]) -> (Vec<&KnownPackage>, Vec<&KnownPackage>) {
     let mut components = Vec::new();
     let mut interfaces = Vec::new();
 
     for pkg in packages {
-        // Packages without WIT metadata go into components as a fallback
-        if pkg.wit_namespace.is_none() {
-            components.push(pkg);
-        } else {
-            interfaces.push(pkg);
+        match pkg.kind {
+            Some(wasm_meta_registry_client::PackageKind::Interface) => interfaces.push(pkg),
+            _ => components.push(pkg),
         }
     }
 
@@ -103,11 +117,7 @@ fn split_by_kind(packages: &[KnownPackage]) -> (Vec<&KnownPackage>, Vec<&KnownPa
 }
 
 /// Render a section with a heading, a grid of package rows, and a "view all" link.
-fn render_section(heading: &str, packages: &[&KnownPackage]) -> Option<Section> {
-    if packages.is_empty() {
-        return None;
-    }
-
+fn render_section(heading: &str, packages: &[&KnownPackage]) -> Section {
     let has_more = packages.len() > HOME_SECTION_LIMIT;
     let visible = packages.get(..HOME_SECTION_LIMIT).unwrap_or(packages);
 
@@ -143,26 +153,34 @@ fn render_section(heading: &str, packages: &[&KnownPackage]) -> Option<Section> 
             })
     });
 
-    // Package list — compact rows instead of card grid
-    let mut list = Division::builder();
-    list.class("divide-y divide-border-light");
-    for pkg in visible {
-        list.push(render_row(pkg));
-    }
-    section.push(list.build());
-
-    // "View all" link
-    if has_more {
+    if packages.is_empty() {
+        // Empty state
         section.paragraph(|p| {
-            p.class("mt-4").anchor(|a| {
-                a.href("/all")
-                    .class("text-sm text-accent hover:underline")
-                    .text(format!("View all {heading} →"))
-            })
+            p.class("py-8 text-sm text-fg-faint")
+                .text(format!("No {heading} found yet."))
         });
+    } else {
+        // Package list — compact rows instead of card grid
+        let mut list = Division::builder();
+        list.class("divide-y divide-border-light");
+        for pkg in visible {
+            list.push(render_row(pkg));
+        }
+        section.push(list.build());
+
+        // "View all" link
+        if has_more {
+            section.paragraph(|p| {
+                p.class("mt-4").anchor(|a| {
+                    a.href("/all")
+                        .class("text-sm text-accent hover:underline")
+                        .text(format!("View all {heading} →"))
+                })
+            });
+        }
     }
 
-    Some(section.build())
+    section.build()
 }
 
 /// Render a single package as a compact row.
@@ -222,18 +240,18 @@ fn render_row(pkg: &KnownPackage) -> Division {
 mod tests {
     use super::*;
 
-    fn package(wit_namespace: Option<&str>) -> KnownPackage {
+    fn package(kind: Option<wasm_meta_registry_client::PackageKind>) -> KnownPackage {
         KnownPackage {
             registry: "ghcr.io".to_string(),
             repository: "example/pkg".to_string(),
-            kind: None,
+            kind,
             description: None,
             tags: vec!["1.0.0".to_string()],
             signature_tags: vec![],
             attestation_tags: vec![],
             last_seen_at: "2026-01-01T00:00:00Z".to_string(),
             created_at: "2026-01-01T00:00:00Z".to_string(),
-            wit_namespace: wit_namespace.map(ToOwned::to_owned),
+            wit_namespace: Some("test".to_string()),
             wit_name: Some("demo".to_string()),
             dependencies: vec![],
         }
@@ -241,15 +259,19 @@ mod tests {
 
     // r[verify frontend.pages.home]
     #[test]
-    fn split_by_kind_uses_wit_namespace_presence() {
-        let interface = package(Some("wasi"));
-        let component = package(None);
-        let input = vec![interface, component];
+    fn split_by_kind_uses_package_kind() {
+        use wasm_meta_registry_client::PackageKind;
+
+        let interface = package(Some(PackageKind::Interface));
+        let component = package(Some(PackageKind::Component));
+        let unknown = package(None);
+        let input = vec![interface, component, unknown];
 
         let (components, interfaces) = split_by_kind(&input);
-        assert_eq!(components.len(), 1);
         assert_eq!(interfaces.len(), 1);
-        assert!(components[0].wit_namespace.is_none());
-        assert!(interfaces[0].wit_namespace.is_some());
+        assert_eq!(components.len(), 2);
+        assert_eq!(interfaces[0].kind, Some(PackageKind::Interface));
+        assert_eq!(components[0].kind, Some(PackageKind::Component));
+        assert_eq!(components[1].kind, None);
     }
 }

--- a/crates/wasm-frontend/src/pages/home.rs
+++ b/crates/wasm-frontend/src/pages/home.rs
@@ -77,6 +77,7 @@ fn render_hero(total: usize) -> Division {
                     .name("q")
                     .placeholder(placeholder)
                     .aria_label("Search packages")
+                    .autofocus(true)
                     .class("flex-1 px-4 py-2.5 rounded-l-md text-base border border-border bg-surface text-fg placeholder:text-fg-faint focus:border-accent focus:outline-none transition-colors")
             })
             .button(|btn| {

--- a/crates/wasm-frontend/src/pages/mod.rs
+++ b/crates/wasm-frontend/src/pages/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod about;
 pub(crate) mod all;
+pub(crate) mod docs;
 pub(crate) mod error;
 pub(crate) mod home;
 pub(crate) mod not_found;

--- a/crates/wasm-frontend/src/pages/not_found.rs
+++ b/crates/wasm-frontend/src/pages/not_found.rs
@@ -10,7 +10,7 @@ use crate::layout;
 #[must_use]
 pub(crate) fn render() -> String {
     let body = Division::builder()
-        .class("text-center py-20")
+        .class("text-center pt-28 pb-20")
         .heading_1(|h1| h1.class("text-6xl font-bold tracking-tighter text-accent").text("404"))
         .paragraph(|p| p.class("text-lg text-fg-secondary mt-4").text("Page not found"))
         .paragraph(|p| {

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -24,6 +24,8 @@ pub(crate) fn render(pkg: &KnownPackage, version: &str) -> String {
 
     let mut body = Division::builder();
 
+    body.class("pt-8");
+
     // Breadcrumb
     body.push(render_breadcrumb(&display_name));
 

--- a/crates/wasm-frontend/src/pages/search.rs
+++ b/crates/wasm-frontend/src/pages/search.rs
@@ -23,7 +23,7 @@ fn render_results(query: &str, packages: &[KnownPackage]) -> String {
 
     // Page header
     body.division(|div| {
-        div.class("pb-6 border-b border-border mb-6")
+        div.class("pt-8 pb-6 border-b border-border mb-6")
             .heading_1(|h1| {
                 h1.class("text-3xl font-bold tracking-tight")
                     .text(format!("Results for \u{201c}{query}\u{201d}"))
@@ -80,7 +80,7 @@ fn render_error(query: &str, err: &ApiError) -> String {
     let mut body = Division::builder();
 
     body.division(|div| {
-        div.class("pb-6 border-b border-border mb-6")
+        div.class("pt-8 pb-6 border-b border-border mb-6")
             .heading_1(|h1| {
                 h1.class("text-3xl font-bold tracking-tight")
                     .text(format!("Results for \u{201c}{query}\u{201d}"))

--- a/crates/wasm-frontend/src/reserved.rs
+++ b/crates/wasm-frontend/src/reserved.rs
@@ -7,8 +7,8 @@
 
 /// Namespaces reserved for application routes.
 const RESERVED_NAMESPACES: &[&str] = &[
-    "about", "admin", "all", "api", "assets", "explore", "health", "login", "logout", "new",
-    "register", "search", "settings", "signup", "static",
+    "about", "admin", "all", "api", "assets", "docs", "explore", "health", "login", "logout",
+    "new", "register", "search", "settings", "signup", "static",
 ];
 
 /// Returns `true` if the given string is a reserved namespace.


### PR DESCRIPTION
This follow-up addresses review feedback from the style/layout PR by aligning error-state spacing with the updated page rhythm and correcting stale inline documentation to reflect the current UI structure.

- **All Packages error-state layout**
  - Added missing top padding to the `/all` error header so error and success paths share the same vertical offset after global main padding removal.
  - Updated class list in `render_error` (`crates/wasm-frontend/src/pages/all.rs`).

- **Home page inline docs**
  - Corrected `render_section` doc comment to describe the current card-based grid (not row-based output) in `crates/wasm-frontend/src/pages/home.rs`.

```rust
// crates/wasm-frontend/src/pages/all.rs
div.class("pt-8 pb-6 border-b border-border mb-6")
```