### PR TITLE
Add fetch queue

### DIFF
--- a/crates/wasm-frontend/src/lib.rs
+++ b/crates/wasm-frontend/src/lib.rs
@@ -39,6 +39,7 @@ fn app() -> Router {
         .route("/docs", get(docs))
         .route("/design-system", get(design_system))
         .route("/downloads", get(downloads))
+        .route("/status", get(queue_status))
         .route("/health", get(health))
         .route("/{namespace}/{name}", get(package_redirect))
         .route("/{namespace}/{name}/", get(package_redirect))
@@ -160,6 +161,13 @@ async fn design_system() -> Response {
 async fn downloads() -> Response {
     let html = pages::downloads::render();
     with_cache_control(html, "public, max-age=3600")
+}
+
+/// Fetch queue status page.
+async fn queue_status() -> Response {
+    let client = RegistryClient::from_env();
+    let html = pages::queue::render(&client).await;
+    with_cache_control(html, "no-cache")
 }
 
 /// Namespace page — list all packages under a publisher.

--- a/crates/wasm-frontend/src/pages/mod.rs
+++ b/crates/wasm-frontend/src/pages/mod.rs
@@ -13,5 +13,6 @@ pub(crate) mod item;
 pub(crate) mod namespace;
 pub(crate) mod not_found;
 pub(crate) mod package;
+pub(crate) mod queue;
 pub(crate) mod search;
 pub(crate) mod world;

--- a/crates/wasm-frontend/src/pages/queue.rs
+++ b/crates/wasm-frontend/src/pages/queue.rs
@@ -1,0 +1,271 @@
+//! Status page — shows the fetch queue with tabbed Queue / History views.
+
+use std::fmt::Write;
+
+use html::text_content::Division;
+use wasm_meta_registry_client::{QueueStatus, QueueTask, RegistryClient};
+
+use crate::components::ds::typography;
+use crate::layout;
+
+/// Render the status page.
+pub(crate) async fn render(client: &RegistryClient) -> String {
+    match client.fetch_queue_status().await {
+        Ok(status) => render_status(&status),
+        Err(err) => render_error(&err.to_string()),
+    }
+}
+
+/// Render the status overview with tabbed Queue / History views.
+fn render_status(status: &QueueStatus) -> String {
+    let mut body = Division::builder();
+    body.class("pt-8 pb-12 max-w-4xl space-y-8");
+
+    // Heading
+    body.heading_1(|h1| {
+        h1.class(format!("{} mb-2", typography::H1_CLASS))
+            .text("Status")
+    });
+    body.paragraph(|p| {
+        p.class(typography::BODY_CLASS).text(
+            "Background task queue for pulling package versions from OCI registries \
+             and reindexing cached data.",
+        )
+    });
+
+    // Status summary cards
+    body.division(|cards| {
+        cards
+            .class("grid grid-cols-2 sm:grid-cols-4 gap-4 mt-6")
+            .push(status_card("Pending", status.pending, "text-amber-600"))
+            .push(status_card(
+                "In Progress",
+                status.in_progress,
+                "text-blue-600",
+            ))
+            .push(status_card("Completed", status.completed, "text-positive"))
+            .push(status_card("Failed", status.failed, "text-negative"))
+    });
+
+    // Tab bar + tab panels
+    let active_count = status.active.len();
+    let history_count = status.history.len();
+    body.text(render_tabs(
+        &status.active,
+        &status.history,
+        active_count,
+        history_count,
+    ));
+
+    // Auto-refresh while tasks are active.
+    let has_active = status.pending > 0 || status.in_progress > 0;
+    let script = if has_active {
+        "<script>setTimeout(function(){location.reload()},30000)</script>"
+    } else {
+        ""
+    };
+
+    let html = body.build().to_string();
+    layout::document_with_nav("Status", &format!("{html}{script}"))
+}
+
+/// Render a single status summary card.
+fn status_card(label: &str, count: u64, color_class: &str) -> Division {
+    Division::builder()
+        .class("border border-line rounded-lg p-4 bg-surface")
+        .division(|d| {
+            d.class(format!("text-[28px] font-semibold {color_class}"))
+                .text(count.to_string())
+        })
+        .division(|d| {
+            d.class("text-[13px] text-ink-500 mt-1")
+                .text(label.to_owned())
+        })
+        .build()
+}
+
+/// Render the tabbed section with Queue and History panels.
+fn render_tabs(
+    active: &[QueueTask],
+    history: &[QueueTask],
+    active_count: usize,
+    history_count: usize,
+) -> String {
+    let tab_script = r"<script>
+document.querySelectorAll('[data-tab]').forEach(function(btn){
+  btn.addEventListener('click',function(){
+    var target=btn.getAttribute('data-tab');
+    document.querySelectorAll('[data-tab]').forEach(function(b){
+      b.classList.remove('border-ink-900','text-ink-900');
+      b.classList.add('border-transparent','text-ink-500');
+    });
+    btn.classList.remove('border-transparent','text-ink-500');
+    btn.classList.add('border-ink-900','text-ink-900');
+    document.querySelectorAll('[data-panel]').forEach(function(p){
+      p.style.display=p.getAttribute('data-panel')===target?'block':'none';
+    });
+  });
+});
+</script>";
+
+    let queue_panel = if active.is_empty() {
+        "<p class=\"text-ink-500 text-[13px] py-6\">No active tasks.</p>".to_owned()
+    } else {
+        render_table_html(active, true)
+    };
+
+    let history_panel = if history.is_empty() {
+        "<p class=\"text-ink-500 text-[13px] py-6\">No completed or failed tasks yet.</p>"
+            .to_owned()
+    } else {
+        render_table_html(history, false)
+    };
+
+    format!(
+        "<div class=\"mt-8\">\
+           <div class=\"flex border-b border-line gap-6\">\
+             <button data-tab=\"queue\" class=\"pb-2 text-[13px] font-medium border-b-2 \
+               border-ink-900 text-ink-900 cursor-pointer\">\
+               Queue <span class=\"ml-1 text-ink-400\">({active_count})</span>\
+             </button>\
+             <button data-tab=\"history\" class=\"pb-2 text-[13px] font-medium border-b-2 \
+               border-transparent text-ink-500 hover:text-ink-700 cursor-pointer\">\
+               History <span class=\"ml-1 text-ink-400\">({history_count})</span>\
+             </button>\
+           </div>\
+           <div data-panel=\"queue\" class=\"pt-4\">{queue_panel}</div>\
+           <div data-panel=\"history\" class=\"pt-4\" style=\"display:none\">{history_panel}</div>\
+         </div>\
+         {tab_script}"
+    )
+}
+
+/// Render a task table as raw HTML.
+///
+/// When `show_priority` is true, shows a Priority column (active queue).
+/// When false, shows a Completed-at column (history).
+fn render_table_html(tasks: &[QueueTask], show_priority: bool) -> String {
+    let mut rows = String::new();
+    for task in tasks {
+        let badge = status_badge_html(&task.status);
+
+        let error_cell = task
+            .last_error
+            .as_deref()
+            .map(|e: &str| {
+                let truncated = if e.len() > 80 {
+                    format!("{}…", &e[..80])
+                } else {
+                    e.to_string()
+                };
+                let escaped = html_escape(&truncated);
+                format!(
+                    "<span class=\"text-negative text-[11px]\" title=\"{escaped}\">{escaped}</span>"
+                )
+            })
+            .unwrap_or_default();
+
+        let extra_col = if show_priority {
+            format!(
+                "<td class=\"py-2 pr-3 text-[13px] text-ink-500 text-center\">{}</td>",
+                task.priority
+            )
+        } else {
+            format!(
+                "<td class=\"py-2 pr-3 text-[13px] text-ink-500 mono\">{}</td>",
+                html_escape(&task.updated_at)
+            )
+        };
+
+        let _ = write!(
+            rows,
+            "<tr class=\"border-b border-line last:border-0\">\
+               <td class=\"py-2 px-3 text-[13px] mono text-ink-700\">{}/{}</td>\
+               <td class=\"py-2 px-3 text-[13px] mono\">{}</td>\
+               <td class=\"py-2 px-3 text-[13px]\">{}</td>\
+               <td class=\"py-2 px-3 text-[13px]\">{badge}</td>\
+               <td class=\"py-2 px-3 text-[13px] text-ink-500\">{}/{}</td>\
+               {extra_col}\
+               <td class=\"py-2 px-3 text-[13px]\">{error_cell}</td>\
+             </tr>",
+            html_escape(&task.registry),
+            html_escape(&task.repository),
+            html_escape(&task.tag),
+            html_escape(&task.task),
+            task.attempts,
+            task.max_attempts,
+        );
+    }
+
+    let extra_header = if show_priority {
+        "<th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Priority</th>"
+    } else {
+        "<th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Completed</th>"
+    };
+
+    format!(
+        "<div class=\"overflow-x-auto border border-line rounded-lg\">\
+           <table class=\"w-full text-left\">\
+             <thead>\
+               <tr class=\"border-b border-line bg-surfaceMuted\">\
+                 <th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Package</th>\
+                 <th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Tag</th>\
+                 <th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Task</th>\
+                 <th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Status</th>\
+                 <th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Attempts</th>\
+                 {extra_header}\
+                 <th class=\"py-2 px-3 text-[11px] font-medium text-ink-500 uppercase tracking-wider\">Error</th>\
+               </tr>\
+             </thead>\
+             <tbody>{rows}</tbody>\
+           </table>\
+         </div>"
+    )
+}
+
+/// Return an HTML badge span for a task status string.
+fn status_badge_html(status: &str) -> &'static str {
+    match status {
+        "pending" => {
+            "<span class=\"px-2 py-0.5 rounded-full text-[11px] font-medium \
+             bg-amber-100 text-amber-800\">pending</span>"
+        }
+        "in_progress" => {
+            "<span class=\"px-2 py-0.5 rounded-full text-[11px] font-medium \
+             bg-blue-100 text-blue-800\">in progress</span>"
+        }
+        "completed" => {
+            "<span class=\"px-2 py-0.5 rounded-full text-[11px] font-medium \
+             bg-emerald-100 text-emerald-800\">completed</span>"
+        }
+        "failed" => {
+            "<span class=\"px-2 py-0.5 rounded-full text-[11px] font-medium \
+             bg-red-100 text-red-800\">failed</span>"
+        }
+        _ => "",
+    }
+}
+
+/// Render an error page when the API is unreachable.
+fn render_error(message: &str) -> String {
+    let body = Division::builder()
+        .class("pt-8 max-w-lg")
+        .heading_1(|h1| {
+            h1.class(format!("{} mb-4", typography::H1_CLASS))
+                .text("Status")
+        })
+        .paragraph(|p| {
+            p.class(typography::BODY_CLASS)
+                .text(format!("Could not load queue status: {message}"))
+        })
+        .build();
+    layout::document_with_nav("Status", &body.to_string())
+}
+
+/// Minimal HTML entity escaping.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}

--- a/crates/wasm-meta-registry-client/src/client.rs
+++ b/crates/wasm-meta-registry-client/src/client.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 
 use crate::KnownPackage;
-use wasm_meta_registry_types::{PackageDetail, PackageVersion};
+use wasm_meta_registry_types::{PackageDetail, PackageVersion, QueueStatus};
 
 /// Default API base URL when no environment variable is set.
 const DEFAULT_API_BASE_URL: &str = "http://localhost:8081";
@@ -274,6 +274,17 @@ impl RegistryClient {
         let encoded = percent_encode_query_component(interface);
         let url = format!("{}/v1/search/by-export?interface={encoded}", self.base_url);
         self.fetch_packages_from(&url).await
+    }
+
+    /// Fetch the current fetch queue status.
+    pub async fn fetch_queue_status(&self) -> Result<QueueStatus, ApiError> {
+        let url = format!("{}/v1/queue", self.base_url);
+        let bytes = self.get(&url).await?;
+        serde_json::from_slice(&bytes).map_err(|e| {
+            ApiError::new(format!(
+                "received an unexpected response from the registry: {e}"
+            ))
+        })
     }
 
     /// Fetch and deserialize a list of packages from the given URL.

--- a/crates/wasm-meta-registry-types/src/lib.rs
+++ b/crates/wasm-meta-registry-types/src/lib.rs
@@ -863,3 +863,89 @@ mod tests {
         assert_eq!(parsed.referrers.len(), 1);
     }
 }
+
+// ============================================================
+// Queue status
+// ============================================================
+
+/// Summary of the fetch queue, returned by `/v1/queue`.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_meta_registry_types::QueueStatus;
+///
+/// let status = QueueStatus {
+///     pending: 5,
+///     in_progress: 1,
+///     completed: 42,
+///     failed: 2,
+///     active: vec![],
+///     history: vec![],
+/// };
+/// let json = serde_json::to_string(&status).unwrap();
+/// assert!(json.contains("\"pending\":5"));
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct QueueStatus {
+    /// Number of tasks waiting to be processed.
+    pub pending: u64,
+    /// Number of tasks currently being processed.
+    pub in_progress: u64,
+    /// Number of successfully completed tasks.
+    pub completed: u64,
+    /// Number of tasks that exhausted their retry budget.
+    pub failed: u64,
+    /// Currently active tasks (pending + in_progress), ordered by priority.
+    pub active: Vec<QueueTask>,
+    /// Recent history (completed + failed), most recent first.
+    pub history: Vec<QueueTask>,
+}
+
+/// A single task in the fetch queue.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_meta_registry_types::QueueTask;
+///
+/// let task = QueueTask {
+///     registry: "ghcr.io/webassembly".into(),
+///     repository: "wasi/http".into(),
+///     tag: "0.2.11".into(),
+///     task: "pull".into(),
+///     status: "pending".into(),
+///     priority: 0,
+///     attempts: 0,
+///     max_attempts: 3,
+///     last_error: None,
+///     created_at: "2026-04-24 12:00:00".into(),
+///     updated_at: "2026-04-24 12:00:00".into(),
+/// };
+/// assert_eq!(task.tag, "0.2.11");
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct QueueTask {
+    /// OCI registry hostname.
+    pub registry: String,
+    /// OCI repository path.
+    pub repository: String,
+    /// Version tag.
+    pub tag: String,
+    /// Task type: "pull" or "reindex".
+    pub task: String,
+    /// Current status: "pending", "in_progress", "completed", or "failed".
+    pub status: String,
+    /// Priority (lower = higher).
+    pub priority: i32,
+    /// Number of attempts so far.
+    pub attempts: i32,
+    /// Maximum allowed attempts.
+    pub max_attempts: i32,
+    /// Error from the last failed attempt, if any.
+    pub last_error: Option<String>,
+    /// ISO 8601 timestamp of when this task was created.
+    pub created_at: String,
+    /// ISO 8601 timestamp of the last modification.
+    pub updated_at: String,
+}

--- a/crates/wasm-meta-registry/src/indexer.rs
+++ b/crates/wasm-meta-registry/src/indexer.rs
@@ -85,13 +85,19 @@ impl Indexer {
         self
     }
 
-    /// Run a single sync cycle, indexing all configured packages.
-    ///
-    /// This fetches metadata for each configured package source without
-    /// downloading any wasm layers.
+    /// Run a single sync cycle: discover tags and enqueue work, then
+    /// process the queue until it is drained.
     pub async fn sync(&mut self) {
+        self.discover().await;
+        self.process_queue().await;
+    }
+
+    /// Discovery phase: iterate configured packages, fetch tags from
+    /// the registries, and enqueue pull tasks for any new or stale
+    /// versions.
+    async fn discover(&mut self) {
         info!(
-            "Starting sync cycle for {} packages",
+            "Starting discovery for {} packages",
             self.config.packages.len()
         );
 
@@ -131,11 +137,11 @@ impl Indexer {
             };
             match result {
                 Ok(pkg) => {
-                    info!(
+                    tracing::debug!(
                         registry = %pkg.registry,
                         repository = %pkg.repository,
                         tags = pkg.tags.len(),
-                        "Indexed package"
+                        "Discovered package"
                     );
                 }
                 Err(e) => {
@@ -143,13 +149,49 @@ impl Indexer {
                         registry = %source.registry,
                         repository = %source.repository,
                         error = %e,
-                        "Failed to index package"
+                        "Failed to discover package"
                     );
                 }
             }
         }
 
-        info!("Sync cycle complete");
+        // Only refetch on the first cycle.
+        self.refetch = false;
+
+        info!("Discovery complete");
+    }
+
+    /// Processing phase: drain the fetch queue, pulling or reindexing
+    /// each enqueued version.  A short delay between tasks avoids
+    /// hammering upstream registries.
+    async fn process_queue(&mut self) {
+        let mut processed = 0u64;
+        let mut consecutive_errors = 0u64;
+        loop {
+            match self.manager.process_next_task().await {
+                Ok(true) => {
+                    processed += 1;
+                    consecutive_errors = 0;
+                    // Brief pause between tasks to be a good citizen to
+                    // upstream registries and let the HTTP server breathe.
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                }
+                Ok(false) => break, // queue is empty
+                Err(e) => {
+                    consecutive_errors += 1;
+                    error!(error = %e, "Error processing fetch queue");
+                    if consecutive_errors >= 5 {
+                        error!("Too many consecutive queue errors, pausing until next cycle");
+                        break;
+                    }
+                    // Back off before retrying after an error.
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+            }
+        }
+        if processed > 0 {
+            info!(processed, "Fetch queue drained");
+        }
     }
 
     /// Run the indexer in a loop, syncing at the configured interval.

--- a/crates/wasm-meta-registry/src/indexer.rs
+++ b/crates/wasm-meta-registry/src/indexer.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use tracing::{error, info, warn};
 use wasm_package_manager::Reference;
-use wasm_package_manager::manager::Manager;
+use wasm_package_manager::manager::{Manager, TaskOutcome};
 
 use crate::config::Config;
 
@@ -169,14 +169,24 @@ impl Indexer {
         let mut consecutive_errors = 0u64;
         loop {
             match self.manager.process_next_task().await {
-                Ok(true) => {
+                Ok(TaskOutcome::Succeeded) => {
                     processed += 1;
                     consecutive_errors = 0;
                     // Brief pause between tasks to be a good citizen to
                     // upstream registries and let the HTTP server breathe.
                     tokio::time::sleep(Duration::from_millis(250)).await;
                 }
-                Ok(false) => break, // queue is empty
+                Ok(TaskOutcome::Failed) => {
+                    processed += 1;
+                    consecutive_errors += 1;
+                    if consecutive_errors >= 5 {
+                        error!("Too many consecutive task failures, pausing until next cycle");
+                        break;
+                    }
+                    // Back off before processing the next task after a failure.
+                    tokio::time::sleep(Duration::from_secs(2)).await;
+                }
+                Ok(TaskOutcome::Empty) => break, // queue is empty
                 Err(e) => {
                     consecutive_errors += 1;
                     error!(error = %e, "Error processing fetch queue");

--- a/crates/wasm-meta-registry/src/main.rs
+++ b/crates/wasm-meta-registry/src/main.rs
@@ -76,14 +76,21 @@ async fn main() -> anyhow::Result<()> {
     // Open the Manager for the HTTP server with its own data directory
     let server_manager = Manager::open_at(&data_dir).await?;
 
+    // Back-fill the queue history with tags that were pulled before the
+    // queue was introduced, so the status page shows them immediately.
+    match server_manager.seed_completed_from_tags() {
+        Ok(n) if n > 0 => info!(count = n, "Seeded queue history from existing tags"),
+        Ok(_) => {}
+        Err(e) => warn!(error = %e, "Failed to seed queue history (non-fatal)"),
+    }
+
     if cli.reindex_wit_on_startup {
-        // Re-derive WIT metadata from cached OCI layers so that existing
-        // packages pick up any improvements to the extraction logic (e.g.
-        // switching from the lossy hand-rolled formatter to WitPrinter).
-        match server_manager.reindex_wit().await {
-            Ok(n) if n > 0 => info!(count = n, "Re-indexed WIT packages"),
+        // Enqueue reindex tasks for all cached packages.  The background
+        // indexer will process them during its first cycle.
+        match server_manager.enqueue_reindex_all() {
+            Ok(n) if n > 0 => info!(count = n, "Enqueued WIT reindex tasks"),
             Ok(_) => {}
-            Err(e) => warn!(error = %e, "WIT re-index failed (non-fatal)"),
+            Err(e) => warn!(error = %e, "Failed to enqueue WIT reindex tasks (non-fatal)"),
         }
     } else {
         info!("Skipping WIT re-index at startup (use --reindex-wit-on-startup to enable)");

--- a/crates/wasm-meta-registry/src/server.rs
+++ b/crates/wasm-meta-registry/src/server.rs
@@ -135,6 +135,7 @@ pub fn router(state: AppState) -> Router {
             get(get_package_version_reordered),
         )
         .route("/v1/packages/{registry}/{*repository}", get(get_package))
+        .route("/v1/queue", get(get_queue_status))
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(state)
@@ -143,6 +144,15 @@ pub fn router(state: AppState) -> Router {
 /// Health check endpoint.
 async fn health() -> impl IntoResponse {
     Json(serde_json::json!({ "status": "ok" }))
+}
+
+/// Fetch queue status.
+async fn get_queue_status(State(manager): State<AppState>) -> Result<impl IntoResponse, AppError> {
+    let manager = manager
+        .lock()
+        .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+    let status = manager.get_queue_status()?;
+    Ok(Json(status))
 }
 
 /// Search packages by query string.

--- a/crates/wasm-package-manager/src/manager/mod.rs
+++ b/crates/wasm-package-manager/src/manager/mod.rs
@@ -1013,7 +1013,7 @@ impl Manager {
                 reference.registry(),
                 reference.repository(),
                 tag,
-                3600, // 1 hour cooldown
+                PULL_COOLDOWN_SECS,
             ) {
                 self.store.enqueue_pull(
                     reference.registry(),

--- a/crates/wasm-package-manager/src/manager/mod.rs
+++ b/crates/wasm-package-manager/src/manager/mod.rs
@@ -24,6 +24,18 @@ pub use logic::{
 };
 pub use models::{InstallResult, PullResult, SyncPolicy, SyncResult};
 
+/// Outcome of [`Manager::process_next_task`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskOutcome {
+    /// A task ran to completion.
+    Succeeded,
+    /// A task was dequeued but its execution failed; the failure has
+    /// been recorded in the queue.
+    Failed,
+    /// The queue was empty; no work was performed.
+    Empty,
+}
+
 /// How long (in seconds) to skip re-pulling a tag during background indexing
 /// when its layers are already present in the local store.  Set to one hour
 /// so server restarts don't trigger a full re-fetch of every known version.
@@ -1042,11 +1054,14 @@ impl Manager {
 
     /// Process the next pending task from the fetch queue.
     ///
-    /// Returns `Ok(true)` when a task was processed, `Ok(false)` when the
-    /// queue is empty.
-    pub async fn process_next_task(&self) -> anyhow::Result<bool> {
+    /// Returns [`TaskOutcome::Empty`] when there are no pending tasks,
+    /// [`TaskOutcome::Succeeded`] when a task ran to completion, and
+    /// [`TaskOutcome::Failed`] when the task itself failed (the failure
+    /// is recorded in the queue).  Errors are reserved for failures that
+    /// prevent us from interacting with the queue at all.
+    pub async fn process_next_task(&self) -> anyhow::Result<TaskOutcome> {
         let Some(task) = self.store.dequeue_next()? else {
-            return Ok(false);
+            return Ok(TaskOutcome::Empty);
         };
 
         tracing::info!(
@@ -1066,7 +1081,7 @@ impl Manager {
         match result {
             Ok(()) => {
                 self.store.complete_task(task.id)?;
-                Ok(true)
+                Ok(TaskOutcome::Succeeded)
             }
             Err(e) => {
                 tracing::warn!(
@@ -1077,7 +1092,7 @@ impl Manager {
                     "Fetch task failed"
                 );
                 self.store.fail_task(task.id, &e.to_string())?;
-                Ok(true)
+                Ok(TaskOutcome::Failed)
             }
         }
     }

--- a/crates/wasm-package-manager/src/manager/mod.rs
+++ b/crates/wasm-package-manager/src/manager/mod.rs
@@ -13,7 +13,7 @@ mod models;
 use crate::config::Config;
 use crate::oci::{Client, ImageEntry, InsertResult};
 use crate::progress::ProgressEvent;
-use crate::storage::{KnownPackage, KnownPackageParams, StateInfo, Store};
+use crate::storage::{FetchTaskKind, KnownPackage, KnownPackageParams, StateInfo, Store};
 use crate::types::WitPackage;
 use wasm_meta_registry_types::PackageKind;
 
@@ -834,6 +834,24 @@ impl Manager {
         self.store.reindex_wit_packages().await
     }
 
+    /// Enqueue reindex tasks for all known tags that have cached layers.
+    ///
+    /// Returns the number of tasks enqueued.
+    pub fn enqueue_reindex_all(&self) -> anyhow::Result<u64> {
+        self.store.enqueue_reindex_all()
+    }
+
+    /// Seed the fetch queue with completed entries for tags that were
+    /// pulled before the queue existed.
+    pub fn seed_completed_from_tags(&self) -> anyhow::Result<u64> {
+        self.store.seed_completed_from_tags()
+    }
+
+    /// Return the current fetch queue status.
+    pub fn get_queue_status(&self) -> anyhow::Result<wasm_meta_registry_types::QueueStatus> {
+        self.store.get_queue_status()
+    }
+
     /// Fetches the manifest and config to extract metadata (description from
     /// OCI annotations), lists all tags, and upserts into the known packages
     /// table. Also pulls the wasm layer for the most recent tag to extract
@@ -885,10 +903,10 @@ impl Manager {
             return Err(ManagerError::OfflineIndex.into());
         }
 
-        tracing::info!(
+        tracing::debug!(
             registry = %reference.registry(),
             repository = %reference.repository(),
-            "Indexing package"
+            "Discovering package tags"
         );
 
         // Discover available tags first — the reference may not carry a valid
@@ -940,23 +958,19 @@ impl Manager {
                 })?;
         }
 
-        // Pull every semver-tagged version so that per-version WIT text,
-        // worlds, components and dependency metadata are all available in the
-        // local database.  Tags that are not valid semver (e.g. `latest`,
-        // hash-based signatures like `sha256-...`, or arbitrary strings such
-        // as `dev`/`nightly`) are skipped — they typically duplicate a semver
-        // tag and cannot be reasoned about by the resolver.
+        // Enqueue every semver-tagged version for pulling.  Tags that are
+        // not valid semver (e.g. `latest`, hash-based signatures like
+        // `sha256-...`, or arbitrary strings such as `dev`/`nightly`) are
+        // skipped — they typically duplicate a semver tag and cannot be
+        // reasoned about by the resolver.
         //
         // The semver tags are sorted in ascending order so that the highest
-        // stable version is pulled last.  Because `get_package_dependencies`
-        // selects the dependencies of the most recently inserted manifest
-        // (`ORDER BY om.id DESC`), this keeps that query reflecting the
-        // latest stable version.  Pre-release tags are pulled before stable
-        // ones so a stable manifest always wins when both exist.
+        // stable version is enqueued last (and thus processed last), keeping
+        // the most recent stable version's dependencies at the top of the
+        // `get_package_dependencies` query.
         //
         // Tags that were already pulled recently (within `PULL_COOLDOWN_SECS`
-        // seconds) are skipped to avoid redundant network traffic on server
-        // restarts.
+        // seconds) are skipped unless `skip_cooldown` is set (--refetch).
         // r[impl server.index.dependencies]
         let mut semver_tags: Vec<(&String, semver::Version)> = Vec::with_capacity(tags.len());
         for tag in &tags {
@@ -967,59 +981,51 @@ impl Manager {
                         registry = %reference.registry(),
                         repository = %reference.repository(),
                         tag = %tag,
-                        "Skipping pull — tag is not a valid semver version"
+                        "Skipping enqueue — tag is not a valid semver version"
                     );
                 }
             }
         }
         // Sort ascending: pre-releases first, then stable versions in order.
-        // The `cmp` impl on `semver::Version` already orders pre-releases
-        // before their corresponding stable release.
         semver_tags.sort_by(|(_, a), (_, b)| a.cmp(b));
 
         for (tag, _version) in &semver_tags {
-            if !skip_cooldown
-                && self.store.is_tag_fresh(
+            if skip_cooldown {
+                self.store.enqueue_refetch(
                     reference.registry(),
                     reference.repository(),
                     tag,
-                    PULL_COOLDOWN_SECS,
-                )
-            {
-                tracing::debug!(
-                    registry = %reference.registry(),
-                    repository = %reference.repository(),
-                    tag = %tag,
-                    "Skipping pull — already fresh"
-                );
-                continue;
+                    -1, // high priority for explicit refetch
+                )?;
+            } else if !self.store.is_tag_fresh(
+                reference.registry(),
+                reference.repository(),
+                tag,
+                3600, // 1 hour cooldown
+            ) {
+                self.store.enqueue_pull(
+                    reference.registry(),
+                    reference.repository(),
+                    tag,
+                    0, // normal priority
+                )?;
+            } else {
+                // Tag is fresh — record it as completed so it appears
+                // in the queue history for visibility.
+                self.store
+                    .record_completed(reference.registry(), reference.repository(), tag)?;
             }
+        }
+
+        if let Ok(pending) = self.store.pending_count()
+            && pending > 0
+        {
             tracing::info!(
                 registry = %reference.registry(),
                 repository = %reference.repository(),
-                tag = %tag,
-                "Pulling version for indexing"
+                pending,
+                "Enqueued versions for pulling"
             );
-            let tag_ref: Reference = match format!(
-                "{}/{}:{}",
-                reference.registry(),
-                reference.repository(),
-                tag
-            )
-            .parse()
-            {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            if let Err(e) = self.pull(tag_ref).await {
-                tracing::debug!(
-                    registry = %reference.registry(),
-                    repository = %reference.repository(),
-                    tag = %tag,
-                    error = %e,
-                    "Could not pull wasm layer during index"
-                );
-            }
         }
 
         // Return the indexed package with its now-populated dependencies.
@@ -1032,6 +1038,64 @@ impl Manager {
             .store
             .get_package_dependencies(reference.registry(), reference.repository())?;
         Ok(pkg)
+    }
+
+    /// Process the next pending task from the fetch queue.
+    ///
+    /// Returns `Ok(true)` when a task was processed, `Ok(false)` when the
+    /// queue is empty.
+    pub async fn process_next_task(&self) -> anyhow::Result<bool> {
+        let Some(task) = self.store.dequeue_next()? else {
+            return Ok(false);
+        };
+
+        tracing::info!(
+            registry = %task.registry,
+            repository = %task.repository,
+            tag = %task.tag,
+            kind = ?task.kind,
+            attempt = task.attempts + 1,
+            "Processing fetch task"
+        );
+
+        let result = match task.kind {
+            FetchTaskKind::Pull => self.execute_pull_task(&task).await,
+            FetchTaskKind::Reindex => self.execute_reindex_task(&task).await,
+        };
+
+        match result {
+            Ok(()) => {
+                self.store.complete_task(task.id)?;
+                Ok(true)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    registry = %task.registry,
+                    repository = %task.repository,
+                    tag = %task.tag,
+                    error = %e,
+                    "Fetch task failed"
+                );
+                self.store.fail_task(task.id, &e.to_string())?;
+                Ok(true)
+            }
+        }
+    }
+
+    /// Execute a pull task: download the OCI image for a specific tag.
+    async fn execute_pull_task(&self, task: &crate::storage::FetchTask) -> anyhow::Result<()> {
+        let tag_ref: Reference = format!("{}/{}:{}", task.registry, task.repository, task.tag)
+            .parse()
+            .map_err(|e| anyhow::anyhow!("invalid reference: {e}"))?;
+        self.pull(tag_ref).await?;
+        Ok(())
+    }
+
+    /// Execute a reindex task: re-derive WIT from cached layers for a tag.
+    async fn execute_reindex_task(&self, task: &crate::storage::FetchTask) -> anyhow::Result<()> {
+        self.store
+            .reindex_tag(&task.registry, &task.repository, &task.tag)
+            .await
     }
 
     /// Get all WIT interfaces with their associated component references.

--- a/crates/wasm-package-manager/src/storage/migrations/06_create_fetch_queue.sql
+++ b/crates/wasm-package-manager/src/storage/migrations/06_create_fetch_queue.sql
@@ -1,0 +1,44 @@
+CREATE TABLE fetch_queue (
+    -- Surrogate primary key.
+    id INTEGER PRIMARY KEY,
+    -- OCI registry hostname, e.g. "ghcr.io/webassembly".
+    registry TEXT NOT NULL,
+    -- OCI repository path, e.g. "wasi/clocks".
+    repository TEXT NOT NULL,
+    -- The version tag to fetch, e.g. "0.2.11".
+    tag TEXT NOT NULL,
+    -- The kind of work to perform:
+    --   'pull'    — download from the registry and extract metadata
+    --   'reindex' — re-derive WIT from already-cached layers
+    task TEXT NOT NULL DEFAULT 'pull'
+        CHECK (task IN ('pull', 'reindex')),
+    -- Current status of this work item.
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'in_progress', 'completed', 'failed')),
+    -- Lower values are processed first.  0 = normal, -1 = high.
+    priority INTEGER NOT NULL DEFAULT 0,
+    -- How many times this task has been attempted.
+    attempts INTEGER NOT NULL DEFAULT 0,
+    -- Maximum number of attempts before marking as 'failed'.
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    -- Error message from the most recent failed attempt.
+    last_error TEXT,
+    -- ISO 8601 timestamp of when this work item was created.
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- ISO 8601 timestamp of the most recent modification.
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TRIGGER trg_fetch_queue_updated_at
+    AFTER UPDATE ON fetch_queue
+    FOR EACH ROW
+    WHEN OLD.updated_at = NEW.updated_at
+    BEGIN
+        UPDATE fetch_queue
+           SET updated_at = CURRENT_TIMESTAMP
+         WHERE id = OLD.id;
+    END;
+CREATE UNIQUE INDEX uq_fetch_queue_item ON fetch_queue(
+    registry, repository, tag, task
+);
+CREATE INDEX idx_fetch_queue_pending ON fetch_queue(status, priority, created_at)
+    WHERE status = 'pending';

--- a/crates/wasm-package-manager/src/storage/mod.rs
+++ b/crates/wasm-package-manager/src/storage/mod.rs
@@ -9,4 +9,5 @@ pub use config::StateInfo;
 pub use known_package::{KnownPackage, KnownPackageParams};
 pub use models::Migrations;
 pub(crate) use store::Store;
+pub use store::{FetchTask, FetchTaskKind};
 pub use wasm_meta_registry_types::PackageDependencyRef;

--- a/crates/wasm-package-manager/src/storage/models/migration.rs
+++ b/crates/wasm-package-manager/src/storage/models/migration.rs
@@ -35,6 +35,11 @@ const MIGRATIONS: &[MigrationDef] = &[
         name: "add_producers_json",
         sql: include_str!("../migrations/05_add_producers_json.sql"),
     },
+    MigrationDef {
+        version: 6,
+        name: "create_fetch_queue",
+        sql: include_str!("../migrations/06_create_fetch_queue.sql"),
+    },
 ];
 
 /// Information about the current migration state.

--- a/crates/wasm-package-manager/src/storage/schema.sql
+++ b/crates/wasm-package-manager/src/storage/schema.sql
@@ -617,6 +617,65 @@ CREATE UNIQUE INDEX uq_component_target ON component_target(
 );
 
 -- ============================================================
+-- FETCH QUEUE
+--
+-- A persistent work queue for pulling package versions from OCI
+-- registries and reindexing cached data.  Each row represents a
+-- single unit of work (one tag of one repository).
+--
+-- Lifecycle:
+--   pending → in_progress → completed
+--                         → failed (retries until max_attempts)
+-- ============================================================
+
+CREATE TABLE fetch_queue (
+    -- Surrogate primary key.
+    id INTEGER PRIMARY KEY,
+    -- OCI registry hostname, e.g. "ghcr.io/webassembly".
+    registry TEXT NOT NULL,
+    -- OCI repository path, e.g. "wasi/clocks".
+    repository TEXT NOT NULL,
+    -- The version tag to fetch, e.g. "0.2.11".
+    tag TEXT NOT NULL,
+    -- The kind of work to perform:
+    --   'pull'    — download from the registry and extract metadata
+    --   'reindex' — re-derive WIT from already-cached layers
+    task TEXT NOT NULL DEFAULT 'pull'
+        CHECK (task IN ('pull', 'reindex')),
+    -- Current status of this work item.
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'in_progress', 'completed', 'failed')),
+    -- Lower values are processed first.  0 = normal, -1 = high.
+    priority INTEGER NOT NULL DEFAULT 0,
+    -- How many times this task has been attempted.
+    attempts INTEGER NOT NULL DEFAULT 0,
+    -- Maximum number of attempts before marking as 'failed'.
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    -- Error message from the most recent failed attempt.
+    last_error TEXT,
+    -- ISO 8601 timestamp of when this work item was created.
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    -- ISO 8601 timestamp of the most recent modification.
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Only one work item per (registry, repository, tag, task) combo.
+CREATE UNIQUE INDEX uq_fetch_queue_item ON fetch_queue(
+    registry, repository, tag, task
+);
+
+-- Automatically advance updated_at on any UPDATE.
+CREATE TRIGGER trg_fetch_queue_updated_at
+    AFTER UPDATE ON fetch_queue
+    FOR EACH ROW
+    WHEN OLD.updated_at = NEW.updated_at
+    BEGIN
+        UPDATE fetch_queue
+           SET updated_at = CURRENT_TIMESTAMP
+         WHERE id = OLD.id;
+    END;
+
+-- ============================================================
 -- INDEXES
 --
 -- Only created where no UNIQUE constraint or UNIQUE INDEX already
@@ -639,6 +698,7 @@ CREATE UNIQUE INDEX uq_component_target ON component_target(
 --   wit_package_dep   — uq_wit_package_dependency(dependent_id, ...)
 --   wasm_component    — uq_wasm_component(oci_manifest_id, ...)
 --   component_target  — uq_component_target(wasm_component_id, ...)
+--   fetch_queue       — uq_fetch_queue_item(registry, repository, tag, task)
 -- ============================================================
 
 -- Cross-repo digest lookup: find a manifest by digest regardless
@@ -700,3 +760,7 @@ CREATE INDEX idx_target_declared ON component_target(declared_package, declared_
 -- Reverse lookup on resolved component targets: find all components
 -- that resolved their target to a specific wit_world row.
 CREATE INDEX idx_target_resolved ON component_target(wit_world_id);
+-- Fetch queue: find the next pending item to process, ordered by
+-- priority (ascending) then creation time.
+CREATE INDEX idx_fetch_queue_pending ON fetch_queue(status, priority, created_at)
+    WHERE status = 'pending';

--- a/crates/wasm-package-manager/src/storage/store.rs
+++ b/crates/wasm-package-manager/src/storage/store.rs
@@ -1048,10 +1048,7 @@ impl Store {
               WHERE t.tag != 'latest'
                 AND t.tag NOT LIKE 'sha256-%'
               GROUP BY r.registry, r.repository, t.tag
-             ON CONFLICT(registry, repository, tag, task) DO UPDATE SET
-                 created_at = excluded.created_at,
-                 updated_at = excluded.updated_at
-              WHERE fetch_queue.status = 'completed'",
+             ON CONFLICT(registry, repository, tag, task) DO NOTHING",
             [],
         )?;
         Ok(u64::try_from(count).unwrap_or(0))
@@ -1116,9 +1113,15 @@ impl Store {
     }
 
     /// Mark a task as successfully completed.
+    ///
+    /// Clears any `last_error` from previous failed attempts so the
+    /// status page reflects the successful outcome.
     pub(crate) fn complete_task(&self, task_id: i64) -> anyhow::Result<()> {
         self.conn.execute(
-            "UPDATE fetch_queue SET status = 'completed' WHERE id = ?1",
+            "UPDATE fetch_queue
+                SET status = 'completed',
+                    last_error = NULL
+              WHERE id = ?1",
             [task_id],
         )?;
         Ok(())

--- a/crates/wasm-package-manager/src/storage/store.rs
+++ b/crates/wasm-package-manager/src/storage/store.rs
@@ -18,6 +18,41 @@ use crate::types::{
 };
 use futures_concurrency::prelude::*;
 use oci_client::{Reference, client::ImageData, manifest::OciImageManifest};
+
+/// The kind of work a [`FetchTask`] represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FetchTaskKind {
+    /// Download from the OCI registry and extract metadata.
+    Pull,
+    /// Re-derive WIT metadata from already-cached layers.
+    Reindex,
+}
+
+impl From<String> for FetchTaskKind {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "reindex" => Self::Reindex,
+            _ => Self::Pull,
+        }
+    }
+}
+
+/// A single unit of work dequeued from the fetch queue.
+#[derive(Debug)]
+pub struct FetchTask {
+    /// Row id in the `fetch_queue` table.
+    pub id: i64,
+    /// OCI registry hostname.
+    pub registry: String,
+    /// OCI repository path.
+    pub repository: String,
+    /// Version tag.
+    pub tag: String,
+    /// What to do with this tag.
+    pub kind: FetchTaskKind,
+    /// How many times this task has been attempted so far.
+    pub attempts: i64,
+}
 use rusqlite::{Connection, OptionalExtension};
 
 /// Calculate the total size of a directory recursively
@@ -909,6 +944,390 @@ impl Store {
             .ok();
 
         fresh.unwrap_or(false)
+    }
+
+    // ── Fetch queue ─────────────────────────────────────────────
+
+    /// Enqueue a pull task for a specific tag.
+    ///
+    /// If a pending/in-progress pull for this exact (registry, repo, tag)
+    /// already exists, this is a no-op.  Completed or failed entries are
+    /// left as-is; use [`enqueue_refetch`] to force a re-pull.
+    pub(crate) fn enqueue_pull(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+        priority: i32,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO fetch_queue (registry, repository, tag, task, priority)
+             VALUES (?1, ?2, ?3, 'pull', ?4)
+             ON CONFLICT(registry, repository, tag, task) DO NOTHING",
+            rusqlite::params![registry, repository, tag, priority],
+        )?;
+        Ok(())
+    }
+
+    /// Record a tag as already completed without actually pulling it.
+    ///
+    /// Used for tags that were pulled before the queue existed, so they
+    /// appear in the history for visibility.  No-op if a queue entry
+    /// already exists for this tag.
+    pub(crate) fn record_completed(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO fetch_queue (registry, repository, tag, task, status)
+             VALUES (?1, ?2, ?3, 'pull', 'completed')
+             ON CONFLICT(registry, repository, tag, task) DO NOTHING",
+            rusqlite::params![registry, repository, tag],
+        )?;
+        Ok(())
+    }
+
+    /// Enqueue a reindex task for a specific tag.
+    ///
+    /// Re-derives WIT metadata from already-cached layers.  No-op if a
+    /// pending reindex for this tag already exists.
+    #[allow(dead_code)] // public API for targeted reindexing
+    pub(crate) fn enqueue_reindex(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO fetch_queue (registry, repository, tag, task)
+             VALUES (?1, ?2, ?3, 'reindex')
+             ON CONFLICT(registry, repository, tag, task) DO NOTHING",
+            rusqlite::params![registry, repository, tag],
+        )?;
+        Ok(())
+    }
+
+    /// Enqueue reindex tasks for all tags that have cached layers.
+    ///
+    /// Returns the number of tasks enqueued.
+    pub(crate) fn enqueue_reindex_all(&self) -> anyhow::Result<u64> {
+        let count = self.conn.execute(
+            "INSERT INTO fetch_queue (registry, repository, tag, task)
+             SELECT r.registry, r.repository, t.tag, 'reindex'
+               FROM oci_tag t
+               JOIN oci_repository r ON r.id = t.oci_repository_id
+               JOIN oci_manifest m ON m.oci_repository_id = r.id
+                                  AND m.digest = t.manifest_digest
+               JOIN oci_layer l ON l.oci_manifest_id = m.id
+              GROUP BY r.registry, r.repository, t.tag
+             ON CONFLICT(registry, repository, tag, task) DO NOTHING",
+            [],
+        )?;
+        Ok(u64::try_from(count).unwrap_or(0))
+    }
+
+    /// Seed the fetch queue with completed entries for all tags that
+    /// already have cached layers.
+    ///
+    /// This back-fills the queue history so that previously-pulled tags
+    /// appear in the status page even if they were fetched before the
+    /// queue was introduced.  No-op for tags that already have a queue
+    /// entry.  Returns the number of entries created.
+    pub(crate) fn seed_completed_from_tags(&self) -> anyhow::Result<u64> {
+        let count = self.conn.execute(
+            "INSERT INTO fetch_queue (registry, repository, tag, task, status, created_at, updated_at)
+             SELECT r.registry, r.repository, t.tag, 'pull', 'completed',
+                    t.created_at, t.updated_at
+               FROM oci_tag t
+               JOIN oci_repository r ON r.id = t.oci_repository_id
+               JOIN oci_manifest m ON m.oci_repository_id = r.id
+                                  AND m.digest = t.manifest_digest
+               JOIN oci_layer l ON l.oci_manifest_id = m.id
+              WHERE t.tag != 'latest'
+                AND t.tag NOT LIKE 'sha256-%'
+              GROUP BY r.registry, r.repository, t.tag
+             ON CONFLICT(registry, repository, tag, task) DO UPDATE SET
+                 created_at = excluded.created_at,
+                 updated_at = excluded.updated_at
+              WHERE fetch_queue.status = 'completed'",
+            [],
+        )?;
+        Ok(u64::try_from(count).unwrap_or(0))
+    }
+
+    /// Force a re-pull of a specific tag, even if it was already completed.
+    ///
+    /// Resets the status to 'pending' and clears the attempt counter.
+    pub(crate) fn enqueue_refetch(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+        priority: i32,
+    ) -> anyhow::Result<()> {
+        self.conn.execute(
+            "INSERT INTO fetch_queue (registry, repository, tag, task, priority)
+             VALUES (?1, ?2, ?3, 'pull', ?4)
+             ON CONFLICT(registry, repository, tag, task) DO UPDATE SET
+                 status = 'pending',
+                 priority = excluded.priority,
+                 attempts = 0,
+                 last_error = NULL",
+            rusqlite::params![registry, repository, tag, priority],
+        )?;
+        Ok(())
+    }
+
+    /// Dequeue the next pending task, marking it as in-progress.
+    ///
+    /// Returns `None` when the queue is empty.  Tasks are ordered by
+    /// priority (ascending) then creation time.
+    pub(crate) fn dequeue_next(&self) -> anyhow::Result<Option<FetchTask>> {
+        // Single UPDATE ... RETURNING to atomically claim the next item.
+        let result = self.conn.query_row(
+            "UPDATE fetch_queue
+                SET status = 'in_progress'
+              WHERE id = (
+                  SELECT id FROM fetch_queue
+                   WHERE status = 'pending'
+                   ORDER BY priority ASC, created_at ASC
+                   LIMIT 1
+              )
+              RETURNING id, registry, repository, tag, task, attempts",
+            [],
+            |row| {
+                Ok(FetchTask {
+                    id: row.get(0)?,
+                    registry: row.get(1)?,
+                    repository: row.get(2)?,
+                    tag: row.get(3)?,
+                    kind: row.get::<_, String>(4)?.into(),
+                    attempts: row.get(5)?,
+                })
+            },
+        );
+        match result {
+            Ok(task) => Ok(Some(task)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Mark a task as successfully completed.
+    pub(crate) fn complete_task(&self, task_id: i64) -> anyhow::Result<()> {
+        self.conn.execute(
+            "UPDATE fetch_queue SET status = 'completed' WHERE id = ?1",
+            [task_id],
+        )?;
+        Ok(())
+    }
+
+    /// Record a failed attempt.
+    ///
+    /// If the task has not exhausted its retry budget, it returns to
+    /// 'pending' for another attempt.  Otherwise it is marked 'failed'.
+    pub(crate) fn fail_task(&self, task_id: i64, error: &str) -> anyhow::Result<()> {
+        self.conn.execute(
+            "UPDATE fetch_queue
+                SET attempts = attempts + 1,
+                    last_error = ?2,
+                    status = CASE
+                        WHEN attempts + 1 >= max_attempts THEN 'failed'
+                        ELSE 'pending'
+                    END
+              WHERE id = ?1",
+            rusqlite::params![task_id, error],
+        )?;
+        Ok(())
+    }
+
+    /// Return the number of pending tasks in the queue.
+    pub(crate) fn pending_count(&self) -> anyhow::Result<u64> {
+        let count: i64 = self.conn.query_row(
+            "SELECT COUNT(*) FROM fetch_queue WHERE status = 'pending'",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(u64::try_from(count).unwrap_or(0))
+    }
+
+    /// Return an overview of the fetch queue with per-status counts and
+    /// recent/active tasks.
+    pub(crate) fn get_queue_status(&self) -> anyhow::Result<wasm_meta_registry_types::QueueStatus> {
+        use wasm_meta_registry_types::{QueueStatus, QueueTask};
+
+        // Counts per status.
+        let mut pending = 0u64;
+        let mut in_progress = 0u64;
+        let mut completed = 0u64;
+        let mut failed = 0u64;
+
+        let mut stmt = self
+            .conn
+            .prepare("SELECT status, COUNT(*) FROM fetch_queue GROUP BY status")?;
+        let rows = stmt.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        for row in rows {
+            let (status, count) = row?;
+            let count = u64::try_from(count).unwrap_or(0);
+            match status.as_str() {
+                "pending" => pending = count,
+                "in_progress" => in_progress = count,
+                "completed" => completed = count,
+                "failed" => failed = count,
+                _ => {}
+            }
+        }
+
+        // Active tasks: pending + in_progress, ordered by priority then age.
+        let mut active_stmt = self.conn.prepare(
+            "SELECT registry, repository, tag, task, status,
+                    priority, attempts, max_attempts, last_error,
+                    created_at, updated_at
+               FROM fetch_queue
+              WHERE status IN ('pending', 'in_progress')
+              ORDER BY
+                  CASE status WHEN 'in_progress' THEN 0 ELSE 1 END,
+                  priority ASC,
+                  created_at ASC",
+        )?;
+        let active: Vec<QueueTask> = active_stmt
+            .query_map([], |row| {
+                Ok(QueueTask {
+                    registry: row.get(0)?,
+                    repository: row.get(1)?,
+                    tag: row.get(2)?,
+                    task: row.get(3)?,
+                    status: row.get(4)?,
+                    priority: row.get(5)?,
+                    attempts: row.get(6)?,
+                    max_attempts: row.get(7)?,
+                    last_error: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // History: completed + failed, most recent first, capped at 50.
+        let mut history_stmt = self.conn.prepare(
+            "SELECT registry, repository, tag, task, status,
+                    priority, attempts, max_attempts, last_error,
+                    created_at, updated_at
+               FROM fetch_queue
+              WHERE status IN ('completed', 'failed')
+              ORDER BY updated_at DESC, repository ASC, tag DESC
+              LIMIT 50",
+        )?;
+        let history: Vec<QueueTask> = history_stmt
+            .query_map([], |row| {
+                Ok(QueueTask {
+                    registry: row.get(0)?,
+                    repository: row.get(1)?,
+                    tag: row.get(2)?,
+                    task: row.get(3)?,
+                    status: row.get(4)?,
+                    priority: row.get(5)?,
+                    attempts: row.get(6)?,
+                    max_attempts: row.get(7)?,
+                    last_error: row.get(8)?,
+                    created_at: row.get(9)?,
+                    updated_at: row.get(10)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(QueueStatus {
+            pending,
+            in_progress,
+            completed,
+            failed,
+            active,
+            history,
+        })
+    }
+
+    /// Re-derive WIT metadata for a single tag from cached layers.
+    ///
+    /// Finds the manifest for the given tag, then deletes and re-extracts
+    /// the WIT package and wasm component data from the cached layer bytes.
+    pub(crate) async fn reindex_tag(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+    ) -> anyhow::Result<()> {
+        // Find the manifest id for this tag.
+        let manifest_id: Option<i64> = self
+            .conn
+            .query_row(
+                "SELECT m.id
+                   FROM oci_tag t
+                   JOIN oci_repository r ON r.id = t.oci_repository_id
+                   JOIN oci_manifest m ON m.oci_repository_id = r.id
+                                      AND m.digest = t.manifest_digest
+                  WHERE r.registry = ?1
+                    AND r.repository = ?2
+                    AND t.tag = ?3
+                  LIMIT 1",
+                rusqlite::params![registry, repository, tag],
+                |row| row.get(0),
+            )
+            .ok();
+
+        let Some(manifest_id) = manifest_id else {
+            anyhow::bail!("no manifest found for {registry}/{repository}:{tag}");
+        };
+
+        // Find the first wasm layer for this manifest.
+        let layer: Option<(i64, String)> = self
+            .conn
+            .query_row(
+                "SELECT id, digest FROM oci_layer
+                  WHERE oci_manifest_id = ?1
+                  ORDER BY position ASC LIMIT 1",
+                [manifest_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .ok();
+
+        let Some((layer_id, digest)) = layer else {
+            anyhow::bail!("no layers found for manifest of {registry}/{repository}:{tag}");
+        };
+
+        // Read bytes from cacache.
+        let store_dir = self.state_info.store_dir().to_path_buf();
+        let bytes = cacache::read(&store_dir, &digest).await?;
+
+        // Delete old data and re-extract.
+        self.conn.execute_batch("SAVEPOINT reindex_tag")?;
+
+        let ok = self
+            .conn
+            .execute(
+                "DELETE FROM wit_package WHERE oci_manifest_id = ?1",
+                [manifest_id],
+            )
+            .and_then(|_| {
+                self.conn.execute(
+                    "DELETE FROM wasm_component WHERE oci_manifest_id = ?1",
+                    [manifest_id],
+                )
+            })
+            .is_ok_and(|_| self.try_extract_wit_package(manifest_id, Some(layer_id), &bytes));
+
+        if ok {
+            self.conn.execute_batch("RELEASE SAVEPOINT reindex_tag")?;
+        } else {
+            self.conn.execute_batch(
+                "ROLLBACK TO SAVEPOINT reindex_tag; RELEASE SAVEPOINT reindex_tag",
+            )?;
+            anyhow::bail!("failed to re-extract WIT for {registry}/{repository}:{tag}");
+        }
+        Ok(())
     }
 
     /// Get all WIT packages.


### PR DESCRIPTION
Creates a queue to track fetches and indexing jobs rather than just doing them as-is. This allows us to keep a history and look at enqueued jobs.