### PR TITLE
Fix component rendering

### DIFF
--- a/crates/wasm-frontend/src/components/ds/wit_item.rs
+++ b/crates/wasm-frontend/src/components/ds/wit_item.rs
@@ -153,11 +153,22 @@ pub(crate) fn render_item_section(title: &str, items: &[WitItem]) -> Division {
 /// version suffix) so component imports/exports look identical to the
 /// rich-WIT world page.
 pub(crate) fn iface_ref_to_item(iface: &wasm_meta_registry_client::WitInterfaceRef) -> WitItem {
-    let mut name = iface.package.clone();
-    if let Some(iface_name) = &iface.interface {
-        name.push('/');
-        name.push_str(iface_name);
-    }
+    // When the interface lives in the parent component's own package, render
+    // it as native: drop the package prefix so it reads as a first-class
+    // member of this component.
+    let name = if iface.is_native {
+        iface
+            .interface
+            .clone()
+            .unwrap_or_else(|| iface.package.clone())
+    } else {
+        let mut name = iface.package.clone();
+        if let Some(iface_name) = &iface.interface {
+            name.push('/');
+            name.push_str(iface_name);
+        }
+        name
+    };
     let version = iface.version.clone().unwrap_or_default();
     WitItem {
         kind: WitItemKind::Interface,

--- a/crates/wasm-frontend/src/components/page_sidebar.rs
+++ b/crates/wasm-frontend/src/components/page_sidebar.rs
@@ -452,7 +452,7 @@ fn push_wit_nav(items: &mut Vec<SidebarItem>, ctx: &SidebarContext<'_>, doc: &Wi
     // their items appear as top-level sidebar entries instead.
     for world in &doc.worlds {
         if world.is_synthetic {
-            for item in world.imports.iter().chain(world.exports.iter()) {
+            for item in world.exports.iter().chain(world.imports.iter()) {
                 match item {
                     crate::wit_doc::WorldItemDoc::Interface {
                         name,
@@ -487,7 +487,7 @@ fn push_wit_nav(items: &mut Vec<SidebarItem>, ctx: &SidebarContext<'_>, doc: &Wi
         }
         let is_active = matches!(ctx.active, SidebarActive::World(name) if name == world.name);
         let mut children = Vec::new();
-        for item in world.imports.iter().chain(world.exports.iter()) {
+        for item in world.exports.iter().chain(world.imports.iter()) {
             if let crate::wit_doc::WorldItemDoc::Interface {
                 name,
                 url: Some(url),

--- a/crates/wasm-frontend/src/components/page_sidebar.rs
+++ b/crates/wasm-frontend/src/components/page_sidebar.rs
@@ -448,7 +448,43 @@ fn format_date(iso: &str) -> String {
 /// Push WIT worlds and interfaces nav groups into `items`.
 fn push_wit_nav(items: &mut Vec<SidebarItem>, ctx: &SidebarContext<'_>, doc: &WitDocument) {
     // Worlds — each world is a group with its imports/exports as children.
+    // Synthetic worlds (the `root` world of `root:component`) are flattened:
+    // their items appear as top-level sidebar entries instead.
     for world in &doc.worlds {
+        if world.is_synthetic {
+            for item in world.imports.iter().chain(world.exports.iter()) {
+                match item {
+                    crate::wit_doc::WorldItemDoc::Interface {
+                        name,
+                        url: Some(url),
+                        ..
+                    } => {
+                        items.push(SidebarItem::Entry(SidebarEntry {
+                            sigil_bg: s::IFACE.bg,
+                            sigil_color: s::IFACE.color,
+                            sigil_text: s::IFACE.text,
+                            name: short_interface_name(name),
+                            href: url.clone(),
+                            meta: String::new(),
+                            active: false,
+                        }));
+                    }
+                    crate::wit_doc::WorldItemDoc::Function(func) if !func.url.is_empty() => {
+                        items.push(SidebarItem::Entry(SidebarEntry {
+                            sigil_bg: s::FUNC.bg,
+                            sigil_color: s::FUNC.color,
+                            sigil_text: s::FUNC.text,
+                            name: func.name.clone(),
+                            href: func.url.clone(),
+                            meta: String::new(),
+                            active: false,
+                        }));
+                    }
+                    _ => {}
+                }
+            }
+            continue;
+        }
         let is_active = matches!(ctx.active, SidebarActive::World(name) if name == world.name);
         let mut children = Vec::new();
         for item in world.imports.iter().chain(world.exports.iter()) {

--- a/crates/wasm-frontend/src/lib.rs
+++ b/crates/wasm-frontend/src/lib.rs
@@ -67,6 +67,10 @@ fn app() -> Router {
             get(world_detail),
         )
         .route(
+            "/{namespace}/{name}/{version}/world/{world_name}/function/{func_name}",
+            get(world_function_detail),
+        )
+        .route(
             "/{namespace}/{name}/{version}/module/{child_name}",
             get(module_detail),
         )
@@ -314,8 +318,16 @@ async fn item_detail(
         return with_cache_control(html, "public, max-age=300");
     }
     if let Some(func) = iface_doc.functions.iter().find(|f| f.name == item_name) {
-        let html =
-            pages::item::render_function(&pkg, &version, Some(&version_detail), &iface, func, &doc);
+        let iface_url = format!("/{namespace}/{name}/{version}/interface/{iface}");
+        let html = pages::item::render_function(
+            &pkg,
+            &version,
+            Some(&version_detail),
+            &iface,
+            &iface_url,
+            func,
+            &doc,
+        );
         return with_cache_control(html, "public, max-age=300");
     }
 
@@ -339,6 +351,55 @@ async fn world_detail(
         return not_found_response();
     };
     let html = pages::world::render(&pkg, &version, Some(&version_detail), world_doc, &doc);
+    with_cache_control(html, "public, max-age=300")
+}
+
+/// Detail page for a freestanding function declared directly on a world,
+/// at `/<namespace>/<name>/<version>/world/<world>/function/<func>`.
+async fn world_function_detail(
+    Path((namespace, name, version, world_name, func_name)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Response {
+    use crate::wit_doc::WorldItemDoc;
+
+    let client = RegistryClient::from_env();
+    let pkg = match fetch_package_or_404(&client, &namespace, &name, &version).await {
+        Ok(Some(pkg)) => pkg,
+        Ok(None) => return not_found_response(),
+        Err(resp) => return resp,
+    };
+    let Some((doc, version_detail)) = fetch_wit_doc(&client, &pkg, &version).await else {
+        return not_found_response();
+    };
+    let Some(world_doc) = doc.worlds.iter().find(|w| w.name == world_name) else {
+        return not_found_response();
+    };
+    let func = world_doc
+        .imports
+        .iter()
+        .chain(world_doc.exports.iter())
+        .find_map(|item| match item {
+            WorldItemDoc::Function(f) if f.name == func_name => Some(f),
+            _ => None,
+        });
+    let Some(func) = func else {
+        return not_found_response();
+    };
+    let world_url = format!("/{namespace}/{name}/{version}/world/{world_name}");
+    let html = pages::item::render_function(
+        &pkg,
+        &version,
+        Some(&version_detail),
+        &world_name,
+        &world_url,
+        func,
+        &doc,
+    );
     with_cache_control(html, "public, max-age=300")
 }
 

--- a/crates/wasm-frontend/src/lib.rs
+++ b/crates/wasm-frontend/src/lib.rs
@@ -71,6 +71,10 @@ fn app() -> Router {
             get(world_function_detail),
         )
         .route(
+            "/{namespace}/{name}/{version}/function/{func_name}",
+            get(package_function_detail),
+        )
+        .route(
             "/{namespace}/{name}/{version}/module/{child_name}",
             get(module_detail),
         )
@@ -350,6 +354,10 @@ async fn world_detail(
     let Some(world_doc) = doc.worlds.iter().find(|w| w.name == world_name) else {
         return not_found_response();
     };
+    if world_doc.is_synthetic {
+        // Synthetic worlds are inlined into the package page; no detail page.
+        return not_found_response();
+    }
     let html = pages::world::render(&pkg, &version, Some(&version_detail), world_doc, &doc);
     with_cache_control(html, "public, max-age=300")
 }
@@ -397,6 +405,50 @@ async fn world_function_detail(
         Some(&version_detail),
         &world_name,
         &world_url,
+        func,
+        &doc,
+    );
+    with_cache_control(html, "public, max-age=300")
+}
+
+/// Detail page for a freestanding function inlined onto a package page,
+/// at `/<namespace>/<name>/<version>/function/<func>`. Searches every
+/// world's imports and exports for a function with the given name and
+/// returns the first match.
+async fn package_function_detail(
+    Path((namespace, name, version, func_name)): Path<(String, String, String, String)>,
+) -> Response {
+    use crate::wit_doc::WorldItemDoc;
+
+    let client = RegistryClient::from_env();
+    let pkg = match fetch_package_or_404(&client, &namespace, &name, &version).await {
+        Ok(Some(pkg)) => pkg,
+        Ok(None) => return not_found_response(),
+        Err(resp) => return resp,
+    };
+    let Some((doc, version_detail)) = fetch_wit_doc(&client, &pkg, &version).await else {
+        return not_found_response();
+    };
+    let func = doc.worlds.iter().find_map(|w| {
+        w.imports
+            .iter()
+            .chain(w.exports.iter())
+            .find_map(|item| match item {
+                WorldItemDoc::Function(f) if f.name == func_name => Some(f),
+                _ => None,
+            })
+    });
+    let Some(func) = func else {
+        return not_found_response();
+    };
+    let pkg_url = format!("/{namespace}/{name}/{version}");
+    let display_name = components::page_shell::display_name_for(&pkg);
+    let html = pages::item::render_function(
+        &pkg,
+        &version,
+        Some(&version_detail),
+        &display_name,
+        &pkg_url,
         func,
         &doc,
     );

--- a/crates/wasm-frontend/src/lib.rs
+++ b/crates/wasm-frontend/src/lib.rs
@@ -429,7 +429,12 @@ async fn package_function_detail(
     let Some((doc, version_detail)) = fetch_wit_doc(&client, &pkg, &version).await else {
         return not_found_response();
     };
-    let func = doc.worlds.iter().find_map(|w| {
+    // For component packages the `/function/` URL space belongs exclusively to
+    // the synthetic `root` world's items.  Searching all worlds would pick the
+    // first match across potentially many worlds that happen to define a
+    // function with the same name, making routing ambiguous.  Only look in
+    // worlds where `is_synthetic` is true so the lookup is deterministic.
+    let func = doc.worlds.iter().filter(|w| w.is_synthetic).find_map(|w| {
         w.imports
             .iter()
             .chain(w.exports.iter())

--- a/crates/wasm-frontend/src/lib.rs
+++ b/crates/wasm-frontend/src/lib.rs
@@ -373,9 +373,18 @@ async fn fetch_wit_doc(
         pkg.wit_name.as_deref().unwrap_or(&pkg.repository),
         version
     );
-    let doc =
-        wit_doc::parse_wit_doc_with_type_docs(wit_text, &url_base, &dep_urls, &detail.type_docs)
-            .ok()?;
+    let own_oci_package = match (pkg.wit_namespace.as_deref(), pkg.wit_name.as_deref()) {
+        (Some(ns), Some(n)) => Some(format!("{ns}:{n}")),
+        _ => None,
+    };
+    let doc = wit_doc::parse_wit_doc_with_type_docs(
+        wit_text,
+        &url_base,
+        &dep_urls,
+        &detail.type_docs,
+        own_oci_package.as_deref(),
+    )
+    .ok()?;
     Some((doc, detail))
 }
 

--- a/crates/wasm-frontend/src/pages/child_component.rs
+++ b/crates/wasm-frontend/src/pages/child_component.rs
@@ -43,16 +43,6 @@ pub(crate) fn render(
 
     let mut body = String::from("<div class=\"space-y-10 pt-8\">");
 
-    // WIT imports
-    if !child.imports.is_empty() {
-        let entries: Vec<WitItem> = child
-            .imports
-            .iter()
-            .map(wit_item::iface_ref_to_item)
-            .collect();
-        body.push_str(&wit_item::render_item_section("Imports", &entries).to_string());
-    }
-
     // WIT exports
     if !child.exports.is_empty() {
         let entries: Vec<WitItem> = child
@@ -61,6 +51,16 @@ pub(crate) fn render(
             .map(wit_item::iface_ref_to_item)
             .collect();
         body.push_str(&wit_item::render_item_section("Exports", &entries).to_string());
+    }
+
+    // WIT imports
+    if !child.imports.is_empty() {
+        let entries: Vec<WitItem> = child
+            .imports
+            .iter()
+            .map(wit_item::iface_ref_to_item)
+            .collect();
+        body.push_str(&wit_item::render_item_section("Imports", &entries).to_string());
     }
 
     // Metadata table (producers, dependencies, languages, size, etc.)

--- a/crates/wasm-frontend/src/pages/child_component.rs
+++ b/crates/wasm-frontend/src/pages/child_component.rs
@@ -157,12 +157,14 @@ mod tests {
                 interface: Some("streams".into()),
                 version: Some("0.2.0".into()),
                 docs: None,
+                is_native: false,
             }],
             exports: vec![WitInterfaceRef {
                 package: "wasi:http".into(),
                 interface: Some("incoming-handler".into()),
                 version: Some("0.2.0".into()),
                 docs: None,
+                is_native: false,
             }],
         }
     }

--- a/crates/wasm-frontend/src/pages/item.rs
+++ b/crates/wasm-frontend/src/pages/item.rs
@@ -110,17 +110,21 @@ pub(crate) fn render_type(
 }
 
 /// Render the item detail page for a freestanding function.
+///
+/// `owner_label` is the breadcrumb/sidebar label of the parent (interface
+/// or world) and `owner_url` is the URL of its detail page.
 #[must_use]
 pub(crate) fn render_function(
     pkg: &KnownPackage,
     version: &str,
     version_detail: Option<&PackageVersion>,
-    iface_name: &str,
+    owner_label: &str,
+    owner_url: &str,
     func: &FunctionDoc,
     doc: &WitDocument,
 ) -> String {
     let display_name = crate::components::page_shell::display_name_for(pkg);
-    let title = format!("{display_name} \u{2014} {iface_name}::{}", func.name);
+    let title = format!("{display_name} \u{2014} {owner_label}::{}", func.name);
 
     // Code block
     let code_block = render_function_definition(func).to_string();
@@ -139,14 +143,10 @@ pub(crate) fn render_function(
 
     let content = String::new();
 
-    let iface_url = format!(
-        "/{}/{version}/interface/{iface_name}",
-        display_name.replace(':', "/")
-    );
     let extra = [
         crate::components::ds::breadcrumb::Crumb {
-            label: iface_name.to_owned(),
-            href: Some(iface_url),
+            label: owner_label.to_owned(),
+            href: Some(owner_url.to_owned()),
         },
         crate::components::ds::breadcrumb::Crumb {
             label: func.name.clone(),
@@ -161,7 +161,7 @@ pub(crate) fn render_function(
         title: &title,
         header_html: &header,
         body_html: &content,
-        sidebar_active: SidebarActive::Item(iface_name, &func.name),
+        sidebar_active: SidebarActive::Item(owner_label, &func.name),
         extra_crumbs: &extra,
         toc_html: None,
         importers: &[],

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -204,7 +204,10 @@ fn render_wit_content_with_doc(
                     .push(render_world_overview(doc, &display_name))
             });
         }
-        if !doc.interfaces.is_empty() {
+        // When inlining the synthetic root world, the world's exports already
+        // surface every native interface — listing them again under
+        // "Interfaces" would duplicate `convert` etc.
+        if !inline_root && !doc.interfaces.is_empty() {
             toc.push(("#interfaces".to_owned(), "Interfaces".to_owned(), false));
             for iface in &doc.interfaces {
                 let id = format!("iface-{}", iface.name);

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -166,10 +166,10 @@ fn render_wit_content_with_doc(
                 .first()
                 .is_some_and(|w| w.is_synthetic && doc.worlds.len() == 1);
         if inline_root {
-            // SAFETY: inline_root is only true when doc.worlds is non-empty
-            let Some(world) = doc.worlds.first() else {
-                unreachable!("inline_root ensures at least one world exists")
-            };
+            let world = doc
+                .worlds
+                .first()
+                .expect("inline_root ensures doc.worlds is non-empty");
             let api_docs = super::world::build_api_doc_lookup(Some(detail), &world.name);
             if !world.exports.is_empty() {
                 toc.push(("#exports".to_owned(), "Exports".to_owned(), false));

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -188,18 +188,18 @@ fn render_wit_content_with_doc(
 
         if has_component_imports {
             for comp in &detail.components {
-                if !comp.imports.is_empty() {
-                    toc.push(("#imports".to_owned(), "Imports".to_owned(), false));
-                    section.division(|d| {
-                        d.id("imports".to_owned())
-                            .push(render_iface_ref_list("Imports", &comp.imports))
-                    });
-                }
                 if !comp.exports.is_empty() {
                     toc.push(("#exports".to_owned(), "Exports".to_owned(), false));
                     section.division(|d| {
                         d.id("exports".to_owned())
                             .push(render_iface_ref_list("Exports", &comp.exports))
+                    });
+                }
+                if !comp.imports.is_empty() {
+                    toc.push(("#imports".to_owned(), "Imports".to_owned(), false));
+                    section.division(|d| {
+                        d.id("imports".to_owned())
+                            .push(render_iface_ref_list("Imports", &comp.imports))
                     });
                 }
             }
@@ -417,11 +417,11 @@ fn render_world_summaries(detail: &PackageVersion) -> Division {
                 });
             }
 
-            if !world.imports.is_empty() {
-                world_div.push(render_iface_ref_list("Imports", &world.imports));
-            }
             if !world.exports.is_empty() {
                 world_div.push(render_iface_ref_list("Exports", &world.exports));
+            }
+            if !world.imports.is_empty() {
+                world_div.push(render_iface_ref_list("Imports", &world.imports));
             }
             world_div
         });

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -156,13 +156,20 @@ fn render_wit_content_with_doc(
     let mut toc: Vec<(String, String, bool)> = Vec::new();
     let display_name = page_shell::display_name_for(pkg);
     if let Some(doc) = doc {
-        // Component special-case: when the only world is the synthetic
-        // `root` produced by extracting bindings from a wasm component,
-        // inline its imports/exports as the component's own instead of
-        // surfacing a single boring "Worlds → root" card.
-        let inline_root = doc.worlds.len() == 1 && doc.worlds[0].is_synthetic;
+        // Component special-case: when the document represents an extracted
+        // wasm component (is_component is true) and the only world is
+        // synthetic, inline its imports/exports as the component's own
+        // instead of surfacing a single boring "Worlds → root" card.
+        let inline_root = doc.is_component
+            && doc
+                .worlds
+                .first()
+                .is_some_and(|w| w.is_synthetic && doc.worlds.len() == 1);
         if inline_root {
-            let world = &doc.worlds[0];
+            // SAFETY: inline_root is only true when doc.worlds is non-empty
+            let Some(world) = doc.worlds.first() else {
+                unreachable!("inline_root ensures at least one world exists")
+            };
             let api_docs = super::world::build_api_doc_lookup(Some(detail), &world.name);
             if !world.exports.is_empty() {
                 toc.push(("#exports".to_owned(), "Exports".to_owned(), false));

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -160,12 +160,7 @@ fn render_wit_content_with_doc(
         // `root` produced by extracting bindings from a wasm component,
         // inline its imports/exports as the component's own instead of
         // surfacing a single boring "Worlds → root" card.
-        let inline_root = doc.worlds.len() == 1
-            && doc.worlds[0].name == "root"
-            && detail
-                .components
-                .iter()
-                .any(|c| c.kind.as_deref() == Some("component"));
+        let inline_root = doc.worlds.len() == 1 && doc.worlds[0].is_synthetic;
         if inline_root {
             let world = &doc.worlds[0];
             let api_docs = super::world::build_api_doc_lookup(Some(detail), &world.name);

--- a/crates/wasm-frontend/src/pages/package.rs
+++ b/crates/wasm-frontend/src/pages/package.rs
@@ -24,7 +24,7 @@ pub(crate) fn render(
 ) -> String {
     let display_name = page_shell::display_name_for(pkg);
     let url_base = page_shell::url_base_for(pkg, version);
-    let wit_doc = version_detail.and_then(|d| try_parse_wit(d, &url_base));
+    let wit_doc = version_detail.and_then(|d| try_parse_wit(d, &url_base, pkg));
 
     // Package heading
     let kind_label = match pkg.kind {
@@ -156,7 +156,44 @@ fn render_wit_content_with_doc(
     let mut toc: Vec<(String, String, bool)> = Vec::new();
     let display_name = page_shell::display_name_for(pkg);
     if let Some(doc) = doc {
-        if !doc.worlds.is_empty() {
+        // Component special-case: when the only world is the synthetic
+        // `root` produced by extracting bindings from a wasm component,
+        // inline its imports/exports as the component's own instead of
+        // surfacing a single boring "Worlds → root" card.
+        let inline_root = doc.worlds.len() == 1
+            && doc.worlds[0].name == "root"
+            && detail
+                .components
+                .iter()
+                .any(|c| c.kind.as_deref() == Some("component"));
+        if inline_root {
+            let world = &doc.worlds[0];
+            let api_docs = super::world::build_api_doc_lookup(Some(detail), &world.name);
+            if !world.exports.is_empty() {
+                toc.push(("#exports".to_owned(), "Exports".to_owned(), false));
+                section.division(|d| {
+                    d.id("exports".to_owned())
+                        .push(super::world::render_item_section(
+                            "Exports",
+                            &world.exports,
+                            &api_docs,
+                            &display_name,
+                        ))
+                });
+            }
+            if !world.imports.is_empty() {
+                toc.push(("#imports".to_owned(), "Imports".to_owned(), false));
+                section.division(|d| {
+                    d.id("imports".to_owned())
+                        .push(super::world::render_item_section(
+                            "Imports",
+                            &world.imports,
+                            &api_docs,
+                            &display_name,
+                        ))
+                });
+            }
+        } else if !doc.worlds.is_empty() {
             toc.push(("#worlds".to_owned(), "Worlds".to_owned(), false));
             for world in &doc.worlds {
                 let id = format!("world-{}", world.name);
@@ -317,10 +354,25 @@ fn render_children_overview(
 }
 
 /// Try parsing the WIT text into a rich document model.
-fn try_parse_wit(detail: &PackageVersion, url_base: &str) -> Option<WitDocument> {
+fn try_parse_wit(
+    detail: &PackageVersion,
+    url_base: &str,
+    pkg: &KnownPackage,
+) -> Option<WitDocument> {
     let wit_text = detail.wit_text.as_deref()?;
     let dep_urls = build_dep_urls(&detail.dependencies);
-    crate::wit_doc::parse_wit_doc(wit_text, url_base, &dep_urls).ok()
+    let own_oci_package = match (pkg.wit_namespace.as_deref(), pkg.wit_name.as_deref()) {
+        (Some(ns), Some(n)) => Some(format!("{ns}:{n}")),
+        _ => None,
+    };
+    crate::wit_doc::parse_wit_doc_with_type_docs(
+        wit_text,
+        url_base,
+        &dep_urls,
+        &detail.type_docs,
+        own_oci_package.as_deref(),
+    )
+    .ok()
 }
 
 /// Build the `dep_urls` mapping from a package's declared dependencies.

--- a/crates/wasm-frontend/src/pages/world.rs
+++ b/crates/wasm-frontend/src/pages/world.rs
@@ -72,7 +72,7 @@ pub(crate) fn render(
 
 /// Build a lookup map of interface name → doc string from the API's enriched
 /// world data. This provides cross-package docs that the WIT parser can't.
-fn build_api_doc_lookup(
+pub(crate) fn build_api_doc_lookup(
     version_detail: Option<&PackageVersion>,
     world_name: &str,
 ) -> std::collections::HashMap<String, String> {
@@ -99,7 +99,7 @@ fn build_api_doc_lookup(
 }
 
 /// Render an imports or exports section, grouped by package namespace.
-fn render_item_section(
+pub(crate) fn render_item_section(
     heading: &str,
     items: &[WorldItemDoc],
     api_docs: &std::collections::HashMap<String, String>,

--- a/crates/wasm-frontend/src/pages/world.rs
+++ b/crates/wasm-frontend/src/pages/world.rs
@@ -29,22 +29,22 @@ pub(crate) fn render(
     )
     .to_string();
 
-    // Body sections: Imports + Exports (grouped by package).
+    // Body sections: Exports + Imports (grouped by package).
     let api_docs = build_api_doc_lookup(version_detail, &world.name);
     let mut body = Division::builder();
     body.class("space-y-10 pt-8");
-    if !world.imports.is_empty() {
-        body.push(render_item_section(
-            "Imports",
-            &world.imports,
-            &api_docs,
-            &display_name,
-        ));
-    }
     if !world.exports.is_empty() {
         body.push(render_item_section(
             "Exports",
             &world.exports,
+            &api_docs,
+            &display_name,
+        ));
+    }
+    if !world.imports.is_empty() {
+        body.push(render_item_section(
+            "Imports",
+            &world.imports,
             &api_docs,
             &display_name,
         ));

--- a/crates/wasm-frontend/src/wit_doc/convert.rs
+++ b/crates/wasm-frontend/src/wit_doc/convert.rs
@@ -658,7 +658,10 @@ impl Converter<'_> {
             // Check if this is an interface in our own package.
             if self.own_interfaces.contains(&id) {
                 let iface_url = format!("{}/interface/{iface_name}", self.url_base);
-                return (display, Some(iface_url));
+                // Native interfaces drop the package prefix so they read as
+                // first-class members of this document (e.g. `convert`
+                // instead of `yoshuawuyts:wordmark/convert`).
+                return (iface_name.to_owned(), Some(iface_url));
             }
 
             // Check dep_urls for external packages.

--- a/crates/wasm-frontend/src/wit_doc/convert.rs
+++ b/crates/wasm-frontend/src/wit_doc/convert.rs
@@ -567,12 +567,12 @@ impl Converter<'_> {
             imports: world
                 .imports
                 .iter()
-                .map(|(key, item)| self.convert_world_item(key, item))
+                .map(|(key, item)| self.convert_world_item(key, item, name))
                 .collect(),
             exports: world
                 .exports
                 .iter()
-                .map(|(key, item)| self.convert_world_item(key, item))
+                .map(|(key, item)| self.convert_world_item(key, item, name))
                 .collect(),
             stability: convert_stability(&world.stability),
             url,
@@ -580,7 +580,12 @@ impl Converter<'_> {
     }
 
     /// Convert a world import/export item.
-    fn convert_world_item(&self, key: &WorldKey, item: &WorldItem) -> WorldItemDoc {
+    fn convert_world_item(
+        &self,
+        _key: &WorldKey,
+        item: &WorldItem,
+        world_name: &str,
+    ) -> WorldItemDoc {
         match item {
             WorldItem::Interface { id, stability, .. } => {
                 let iface = self
@@ -601,11 +606,12 @@ impl Converter<'_> {
                 }
             }
             WorldItem::Function(func) => {
-                let iface_name = match key {
-                    WorldKey::Name(n) => n.as_str(),
-                    WorldKey::Interface(_) => "world",
-                };
-                WorldItemDoc::Function(self.convert_function(func, iface_name))
+                // Freestanding world functions live directly under their
+                // world page rather than an interface; route them as
+                // `/world/{world_name}/function/{func_name}`.
+                let mut doc = self.convert_function(func, world_name);
+                doc.url = format!("{}/world/{world_name}/function/{}", self.url_base, doc.name);
+                WorldItemDoc::Function(doc)
             }
             WorldItem::Type { id: type_id, .. } => {
                 let type_def = self

--- a/crates/wasm-frontend/src/wit_doc/convert.rs
+++ b/crates/wasm-frontend/src/wit_doc/convert.rs
@@ -145,6 +145,7 @@ pub(crate) fn convert(
         docs,
         interfaces,
         worlds,
+        is_component: converter.primary_is_root_component,
     })
 }
 
@@ -612,12 +613,14 @@ impl Converter<'_> {
                 }
             }
             WorldItem::Function(func) => {
-                // Freestanding world functions live directly under the
-                // package page (component pages inline `world root`), so
-                // route them as `/function/{func_name}` to keep URLs short
-                // and avoid leaking the synthetic `root` world name.
                 let mut doc = self.convert_function(func, world_name);
-                doc.url = format!("{}/function/{}", self.url_base, doc.name);
+                // Only collapse world-level functions to `/function/{name}` for
+                // the synthetic `root` world of an extracted component.  For
+                // non-synthetic worlds, keep a world-qualified URL so that two
+                // worlds exporting a function with the same name don't collide.
+                if self.primary_is_root_component && world_name == "root" {
+                    doc.url = format!("{}/function/{}", self.url_base, doc.name);
+                }
                 WorldItemDoc::Function(doc)
             }
             WorldItem::Type { id: type_id, .. } => {

--- a/crates/wasm-frontend/src/wit_doc/convert.rs
+++ b/crates/wasm-frontend/src/wit_doc/convert.rs
@@ -25,6 +25,10 @@ struct Converter<'a> {
     type_urls: HashMap<TypeId, (String, String)>,
     /// Cross-package type docs from the API (e.g. `"wasi:io/poll/pollable"` → docs).
     type_docs: &'a HashMap<String, String>,
+    /// True when the primary package is the synthetic `root:component`
+    /// envelope produced by extracting bindings from a wasm component.
+    /// Its `root` world is then surfaced as synthetic.
+    primary_is_root_component: bool,
 }
 
 /// Parse WIT text into a [`WitDocument`].
@@ -101,6 +105,7 @@ pub(crate) fn convert(
         own_interfaces,
         type_urls: HashMap::new(),
         type_docs,
+        primary_is_root_component: primary_key == "root:component",
     };
 
     // First pass: register type URLs for every native interface so
@@ -576,6 +581,7 @@ impl Converter<'_> {
                 .collect(),
             stability: convert_stability(&world.stability),
             url,
+            is_synthetic: self.primary_is_root_component && name == "root",
         }
     }
 
@@ -606,11 +612,12 @@ impl Converter<'_> {
                 }
             }
             WorldItem::Function(func) => {
-                // Freestanding world functions live directly under their
-                // world page rather than an interface; route them as
-                // `/world/{world_name}/function/{func_name}`.
+                // Freestanding world functions live directly under the
+                // package page (component pages inline `world root`), so
+                // route them as `/function/{func_name}` to keep URLs short
+                // and avoid leaking the synthetic `root` world name.
                 let mut doc = self.convert_function(func, world_name);
-                doc.url = format!("{}/world/{world_name}/function/{}", self.url_base, doc.name);
+                doc.url = format!("{}/function/{}", self.url_base, doc.name);
                 WorldItemDoc::Function(doc)
             }
             WorldItem::Type { id: type_id, .. } => {

--- a/crates/wasm-frontend/src/wit_doc/convert.rs
+++ b/crates/wasm-frontend/src/wit_doc/convert.rs
@@ -45,51 +45,90 @@ pub(crate) fn convert(
     url_base: &str,
     dep_urls: &HashMap<String, String>,
     type_docs: &HashMap<String, String>,
+    own_oci_package: Option<&str>,
 ) -> anyhow::Result<WitDocument> {
     let mut resolve = Resolve::default();
-    let package_id = resolve.push_str(Path::new("input.wit"), wit_text)?;
+    let primary_id = resolve.push_str(Path::new("input.wit"), wit_text)?;
 
-    let package = resolve
+    let primary = resolve
         .packages
-        .get(package_id)
+        .get(primary_id)
         .expect("just-inserted package should exist");
+    let primary_key = format!("{}:{}", primary.name.namespace, primary.name.name);
+
+    // Locate any additional package whose `ns:name` matches the OCI
+    // package this document represents. Components often place the
+    // user-facing package as a nested package under a synthetic
+    // `root:component` primary; we include its interfaces so they appear
+    // under this document's URL base.
+    let native_id = own_oci_package.and_then(|wanted| {
+        (wanted != primary_key).then(|| {
+            resolve.packages.iter().find_map(|(id, pkg)| {
+                let key = format!("{}:{}", pkg.name.namespace, pkg.name.name);
+                (key == wanted).then_some(id)
+            })
+        })?
+    });
+
+    // The package whose metadata (name, docs, version) describes this
+    // document. Prefer the OCI-native package when present.
+    let package = native_id
+        .and_then(|id| resolve.packages.get(id))
+        .unwrap_or(primary);
 
     let package_name = format!("{}:{}", package.name.namespace, package.name.name);
     let version = package.name.version.as_ref().map(ToString::to_string);
     let docs = package.docs.contents.clone();
 
+    // Native interfaces span both the primary and OCI-native packages so
+    // cross-references and URL resolution treat them uniformly.
+    let native_packages: Vec<&wit_parser::Package> = match native_id {
+        Some(id) => vec![
+            primary,
+            resolve.packages.get(id).expect("native pkg exists"),
+        ],
+        None => vec![primary],
+    };
+    let own_interfaces: HashSet<InterfaceId> = native_packages
+        .iter()
+        .flat_map(|p| p.interfaces.values().copied())
+        .collect();
+
     let mut converter = Converter {
         resolve: &resolve,
         url_base,
         dep_urls,
-        own_interfaces: package.interfaces.values().copied().collect(),
+        own_interfaces,
         type_urls: HashMap::new(),
         type_docs,
     };
 
-    // First pass: register all type URLs so cross-refs within this package
-    // resolve correctly.
-    for (iface_name, iface_id) in &package.interfaces {
-        let iface = resolve
-            .interfaces
-            .get(*iface_id)
-            .expect("interface id should be valid");
-        for (type_name, type_id) in &iface.types {
-            let url = format!("{url_base}/interface/{iface_name}/{type_name}");
-            converter
-                .type_urls
-                .insert(*type_id, (url, type_name.clone()));
+    // First pass: register type URLs for every native interface so
+    // intra-document type refs resolve.
+    for pkg in &native_packages {
+        for (iface_name, iface_id) in &pkg.interfaces {
+            let iface = resolve
+                .interfaces
+                .get(*iface_id)
+                .expect("interface id should be valid");
+            for (type_name, type_id) in &iface.types {
+                let url = format!("{url_base}/interface/{iface_name}/{type_name}");
+                converter
+                    .type_urls
+                    .insert(*type_id, (url, type_name.clone()));
+            }
         }
     }
 
-    // Second pass: build the full document.
-    let interfaces = package
-        .interfaces
+    // Second pass: build the full document. Interfaces come from all
+    // native packages; worlds come from the primary (per wit-parser).
+    let interfaces = native_packages
         .iter()
+        .flat_map(|p| p.interfaces.iter())
         .map(|(name, id)| converter.convert_interface(name, *id))
         .collect();
 
-    let worlds = package
+    let worlds = primary
         .worlds
         .iter()
         .map(|(name, id)| converter.convert_world(name, *id))

--- a/crates/wasm-frontend/src/wit_doc/mod.rs
+++ b/crates/wasm-frontend/src/wit_doc/mod.rs
@@ -30,21 +30,30 @@ pub(crate) fn parse_wit_doc<S: BuildHasher>(
     url_base: &str,
     dep_urls: &HashMap<String, String, S>,
 ) -> anyhow::Result<WitDocument> {
-    parse_wit_doc_with_type_docs(wit_text, url_base, dep_urls, &HashMap::new())
+    parse_wit_doc_with_type_docs(wit_text, url_base, dep_urls, &HashMap::new(), None)
 }
 
 /// Parse WIT text with cross-package type documentation.
+///
+/// `own_oci_package` is the `ns:name` of the OCI package this document
+/// represents (e.g. `"yoshuawuyts:wordmark"`). When provided and the parsed
+/// `Resolve` contains a package with that name, that package is treated as
+/// the document's primary package — its interfaces are listed in the doc
+/// and rendered under `url_base`. This is needed for components whose
+/// extracted WIT places the user-facing package as a nested package under a
+/// synthetic `root:component` primary.
 pub(crate) fn parse_wit_doc_with_type_docs<S: BuildHasher>(
     wit_text: &str,
     url_base: &str,
     dep_urls: &HashMap<String, String, S>,
     type_docs: &HashMap<String, String>,
+    own_oci_package: Option<&str>,
 ) -> anyhow::Result<WitDocument> {
     let standard: HashMap<String, String> = dep_urls
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    convert::convert(wit_text, url_base, &standard, type_docs)
+    convert::convert(wit_text, url_base, &standard, type_docs, own_oci_package)
 }
 
 #[cfg(test)]

--- a/crates/wasm-frontend/src/wit_doc/mod.rs
+++ b/crates/wasm-frontend/src/wit_doc/mod.rs
@@ -25,6 +25,7 @@ use std::hash::BuildHasher;
 /// # Errors
 ///
 /// Returns an error if the WIT text fails to parse.
+#[cfg(test)]
 pub(crate) fn parse_wit_doc<S: BuildHasher>(
     wit_text: &str,
     url_base: &str,

--- a/crates/wasm-frontend/src/wit_doc/types.rs
+++ b/crates/wasm-frontend/src/wit_doc/types.rs
@@ -25,6 +25,15 @@ pub(crate) struct WitDocument {
     pub interfaces: Vec<InterfaceDoc>,
     /// All worlds defined in this package.
     pub worlds: Vec<WorldDoc>,
+    /// True when this document was produced by extracting WIT from a compiled
+    /// WebAssembly component (as opposed to a hand-authored WIT package).
+    ///
+    /// When `true`, the document contains exactly one world whose
+    /// [`WorldDoc::is_synthetic`] flag is also `true`; that world's exports
+    /// and imports are the component's own interface and are surfaced directly
+    /// on the package page rather than behind a "Worlds" section.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_component: bool,
 }
 
 /// Documentation for a single WIT interface.

--- a/crates/wasm-frontend/src/wit_doc/types.rs
+++ b/crates/wasm-frontend/src/wit_doc/types.rs
@@ -277,6 +277,12 @@ pub(crate) struct WorldDoc {
     pub stability: Stability,
     /// Pre-resolved URL for this world's detail page.
     pub url: String,
+    /// True when this world was synthesized by binding-extraction (the
+    /// `root` world of a `root:component` package) rather than being
+    /// authored. Synthetic worlds are inlined into the parent package
+    /// page and don't get their own detail page or sidebar entry.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_synthetic: bool,
 }
 
 /// An item imported or exported by a world.

--- a/crates/wasm-meta-registry-client/src/client.rs
+++ b/crates/wasm-meta-registry-client/src/client.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 
 use crate::KnownPackage;
-use wasm_meta_registry_types::{PackageDetail, PackageVersion, QueueStatus};
+use wasm_meta_registry_types::{NotifyOutcome, PackageDetail, PackageVersion, QueueStatus};
 
 /// Default API base URL when no environment variable is set.
 const DEFAULT_API_BASE_URL: &str = "http://localhost:8081";
@@ -287,6 +287,33 @@ impl RegistryClient {
         })
     }
 
+    /// Notify the registry that a new version of a package was just
+    /// published, requesting it be pulled as soon as possible.
+    ///
+    /// This is a hint, not a guarantee — the registry may dedupe or skip
+    /// the request based on its own freshness/cooldown policy. The returned
+    /// `NotifyOutcome` describes what the server actually did.
+    pub async fn notify_new_version(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+    ) -> Result<NotifyOutcome, ApiError> {
+        let encoded_reg = percent_encode_query_component(registry);
+        let encoded_repo = percent_encode_path_component(repository);
+        let encoded_tag = percent_encode_query_component(tag);
+        let url = format!(
+            "{}/v1/packages/notify/{encoded_reg}/{encoded_repo}?tag={encoded_tag}",
+            self.base_url
+        );
+        let bytes = self.post_empty(&url).await?;
+        serde_json::from_slice(&bytes).map_err(|e| {
+            ApiError::new(format!(
+                "received an unexpected response from the registry: {e}"
+            ))
+        })
+    }
+
     /// Fetch and deserialize a list of packages from the given URL.
     async fn fetch_packages_from(&self, url: &str) -> Result<Vec<KnownPackage>, ApiError> {
         let bytes = self.get(url).await?;
@@ -347,6 +374,36 @@ impl RegistryClient {
         Ok(bytes.to_vec())
     }
 
+    /// Perform an HTTP POST request with an empty body and return the raw
+    /// response body. Accepts both `2xx` responses (including `202 Accepted`).
+    #[cfg(all(target_os = "wasi", target_env = "p2"))]
+    async fn post_empty(&self, url: &str) -> Result<Vec<u8>, ApiError> {
+        use wstd::http::{Body, Request};
+
+        let req = Request::post(url)
+            .body(Body::empty())
+            .map_err(|e| ApiError::new(format!("failed to build request for {url}: {e}")))?;
+
+        let response =
+            self.client.send(req).await.map_err(|e| {
+                ApiError::new(format!("could not connect to the registry API: {e}"))
+            })?;
+
+        let status = response.status();
+        let mut body = response.into_body();
+        let bytes = body
+            .contents()
+            .await
+            .map_err(|e| ApiError::new(format!("failed to read response body: {e}")))?;
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&bytes);
+            return Err(ApiError::new(format!(
+                "registry API returned unexpected status {status} for {url}: {body}"
+            )));
+        }
+        Ok(bytes.to_vec())
+    }
+
     /// Perform an HTTP GET request and return the raw response body.
     #[cfg(not(all(target_os = "wasi", target_env = "p2")))]
     async fn get(&self, url: &str) -> Result<Vec<u8>, ApiError> {
@@ -359,6 +416,30 @@ impl RegistryClient {
             .await
             .map(|b| b.to_vec())
             .map_err(|e| ApiError::new(format!("failed to read response body: {e}")))
+    }
+
+    /// Perform an HTTP POST request with an empty body and return the raw
+    /// response body. Accepts any 2xx status (including `202 Accepted`).
+    #[cfg(not(all(target_os = "wasi", target_env = "p2")))]
+    async fn post_empty(&self, url: &str) -> Result<Vec<u8>, ApiError> {
+        let resp =
+            self.client.post(url).send().await.map_err(|e| {
+                ApiError::new(format!("could not connect to the registry API: {e}"))
+            })?;
+
+        let status = resp.status();
+        let bytes = resp
+            .bytes()
+            .await
+            .map(|b| b.to_vec())
+            .map_err(|e| ApiError::new(format!("failed to read response body: {e}")))?;
+        if !status.is_success() {
+            let body = String::from_utf8_lossy(&bytes);
+            return Err(ApiError::new(format!(
+                "registry API returned unexpected status {status} for {url}: {body}"
+            )));
+        }
+        Ok(bytes)
     }
 
     /// Perform an HTTP GET request, returning `None` for 404 responses.

--- a/crates/wasm-meta-registry-types/src/lib.rs
+++ b/crates/wasm-meta-registry-types/src/lib.rs
@@ -963,3 +963,35 @@ pub struct QueueTask {
     /// ISO 8601 timestamp of the last modification.
     pub updated_at: String,
 }
+
+/// Outcome of a `POST /v1/packages/.../notify` call.
+///
+/// Returned when an external publisher (e.g. a CI pipeline that just pushed
+/// a new image to GHCR) tells the registry that a new version exists. The
+/// registry is free to enqueue, deduplicate, or skip based on its own
+/// freshness/cooldown policy — the caller MUST treat this purely as a hint.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_meta_registry_types::NotifyOutcome;
+///
+/// let outcome = NotifyOutcome::Enqueued;
+/// let json = serde_json::to_string(&outcome).unwrap();
+/// assert_eq!(json, r#"{"status":"enqueued"}"#);
+/// ```
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum NotifyOutcome {
+    /// A pull task was enqueued (or an existing pending task was found).
+    /// The registry will fetch the manifest and layers as soon as the worker
+    /// picks the task up.
+    Enqueued,
+    /// The tag was already pulled recently and is within the freshness
+    /// window, so no new task was created. Try again later if the upstream
+    /// manifest has actually changed.
+    Skipped {
+        /// Human-readable reason, e.g. `"fresh"`.
+        reason: String,
+    },
+}

--- a/crates/wasm-meta-registry-types/src/lib.rs
+++ b/crates/wasm-meta-registry-types/src/lib.rs
@@ -384,6 +384,7 @@ pub struct WitWorldSummary {
 ///     interface: Some("streams".into()),
 ///     version: Some("0.2.2".into()),
 ///     docs: None,
+///     is_native: false,
 /// };
 ///
 /// assert_eq!(iface.package, "wasi:io");
@@ -402,6 +403,11 @@ pub struct WitInterfaceRef {
     /// First sentence of the interface's documentation, if available.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docs: Option<String>,
+    /// True when this interface's package matches the parent component's
+    /// own package. Renderers should treat the interface as native and omit
+    /// any external package prefix or link.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_native: bool,
 }
 
 /// Summary of a compiled Wasm component found in an OCI manifest.
@@ -544,6 +550,7 @@ pub struct ProducerEntry {
 ///     package: "wasi:http".into(),
 ///     world: "proxy".into(),
 ///     version: Some("0.3.0".into()),
+///     is_native: false,
 /// };
 ///
 /// assert_eq!(target.world, "proxy");
@@ -557,6 +564,10 @@ pub struct ComponentTargetRef {
     /// Declared version (e.g. `"0.3.0"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+    /// True when `package` matches the parent component's own package.
+    /// Renderers should treat the world as native to the component.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_native: bool,
 }
 
 /// Well-known OCI manifest annotations promoted to structured fields.
@@ -808,12 +819,14 @@ mod tests {
                     interface: Some("streams".into()),
                     version: Some("0.2.2".into()),
                     docs: None,
+                    is_native: false,
                 }],
                 exports: vec![WitInterfaceRef {
                     package: "wasi:http".into(),
                     interface: Some("handler".into()),
                     version: Some("0.3.0".into()),
                     docs: None,
+                    is_native: false,
                 }],
             }],
             components: vec![ComponentSummary {
@@ -823,6 +836,7 @@ mod tests {
                     package: "wasi:http".into(),
                     world: "proxy".into(),
                     version: Some("0.3.0".into()),
+                    is_native: false,
                 }],
                 producers: vec![],
                 kind: None,

--- a/crates/wasm-meta-registry/src/indexer.rs
+++ b/crates/wasm-meta-registry/src/indexer.rs
@@ -166,31 +166,34 @@ impl Indexer {
     /// hammering upstream registries.
     async fn process_queue(&mut self) {
         let mut processed = 0u64;
-        let mut consecutive_errors = 0u64;
+        // Only counts queue-level errors (network/DB failures from
+        // `process_next_task` itself). Individual task failures (a single
+        // bad pull or reindex) do NOT count — those are isolated and the
+        // queue's own retry/backoff logic already handles them. Counting
+        // them here used to cause a few unrelated bad tasks at the head of
+        // the queue to block every other (working) task behind them.
+        let mut consecutive_queue_errors = 0u64;
         loop {
             match self.manager.process_next_task().await {
                 Ok(TaskOutcome::Succeeded) => {
                     processed += 1;
-                    consecutive_errors = 0;
+                    consecutive_queue_errors = 0;
                     // Brief pause between tasks to be a good citizen to
                     // upstream registries and let the HTTP server breathe.
                     tokio::time::sleep(Duration::from_millis(250)).await;
                 }
                 Ok(TaskOutcome::Failed) => {
                     processed += 1;
-                    consecutive_errors += 1;
-                    if consecutive_errors >= 5 {
-                        error!("Too many consecutive task failures, pausing until next cycle");
-                        break;
-                    }
-                    // Back off before processing the next task after a failure.
+                    // Back off briefly before processing the next task; the
+                    // failure is recorded in the queue with its own attempt
+                    // counter, so we don't need to gate the worker on it.
                     tokio::time::sleep(Duration::from_secs(2)).await;
                 }
                 Ok(TaskOutcome::Empty) => break, // queue is empty
                 Err(e) => {
-                    consecutive_errors += 1;
+                    consecutive_queue_errors += 1;
                     error!(error = %e, "Error processing fetch queue");
-                    if consecutive_errors >= 5 {
+                    if consecutive_queue_errors >= 5 {
                         error!("Too many consecutive queue errors, pausing until next cycle");
                         break;
                     }

--- a/crates/wasm-meta-registry/src/server.rs
+++ b/crates/wasm-meta-registry/src/server.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::{Json, Router, routing::get};
+use axum::{Json, Router, routing::get, routing::post};
 use serde::Deserialize;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -136,6 +136,10 @@ pub fn router(state: AppState) -> Router {
         )
         .route("/v1/packages/{registry}/{*repository}", get(get_package))
         .route("/v1/queue", get(get_queue_status))
+        .route(
+            "/v1/packages/notify/{registry}/{*repository}",
+            post(notify_new_version),
+        )
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(state)
@@ -296,6 +300,36 @@ async fn get_package_version_reordered(
     }
 }
 
+/// Query parameters for `POST /v1/packages/notify/...`.
+#[derive(Debug, Deserialize)]
+pub struct NotifyParams {
+    /// Tag of the newly-published version (e.g. `"1.1.0"`).
+    pub tag: String,
+}
+
+/// Notify the registry that a new version was just published, requesting it
+/// be pulled as soon as possible.
+///
+/// Returns `202 Accepted` with a JSON `NotifyOutcome` body in both the
+/// "enqueued" and "skipped" cases — the request itself was accepted; the
+/// outcome describes what the registry decided to do with it.
+///
+/// To prevent abuse, the registry enforces a freshness window (the same
+/// 1-hour cooldown used by the periodic indexer). Repeated notifications
+/// for a tag that was just pulled are returned as `{"status":"skipped"}`.
+async fn notify_new_version(
+    State(manager): State<AppState>,
+    Path((registry, repository)): Path<(String, String)>,
+    Query(params): Query<NotifyParams>,
+) -> Result<impl IntoResponse, AppError> {
+    let repository = repository.trim_start_matches('/');
+    let manager = manager
+        .lock()
+        .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
+    let outcome = manager.notify_new_version(&registry, repository, &params.tag)?;
+    Ok((StatusCode::ACCEPTED, Json(outcome)))
+}
+
 /// Application error type that converts to HTTP responses.
 struct AppError(anyhow::Error);
 
@@ -348,6 +382,41 @@ mod tests {
         assert_eq!(body, serde_json::json!({ "status": "ok" }));
 
         // Clean up.
+        server.abort();
+    }
+
+    /// Verify the notify endpoint enqueues a pull task and is idempotent.
+    /// A second notify for the same tag while the task is still pending
+    /// should also return `enqueued` (the queue dedupes internally).
+    #[tokio::test]
+    async fn notify_endpoint_enqueues_pull_task() {
+        use wasm_meta_registry_types::NotifyOutcome;
+
+        let manager = Manager::open().await.expect("failed to open manager");
+        let state = Arc::new(std::sync::Mutex::new(manager));
+        let app = router(state);
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind listener");
+        let addr = listener.local_addr().expect("failed to get local addr");
+
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("server error");
+        });
+
+        let url = format!(
+            "http://{addr}/v1/packages/notify/ghcr.io/yoshuawuyts%2Fcomponents%2Fwordmark?tag=1.1.0"
+        );
+        let resp = reqwest::Client::new()
+            .post(&url)
+            .send()
+            .await
+            .expect("request failed");
+        assert_eq!(resp.status(), reqwest::StatusCode::ACCEPTED);
+        let outcome: NotifyOutcome = resp.json().await.expect("invalid json");
+        assert_eq!(outcome, NotifyOutcome::Enqueued);
+
         server.abort();
     }
 }

--- a/crates/wasm-meta-registry/src/server.rs
+++ b/crates/wasm-meta-registry/src/server.rs
@@ -314,20 +314,50 @@ pub struct NotifyParams {
 /// "enqueued" and "skipped" cases — the request itself was accepted; the
 /// outcome describes what the registry decided to do with it.
 ///
-/// To prevent abuse, the registry enforces a freshness window (the same
-/// 1-hour cooldown used by the periodic indexer). Repeated notifications
-/// for a tag that was just pulled are returned as `{"status":"skipped"}`.
+/// To prevent abuse, the endpoint:
+///
+/// * Rejects empty tags with `400 Bad Request`.
+/// * Only accepts notifications for packages already known to this
+///   registry (i.e. previously indexed). Notifications for unknown
+///   packages return `404 Not Found` so the queue can't be flooded with
+///   arbitrary `(registry, repository, tag)` triples.
+/// * Enforces a freshness window (the same 1-hour cooldown used by the
+///   periodic indexer). Repeated notifications for a tag that was just
+///   pulled are returned as `{"status":"skipped"}`.
 async fn notify_new_version(
     State(manager): State<AppState>,
     Path((registry, repository)): Path<(String, String)>,
     Query(params): Query<NotifyParams>,
-) -> Result<impl IntoResponse, AppError> {
+) -> Result<axum::response::Response, AppError> {
     let repository = repository.trim_start_matches('/');
+    let tag = params.tag.trim();
+    if tag.is_empty() {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "tag must not be empty" })),
+        )
+            .into_response());
+    }
+
     let manager = manager
         .lock()
         .map_err(|e| anyhow::anyhow!("lock poisoned: {e}"))?;
-    let outcome = manager.notify_new_version(&registry, repository, &params.tag)?;
-    Ok((StatusCode::ACCEPTED, Json(outcome)))
+
+    // Only allow notifications for packages we already know about. This
+    // prevents arbitrary clients from filling the fetch queue with
+    // unknown `(registry, repository, tag)` triples.
+    if manager.get_known_package(&registry, repository)?.is_none() {
+        return Ok((
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "unknown package; only previously-indexed packages may be notified"
+            })),
+        )
+            .into_response());
+    }
+
+    let outcome = manager.notify_new_version(&registry, repository, tag)?;
+    Ok((StatusCode::ACCEPTED, Json(outcome)).into_response())
 }
 
 /// Application error type that converts to HTTP responses.
@@ -393,6 +423,20 @@ mod tests {
         use wasm_meta_registry_types::NotifyOutcome;
 
         let manager = Manager::open().await.expect("failed to open manager");
+
+        // Register the target as a known package up-front: the notify
+        // endpoint rejects unknown packages with `404` to prevent
+        // arbitrary clients from flooding the fetch queue.
+        let registry = "example.test";
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let repository = format!("notify-test-{unique}");
+        manager
+            .add_known_package(registry, &repository, None, None)
+            .expect("failed to register known package");
+
         let state = Arc::new(std::sync::Mutex::new(manager));
         let app = router(state);
 
@@ -405,20 +449,24 @@ mod tests {
             axum::serve(listener, app).await.expect("server error");
         });
 
-        // Use a time-suffixed repo to ensure no prior pull data exists in
-        // the user's real DB (which `Manager::open()` opens).
-        let unique = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let url = format!(
-            "http://{addr}/v1/packages/notify/example.test/notify-test-{unique}?tag=0.0.1-test"
-        );
-        let resp = reqwest::Client::new()
+        let url =
+            format!("http://{addr}/v1/packages/notify/{registry}/{repository}?tag=0.0.1-test");
+        let client = reqwest::Client::new();
+        let resp = client.post(&url).send().await.expect("request failed");
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let outcome: NotifyOutcome = resp.json().await.expect("invalid json");
+        assert_eq!(outcome, NotifyOutcome::Enqueued);
+
+        // A second notify for the same tag while the task is still
+        // pending must also return `enqueued` — the underlying queue
+        // dedupes by `(registry, repository, tag)` so the request is
+        // accepted and reported as enqueued without creating a duplicate
+        // row.
+        let resp = client
             .post(&url)
             .send()
             .await
-            .expect("request failed");
+            .expect("second request failed");
         assert_eq!(resp.status(), StatusCode::ACCEPTED);
         let outcome: NotifyOutcome = resp.json().await.expect("invalid json");
         assert_eq!(outcome, NotifyOutcome::Enqueued);

--- a/crates/wasm-meta-registry/src/server.rs
+++ b/crates/wasm-meta-registry/src/server.rs
@@ -405,15 +405,21 @@ mod tests {
             axum::serve(listener, app).await.expect("server error");
         });
 
+        // Use a time-suffixed repo to ensure no prior pull data exists in
+        // the user's real DB (which `Manager::open()` opens).
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
         let url = format!(
-            "http://{addr}/v1/packages/notify/ghcr.io/yoshuawuyts%2Fcomponents%2Fwordmark?tag=1.1.0"
+            "http://{addr}/v1/packages/notify/example.test/notify-test-{unique}?tag=0.0.1-test"
         );
         let resp = reqwest::Client::new()
             .post(&url)
             .send()
             .await
             .expect("request failed");
-        assert_eq!(resp.status(), reqwest::StatusCode::ACCEPTED);
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
         let outcome: NotifyOutcome = resp.json().await.expect("invalid json");
         assert_eq!(outcome, NotifyOutcome::Enqueued);
 

--- a/crates/wasm-package-manager/src/components/models.rs
+++ b/crates/wasm-package-manager/src/components/models.rs
@@ -144,6 +144,10 @@ pub struct ComponentTarget {
     pub declared_version: Option<String>,
     /// Resolved foreign key to `wit_world`, if matched.
     pub wit_world_id: Option<i64>,
+    /// True when `declared_package` matches the parent OCI repository's WIT
+    /// package (`wit_namespace:wit_name`). Indicates the targeted world is
+    /// native to this component's own package.
+    pub is_native_package: bool,
 }
 
 impl ComponentTarget {
@@ -162,12 +166,13 @@ impl ComponentTarget {
         declared_world: &str,
         declared_version: Option<&str>,
         wit_world_id: Option<i64>,
+        is_native_package: bool,
     ) -> anyhow::Result<i64> {
         conn.execute(
             "INSERT INTO component_target
                  (wasm_component_id, declared_package, declared_world,
-                  declared_version, wit_world_id)
-             VALUES (?1, ?2, ?3, ?4, ?5)
+                  declared_version, wit_world_id, is_native_package)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)
              ON CONFLICT DO NOTHING",
             rusqlite::params![
                 wasm_component_id,
@@ -175,6 +180,7 @@ impl ComponentTarget {
                 declared_world,
                 declared_version,
                 wit_world_id,
+                is_native_package,
             ],
         )?;
 
@@ -204,7 +210,7 @@ impl ComponentTarget {
     ) -> anyhow::Result<Vec<Self>> {
         let mut stmt = conn.prepare(
             "SELECT id, wasm_component_id, declared_package, declared_world,
-                    declared_version, wit_world_id
+                    declared_version, wit_world_id, is_native_package
              FROM component_target
              WHERE wasm_component_id = ?1
              ORDER BY declared_package ASC, declared_world ASC",
@@ -218,6 +224,7 @@ impl ComponentTarget {
                 declared_world: row.get(3)?,
                 declared_version: row.get(4)?,
                 wit_world_id: row.get(5)?,
+                is_native_package: row.get(6)?,
             })
         })?;
 
@@ -343,12 +350,19 @@ mod tests {
         let mid = insert_test_manifest(&conn);
         let comp_id = WasmComponent::insert(&conn, mid, None, Some("comp"), None, None).unwrap();
 
-        let tid =
-            ComponentTarget::insert(&conn, comp_id, "wasi:http", "proxy", Some("0.2.0"), None)
-                .unwrap();
+        let tid = ComponentTarget::insert(
+            &conn,
+            comp_id,
+            "wasi:http",
+            "proxy",
+            Some("0.2.0"),
+            None,
+            false,
+        )
+        .unwrap();
         assert!(tid > 0);
 
-        ComponentTarget::insert(&conn, comp_id, "wasi:cli", "command", None, None).unwrap();
+        ComponentTarget::insert(&conn, comp_id, "wasi:cli", "command", None, None, false).unwrap();
 
         let targets = ComponentTarget::list_by_component(&conn, comp_id).unwrap();
         assert_eq!(targets.len(), 2);
@@ -366,12 +380,26 @@ mod tests {
         let mid = insert_test_manifest(&conn);
         let comp_id = WasmComponent::insert(&conn, mid, None, Some("comp"), None, None).unwrap();
 
-        let id1 =
-            ComponentTarget::insert(&conn, comp_id, "wasi:http", "proxy", Some("0.2.0"), None)
-                .unwrap();
-        let id2 =
-            ComponentTarget::insert(&conn, comp_id, "wasi:http", "proxy", Some("0.2.0"), None)
-                .unwrap();
+        let id1 = ComponentTarget::insert(
+            &conn,
+            comp_id,
+            "wasi:http",
+            "proxy",
+            Some("0.2.0"),
+            None,
+            false,
+        )
+        .unwrap();
+        let id2 = ComponentTarget::insert(
+            &conn,
+            comp_id,
+            "wasi:http",
+            "proxy",
+            Some("0.2.0"),
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(id1, id2);
     }
 

--- a/crates/wasm-package-manager/src/manager/mod.rs
+++ b/crates/wasm-package-manager/src/manager/mod.rs
@@ -866,6 +866,44 @@ impl Manager {
         self.store.get_queue_status()
     }
 
+    /// Notify the registry that a specific version of a package was just
+    /// published, requesting it be pulled as soon as possible.
+    ///
+    /// This is the entry point for external publishers (e.g. CI pipelines)
+    /// that have just pushed a new image and want the registry to index it
+    /// without waiting for the next periodic sync cycle.
+    ///
+    /// To prevent abuse and avoid hammering upstream registries, the request
+    /// is rejected when the tag was already pulled within
+    /// `PULL_COOLDOWN_SECS` (the same freshness window used by the periodic
+    /// sync). The caller MUST treat this as a hint, not a guarantee.
+    ///
+    /// Enqueued tasks are given high priority (priority `-1`) so they jump
+    /// ahead of the routine sync backlog.
+    pub fn notify_new_version(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+    ) -> anyhow::Result<wasm_meta_registry_types::NotifyOutcome> {
+        use wasm_meta_registry_types::NotifyOutcome;
+
+        if self
+            .store
+            .is_tag_fresh(registry, repository, tag, PULL_COOLDOWN_SECS)
+        {
+            return Ok(NotifyOutcome::Skipped {
+                reason: "fresh".to_string(),
+            });
+        }
+
+        // High priority so external notifications jump ahead of the routine
+        // sync backlog. Idempotent: a duplicate notify while a task is
+        // already pending is a no-op.
+        self.store.enqueue_pull(registry, repository, tag, -1)?;
+        Ok(NotifyOutcome::Enqueued)
+    }
+
     /// Fetches the manifest and config to extract metadata (description from
     /// OCI annotations), lists all tags, and upserts into the known packages
     /// table. Also pulls the wasm layer for the most recent tag to extract

--- a/crates/wasm-package-manager/src/manager/mod.rs
+++ b/crates/wasm-package-manager/src/manager/mod.rs
@@ -898,9 +898,11 @@ impl Manager {
         }
 
         // High priority so external notifications jump ahead of the routine
-        // sync backlog. Idempotent: a duplicate notify while a task is
-        // already pending is a no-op.
-        self.store.enqueue_pull(registry, repository, tag, -1)?;
+        // sync backlog. Use `enqueue_refetch` rather than `enqueue_pull` so a
+        // previous "completed" or "failed" queue entry for this tag is reset
+        // to "pending" instead of silently no-oping (which would happen with
+        // `enqueue_pull`'s `ON CONFLICT DO NOTHING`).
+        self.store.enqueue_refetch(registry, repository, tag, -1)?;
         Ok(NotifyOutcome::Enqueued)
     }
 

--- a/crates/wasm-package-manager/src/storage/migrations/07_component_target_native_package.sql
+++ b/crates/wasm-package-manager/src/storage/migrations/07_component_target_native_package.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "component_target" ADD COLUMN "is_native_package" integer NOT NULL DEFAULT 0;
+
+-- Backfill: set is_native_package = 1 where the declared package matches
+-- the parent OCI repository's WIT package (wit_namespace:wit_name).
+UPDATE component_target
+SET is_native_package = 1
+WHERE id IN (
+    SELECT ct.id
+    FROM component_target ct
+    JOIN wasm_component wc ON wc.id = ct.wasm_component_id
+    JOIN oci_manifest om ON om.id = wc.oci_manifest_id
+    JOIN oci_repository orep ON orep.id = om.oci_repository_id
+    WHERE orep.wit_namespace IS NOT NULL
+      AND orep.wit_name IS NOT NULL
+      AND ct.declared_package = (orep.wit_namespace || ':' || orep.wit_name)
+);

--- a/crates/wasm-package-manager/src/storage/models/migration.rs
+++ b/crates/wasm-package-manager/src/storage/models/migration.rs
@@ -40,6 +40,11 @@ const MIGRATIONS: &[MigrationDef] = &[
         name: "create_fetch_queue",
         sql: include_str!("../migrations/06_create_fetch_queue.sql"),
     },
+    MigrationDef {
+        version: 7,
+        name: "component_target_native_package",
+        sql: include_str!("../migrations/07_component_target_native_package.sql"),
+    },
 ];
 
 /// Information about the current migration state.

--- a/crates/wasm-package-manager/src/storage/models/raw_known_package.rs
+++ b/crates/wasm-package-manager/src/storage/models/raw_known_package.rs
@@ -138,34 +138,15 @@ impl RawKnownPackage {
             tracing::warn!("Failed to update description for repo {repo_id}: {e}");
         }
 
-        // If a tag was provided and a manifest exists that it could reference,
-        // upsert the tag.  During index/sync there may be no manifest yet, so
-        // this is best-effort.
-        if let Some(tag) = params.tag {
-            // Try to find the most recent manifest for this repo.
-            let digest: Option<String> = conn
-                .query_row(
-                    "SELECT digest FROM oci_manifest
-                     WHERE oci_repository_id = ?1
-                     ORDER BY created_at DESC LIMIT 1",
-                    [repo_id],
-                    |row| row.get(0),
-                )
-                .ok();
-
-            if let Some(digest) = digest
-                && let Err(e) = conn.execute(
-                    "INSERT INTO oci_tag (oci_repository_id, tag, manifest_digest)
-                     VALUES (?1, ?2, ?3)
-                     ON CONFLICT(oci_repository_id, tag) DO UPDATE SET
-                         manifest_digest = ?3,
-                         updated_at = CURRENT_TIMESTAMP",
-                    rusqlite::params![repo_id, tag, digest],
-                )
-            {
-                tracing::warn!("Failed to upsert tag '{tag}' for repo {repo_id}: {e}");
-            }
-        }
+        // Note: a `tag` may be passed in by the sync/discovery path, but we
+        // intentionally do NOT write it to `oci_tag` here. Tag→digest
+        // mappings are authoritative only when produced by an actual pull
+        // (`Store::insert` → `OciTag::upsert`), where we know the real
+        // manifest digest. Inventing a placeholder mapping (e.g. by guessing
+        // "the most recent manifest in this repo") historically caused
+        // different versions to appear to share the same content. The tag is
+        // still discoverable via the indexer's pull queue.
+        let _ = params.tag;
 
         Ok(())
     }
@@ -1052,5 +1033,80 @@ mod tests {
         let packages = RawKnownPackage::get_all(&conn, 0, 100).unwrap();
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].kind, None);
+    }
+
+    /// Regression test: `upsert` must not clobber an existing tag→digest
+    /// mapping with whichever manifest happens to be most recently inserted.
+    ///
+    /// The bug: when sync calls `add_known_package(tag, None)` after pulling
+    /// a new version, `upsert_with_params` looked up "the most recent
+    /// manifest in this repo" and overwrote *every* tag's `manifest_digest`
+    /// with that placeholder. This caused older version tags (e.g. `1.0.0`)
+    /// to silently re-point at the latest pulled manifest, so older versions
+    /// would render the latest version's WIT/docs.
+    ///
+    /// After the fix, `upsert` is a no-op when an `oci_tag` row already
+    /// exists for the given `(repository, tag)` pair.
+    #[test]
+    fn test_known_package_upsert_does_not_clobber_existing_tag_digest() {
+        use crate::oci::{OciManifest, OciRepository as OciRepo, OciTag};
+        use std::collections::HashMap;
+
+        let conn = setup_test_db();
+        let repo_id = OciRepo::upsert(&conn, "ghcr.io", "example/wordmark").unwrap();
+
+        // Two distinct manifests representing two real published versions.
+        let v1_digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+        let v2_digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+        for digest in [v1_digest, v2_digest] {
+            OciManifest::upsert(
+                &conn,
+                repo_id,
+                digest,
+                Some("application/vnd.oci.image.manifest.v1+json"),
+                Some("{}"),
+                Some(1024),
+                None,
+                None,
+                None,
+                &HashMap::new(),
+            )
+            .unwrap();
+        }
+
+        // Authoritative mappings — the digests each tag actually points to,
+        // as set by the real pull path (`Store::insert` → `OciTag::upsert`).
+        OciTag::upsert(&conn, repo_id, "1.0.0", v1_digest).unwrap();
+        OciTag::upsert(&conn, repo_id, "1.1.0", v2_digest).unwrap();
+
+        // Sync re-discovers the same tags and registers them without a
+        // digest. This must not corrupt the existing mappings.
+        RawKnownPackage::upsert(&conn, "ghcr.io", "example/wordmark", Some("1.0.0"), None).unwrap();
+        RawKnownPackage::upsert(&conn, "ghcr.io", "example/wordmark", Some("1.1.0"), None).unwrap();
+
+        let v1_after = OciTag::find_by_tag(&conn, repo_id, "1.0.0")
+            .unwrap()
+            .expect("1.0.0 tag should still exist");
+        let v2_after = OciTag::find_by_tag(&conn, repo_id, "1.1.0")
+            .unwrap()
+            .expect("1.1.0 tag should still exist");
+        assert_eq!(
+            v1_after.manifest_digest, v1_digest,
+            "1.0.0 tag must continue to point at its original manifest"
+        );
+        assert_eq!(
+            v2_after.manifest_digest, v2_digest,
+            "1.1.0 tag must continue to point at its original manifest"
+        );
+
+        // Sync of a never-pulled tag must NOT invent an `oci_tag` row —
+        // tag→digest mappings are owned exclusively by the real pull path.
+        RawKnownPackage::upsert(&conn, "ghcr.io", "example/wordmark", Some("1.2.0"), None).unwrap();
+        assert!(
+            OciTag::find_by_tag(&conn, repo_id, "1.2.0")
+                .unwrap()
+                .is_none(),
+            "sync must not create speculative oci_tag rows"
+        );
     }
 }

--- a/crates/wasm-package-manager/src/storage/schema.sql
+++ b/crates/wasm-package-manager/src/storage/schema.sql
@@ -603,6 +603,11 @@ CREATE TABLE component_target (
     -- NULL if resolution has not been performed or if the world
     -- exists in multiple OCI sources and the choice is ambiguous.
     wit_world_id INTEGER,
+    -- True when declared_package matches the parent OCI repository's
+    -- WIT package (wit_namespace:wit_name).  Indicates the targeted
+    -- world is "native" to this component's own package, so consumers
+    -- should render it inline rather than as an external reference.
+    is_native_package INTEGER NOT NULL DEFAULT 0,
     FOREIGN KEY (wasm_component_id) REFERENCES wasm_component(id)
         ON UPDATE NO ACTION ON DELETE CASCADE,
     FOREIGN KEY (wit_world_id) REFERENCES wit_world(id)

--- a/crates/wasm-package-manager/src/storage/store.rs
+++ b/crates/wasm-package-manager/src/storage/store.rs
@@ -19,6 +19,27 @@ use crate::types::{
 use futures_concurrency::prelude::*;
 use oci_client::{Reference, client::ImageData, manifest::OciImageManifest};
 
+/// Outcome of [`Store::try_extract_wit_package`].
+///
+/// Distinguishes between bytes that simply don't carry a WIT package
+/// (`NotApplicable` — e.g. a signed image, a plain wasm module, or a
+/// component without a package name) and an actual database-layer
+/// failure during extraction (`Failed`). Callers wrapping the call in a
+/// transaction or savepoint can commit on `NotApplicable` / `Extracted`
+/// and roll back / surface an error on `Failed`.
+#[derive(Debug)]
+enum WitExtractOutcome {
+    /// The bytes don't represent something we should index — leave the
+    /// row in its current (possibly empty) state and commit.
+    NotApplicable,
+    /// A WIT package was successfully extracted and inserted.
+    Extracted,
+    /// Extraction was attempted but a database insert failed mid-way.
+    /// Callers should roll back any preceding mutations and surface the
+    /// error rather than silently committing a partially-cleared state.
+    Failed(anyhow::Error),
+}
+
 /// The kind of work a [`FetchTask`] represents.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FetchTaskKind {
@@ -440,21 +461,26 @@ impl Store {
         Ok(())
     }
 
-    /// Attempt to extract WIT package from wasm component bytes.
-    /// This is best-effort - if extraction fails, we log a warning and skip.
+    /// Outcome of attempting to extract a WIT package from wasm bytes.
+    ///
+    /// Distinguishes between "the bytes don't represent something we should
+    /// have extracted" (`NotApplicable`) and "we tried to extract but failed
+    /// at the database layer" (`Failed`). Callers that wrap the call in a
+    /// transaction/savepoint can commit on `NotApplicable`/`Extracted` and
+    /// roll back on `Failed`.
     fn try_extract_wit_package(
         &self,
         manifest_id: i64,
         layer_id: Option<i64>,
         wasm_bytes: &[u8],
-    ) -> bool {
+    ) -> WitExtractOutcome {
         let Some(metadata) = extract_wit_metadata(wasm_bytes) else {
-            return false; // Not a valid wasm component, skip
+            return WitExtractOutcome::NotApplicable; // Not a valid wasm component, skip
         };
 
         // Insert the WIT package (best-effort; skip if no package name)
         let Some(raw_name) = metadata.package_name.as_deref() else {
-            return false;
+            return WitExtractOutcome::NotApplicable;
         };
 
         // Split "namespace:name@version" into (package_name, version).
@@ -476,7 +502,9 @@ impl Store {
                     manifest_id,
                     e
                 );
-                return false;
+                return WitExtractOutcome::Failed(anyhow::anyhow!(
+                    "failed to insert wit_package for manifest {manifest_id}: {e}"
+                ));
             }
         };
 
@@ -549,15 +577,18 @@ impl Store {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::warn!("Failed to insert WasmComponent: {}", e);
-                    return false;
+                    return WitExtractOutcome::Failed(anyhow::anyhow!(
+                        "failed to insert wasm_component for manifest {manifest_id}: {e}"
+                    ));
                 }
             };
+
+            let parent_package = parent_pkg_for_manifest(&self.conn, manifest_id);
 
             for world in &metadata.worlds {
                 let wit_world_id = world_ids.get(&world.name).copied();
                 let declared_package = package_name;
-                let is_native = parent_pkg_for_manifest(&self.conn, manifest_id).as_deref()
-                    == Some(declared_package);
+                let is_native = parent_package.as_deref() == Some(declared_package);
 
                 if let Err(e) = ComponentTarget::insert(
                     &self.conn,
@@ -575,7 +606,7 @@ impl Store {
 
         // Best-effort resolution of cross-package foreign keys
         self.try_resolve_foreign_keys(wit_package_id, manifest_id);
-        true
+        WitExtractOutcome::Extracted
     }
 
     /// Best-effort resolution of cross-package foreign keys.
@@ -714,7 +745,12 @@ impl Store {
                         );
                         false
                     },
-                    |_| self.try_extract_wit_package(*manifest_id, Some(*layer_id), &bytes),
+                    |_| {
+                        matches!(
+                            self.try_extract_wit_package(*manifest_id, Some(*layer_id), &bytes),
+                            WitExtractOutcome::Extracted
+                        )
+                    },
                 );
 
             let savepoint_sql = if replaced {
@@ -1324,12 +1360,19 @@ impl Store {
         let bytes = cacache::read(&store_dir, &digest).await?;
 
         // Delete old WIT data, then re-extract from the cached layer bytes.
-        // A `false` return from `try_extract_wit_package` means the layer
-        // isn't a wasm component or carries no WIT package — that's a
-        // legitimate outcome (e.g. signed images, plain wasm modules), not
-        // a failure. The DELETEs still apply (the row is correctly empty)
-        // and we commit; reporting an error here would burn retry attempts
-        // and (depending on queue policy) block other tasks behind it.
+        // The DELETEs above clear any stale rows for this manifest; the
+        // re-extraction can have three outcomes:
+        //
+        // * `NotApplicable`: the layer isn't a wasm component or carries
+        //   no WIT package (e.g. signed images, plain wasm modules).
+        //   That's a legitimate outcome — the row is correctly empty,
+        //   so we commit. Reporting an error here would burn retry
+        //   attempts and (depending on queue policy) block other tasks.
+        // * `Extracted`: re-extraction succeeded. Commit.
+        // * `Failed`: a database insert errored mid-way. Roll back so
+        //   we don't silently clear previously-indexed WIT data, and
+        //   propagate the error so the caller can decide whether to
+        //   retry.
         self.conn.execute_batch("SAVEPOINT reindex_tag")?;
 
         let sql_ok = self
@@ -1353,10 +1396,20 @@ impl Store {
             anyhow::bail!("failed to clear stale WIT data for {registry}/{repository}:{tag}");
         }
 
-        // Best-effort re-extract; logged via tracing inside the helper.
-        let _ = self.try_extract_wit_package(manifest_id, Some(layer_id), &bytes);
-        self.conn.execute_batch("RELEASE SAVEPOINT reindex_tag")?;
-        Ok(())
+        match self.try_extract_wit_package(manifest_id, Some(layer_id), &bytes) {
+            WitExtractOutcome::Extracted | WitExtractOutcome::NotApplicable => {
+                self.conn.execute_batch("RELEASE SAVEPOINT reindex_tag")?;
+                Ok(())
+            }
+            WitExtractOutcome::Failed(e) => {
+                self.conn.execute_batch(
+                    "ROLLBACK TO SAVEPOINT reindex_tag; RELEASE SAVEPOINT reindex_tag",
+                )?;
+                Err(e.context(format!(
+                    "failed to re-extract WIT data for {registry}/{repository}:{tag}"
+                )))
+            }
+        }
     }
 
     /// Get all WIT packages.

--- a/crates/wasm-package-manager/src/storage/store.rs
+++ b/crates/wasm-package-manager/src/storage/store.rs
@@ -1015,6 +1015,12 @@ impl Store {
 
     /// Enqueue reindex tasks for all tags that have cached layers.
     ///
+    /// Skips tags that don't carry meaningful WIT metadata and would
+    /// always fail re-extraction:
+    /// - `latest` (mutable pointer)
+    /// - signature/attestation tags (`sha256-…`)
+    /// - bare 40-char hex tags (commit SHAs from CI builds)
+    ///
     /// Returns the number of tasks enqueued.
     pub(crate) fn enqueue_reindex_all(&self) -> anyhow::Result<u64> {
         let count = self.conn.execute(
@@ -1025,6 +1031,11 @@ impl Store {
                JOIN oci_manifest m ON m.oci_repository_id = r.id
                                   AND m.digest = t.manifest_digest
                JOIN oci_layer l ON l.oci_manifest_id = m.id
+              WHERE t.tag != 'latest'
+                AND t.tag NOT LIKE 'sha256-%'
+                AND NOT (length(t.tag) = 40
+                         AND t.tag GLOB '[0-9a-f]*'
+                         AND t.tag NOT GLOB '*[^0-9a-f]*')
               GROUP BY r.registry, r.repository, t.tag
              ON CONFLICT(registry, repository, tag, task) DO NOTHING",
             [],
@@ -1051,6 +1062,9 @@ impl Store {
                JOIN oci_layer l ON l.oci_manifest_id = m.id
               WHERE t.tag != 'latest'
                 AND t.tag NOT LIKE 'sha256-%'
+                AND NOT (length(t.tag) = 40
+                         AND t.tag GLOB '[0-9a-f]*'
+                         AND t.tag NOT GLOB '*[^0-9a-f]*')
               GROUP BY r.registry, r.repository, t.tag
              ON CONFLICT(registry, repository, tag, task) DO NOTHING",
             [],
@@ -1309,10 +1323,16 @@ impl Store {
         let store_dir = self.state_info.store_dir().to_path_buf();
         let bytes = cacache::read(&store_dir, &digest).await?;
 
-        // Delete old data and re-extract.
+        // Delete old WIT data, then re-extract from the cached layer bytes.
+        // A `false` return from `try_extract_wit_package` means the layer
+        // isn't a wasm component or carries no WIT package — that's a
+        // legitimate outcome (e.g. signed images, plain wasm modules), not
+        // a failure. The DELETEs still apply (the row is correctly empty)
+        // and we commit; reporting an error here would burn retry attempts
+        // and (depending on queue policy) block other tasks behind it.
         self.conn.execute_batch("SAVEPOINT reindex_tag")?;
 
-        let ok = self
+        let sql_ok = self
             .conn
             .execute(
                 "DELETE FROM wit_package WHERE oci_manifest_id = ?1",
@@ -1324,16 +1344,20 @@ impl Store {
                     [manifest_id],
                 )
             })
-            .is_ok_and(|_| self.try_extract_wit_package(manifest_id, Some(layer_id), &bytes));
+            .is_ok();
 
-        if ok {
-            self.conn.execute_batch("RELEASE SAVEPOINT reindex_tag")?;
-        } else {
+        if !sql_ok {
             self.conn.execute_batch(
                 "ROLLBACK TO SAVEPOINT reindex_tag; RELEASE SAVEPOINT reindex_tag",
             )?;
-            anyhow::bail!("failed to re-extract WIT for {registry}/{repository}:{tag}");
+            anyhow::bail!(
+                "failed to clear stale WIT data for {registry}/{repository}:{tag}"
+            );
         }
+
+        // Best-effort re-extract; logged via tracing inside the helper.
+        let _ = self.try_extract_wit_package(manifest_id, Some(layer_id), &bytes);
+        self.conn.execute_batch("RELEASE SAVEPOINT reindex_tag")?;
         Ok(())
     }
 

--- a/crates/wasm-package-manager/src/storage/store.rs
+++ b/crates/wasm-package-manager/src/storage/store.rs
@@ -555,14 +555,18 @@ impl Store {
 
             for world in &metadata.worlds {
                 let wit_world_id = world_ids.get(&world.name).copied();
+                let declared_package = package_name;
+                let is_native = parent_pkg_for_manifest(&self.conn, manifest_id).as_deref()
+                    == Some(declared_package);
 
                 if let Err(e) = ComponentTarget::insert(
                     &self.conn,
                     component_id,
-                    package_name,
+                    declared_package,
                     &world.name,
                     version,
                     wit_world_id,
+                    is_native,
                 ) {
                     tracing::warn!("Failed to insert ComponentTarget: {}", e);
                 }
@@ -1923,6 +1927,8 @@ impl Store {
             })?
             .collect::<Result<Vec<_>, _>>()?;
 
+        let parent_pkg = parent_pkg_for_manifest(&self.conn, manifest_id);
+
         let mut result = Vec::new();
         for (comp_id, name, description, metadata_json) in components {
             let targets = ComponentTarget::list_by_component(&self.conn, comp_id)?;
@@ -1932,6 +1938,7 @@ impl Store {
                     package: t.declared_package,
                     world: t.declared_world,
                     version: t.declared_version,
+                    is_native: t.is_native_package,
                 })
                 .collect();
 
@@ -1968,6 +1975,13 @@ impl Store {
             // Enrich imports/exports with docs from stored WIT packages.
             self.enrich_iface_docs(&mut summary.imports);
             self.enrich_iface_docs(&mut summary.exports);
+
+            // Mark interfaces as native when their package matches the
+            // parent OCI repository's WIT package. Recurses into children
+            // so nested components are flagged consistently.
+            if let Some(pkg) = parent_pkg.as_deref() {
+                mark_native_iface_refs(&mut summary, pkg);
+            }
 
             result.push(summary);
         }
@@ -2237,6 +2251,7 @@ impl Store {
                 interface: row.get(1)?,
                 version: row.get(2)?,
                 docs: None,
+                is_native: false,
             })
         })?;
 
@@ -2265,6 +2280,7 @@ impl Store {
                 interface: row.get(1)?,
                 version: row.get(2)?,
                 docs: None,
+                is_native: false,
             })
         })?;
 
@@ -2385,6 +2401,42 @@ fn resolve_dependency_foreign_keys(
         [wit_package_id],
     )?;
     Ok(updated)
+}
+
+/// Lookup the WIT package (`wit_namespace:wit_name`) of the OCI repository
+/// owning the given manifest, if both namespace and name are recorded.
+fn parent_pkg_for_manifest(conn: &Connection, manifest_id: i64) -> Option<String> {
+    conn.query_row(
+        "SELECT orep.wit_namespace, orep.wit_name
+         FROM oci_manifest om
+         JOIN oci_repository orep ON orep.id = om.oci_repository_id
+         WHERE om.id = ?1",
+        [manifest_id],
+        |row| {
+            let ns: Option<String> = row.get(0)?;
+            let name: Option<String> = row.get(1)?;
+            Ok(ns.zip(name).map(|(ns, n)| format!("{ns}:{n}")))
+        },
+    )
+    .ok()
+    .flatten()
+}
+
+/// Mark every `WitInterfaceRef` in the component's imports/exports (and
+/// recursively in children) as `is_native` when its package equals the
+/// parent component's own package (`wit_namespace:wit_name`).
+fn mark_native_iface_refs(
+    summary: &mut wasm_meta_registry_types::ComponentSummary,
+    parent_pkg: &str,
+) {
+    for iface in summary.imports.iter_mut().chain(summary.exports.iter_mut()) {
+        if iface.package == parent_pkg {
+            iface.is_native = true;
+        }
+    }
+    for child in &mut summary.children {
+        mark_native_iface_refs(child, parent_pkg);
+    }
 }
 
 /// Resolve `component_target.wit_world_id` for targets of components under
@@ -2661,6 +2713,7 @@ fn parse_component_extern_name(name: &str) -> wasm_meta_registry_types::WitInter
             interface: None,
             version: None,
             docs: None,
+            is_native: false,
         };
     }
 
@@ -2679,6 +2732,7 @@ fn parse_component_extern_name(name: &str) -> wasm_meta_registry_types::WitInter
         interface,
         version,
         docs: None,
+        is_native: false,
     }
 }
 
@@ -2693,6 +2747,7 @@ fn world_key_to_iface_ref(
             interface: None,
             version: None,
             docs: None,
+            is_native: false,
         }),
         wit_parser::WorldKey::Interface(id) => {
             let iface = resolve.interfaces.get(*id)?;
@@ -2704,6 +2759,7 @@ fn world_key_to_iface_ref(
                 interface: iface.name.clone(),
                 version: pkg.name.version.as_ref().map(ToString::to_string),
                 docs,
+                is_native: false,
             })
         }
     }
@@ -2895,6 +2951,7 @@ mod tests {
             "proxy",
             Some("0.2.0"),
             Some(world_id),
+            false,
         )
         .unwrap();
         assert!(target_id > 0);
@@ -3229,6 +3286,7 @@ mod tests {
             "proxy",
             Some("0.2.0"),
             None, // wit_world_id is NULL — needs resolution
+            false,
         )
         .unwrap();
 

--- a/crates/wasm-package-manager/src/storage/store.rs
+++ b/crates/wasm-package-manager/src/storage/store.rs
@@ -1350,9 +1350,7 @@ impl Store {
             self.conn.execute_batch(
                 "ROLLBACK TO SAVEPOINT reindex_tag; RELEASE SAVEPOINT reindex_tag",
             )?;
-            anyhow::bail!(
-                "failed to clear stale WIT data for {registry}/{repository}:{tag}"
-            );
+            anyhow::bail!("failed to clear stale WIT data for {registry}/{repository}:{tag}");
         }
 
         // Best-effort re-extract; logged via tracing inside the helper.
@@ -1735,7 +1733,7 @@ impl Store {
             };
 
             let worlds = self.get_wit_worlds_for_manifest(m.id)?;
-            let components = self.get_components_for_manifest(m.id)?;
+            let components = self.get_components_for_manifest(m.id, tag.as_deref())?;
             let dependencies = self.get_dependencies_for_manifest(m.id)?;
             let referrers = self.get_referrers_for_manifest(m.id)?;
             let layers = self.get_layers_for_manifest(m.id)?;
@@ -1871,7 +1869,7 @@ impl Store {
         };
 
         let worlds = self.get_wit_worlds_for_manifest(m.id)?;
-        let components = self.get_components_for_manifest(m.id)?;
+        let components = self.get_components_for_manifest(m.id, Some(version_tag))?;
         let dependencies = self.get_dependencies_for_manifest(m.id)?;
         let referrers = self.get_referrers_for_manifest(m.id)?;
         let layers = self.get_layers_for_manifest(m.id)?;
@@ -1932,9 +1930,14 @@ impl Store {
     }
 
     /// Return all Wasm components (with targets) found in the given manifest.
+    ///
+    /// `parent_version` is the package version tag this manifest is being
+    /// served as; it is used to stamp a version onto native interface/world
+    /// refs that lack one, so URLs to same-package items resolve correctly.
     fn get_components_for_manifest(
         &self,
         manifest_id: i64,
+        parent_version: Option<&str>,
     ) -> anyhow::Result<Vec<wasm_meta_registry_types::ComponentSummary>> {
         use wasm_meta_registry_types::{ComponentSummary, ComponentTargetRef};
         type ComponentRow = (i64, Option<String>, Option<String>, Option<String>);
@@ -1959,9 +1962,13 @@ impl Store {
             let target_refs: Vec<ComponentTargetRef> = targets
                 .into_iter()
                 .map(|t| ComponentTargetRef {
+                    version: if t.is_native_package && t.declared_version.is_none() {
+                        parent_version.map(str::to_owned)
+                    } else {
+                        t.declared_version
+                    },
                     package: t.declared_package,
                     world: t.declared_world,
-                    version: t.declared_version,
                     is_native: t.is_native_package,
                 })
                 .collect();
@@ -2002,9 +2009,11 @@ impl Store {
 
             // Mark interfaces as native when their package matches the
             // parent OCI repository's WIT package. Recurses into children
-            // so nested components are flagged consistently.
+            // so nested components are flagged consistently. Native refs
+            // also inherit the parent's version when they lack one, so
+            // generated URLs include the version segment.
             if let Some(pkg) = parent_pkg.as_deref() {
-                mark_native_iface_refs(&mut summary, pkg);
+                mark_native_iface_refs(&mut summary, pkg, parent_version);
             }
 
             result.push(summary);
@@ -2448,18 +2457,23 @@ fn parent_pkg_for_manifest(conn: &Connection, manifest_id: i64) -> Option<String
 
 /// Mark every `WitInterfaceRef` in the component's imports/exports (and
 /// recursively in children) as `is_native` when its package equals the
-/// parent component's own package (`wit_namespace:wit_name`).
+/// parent component's own package (`wit_namespace:wit_name`). Native refs
+/// inherit `parent_version` when they lack their own.
 fn mark_native_iface_refs(
     summary: &mut wasm_meta_registry_types::ComponentSummary,
     parent_pkg: &str,
+    parent_version: Option<&str>,
 ) {
     for iface in summary.imports.iter_mut().chain(summary.exports.iter_mut()) {
         if iface.package == parent_pkg {
             iface.is_native = true;
+            if iface.version.is_none() {
+                iface.version = parent_version.map(str::to_owned);
+            }
         }
     }
     for child in &mut summary.children {
-        mark_native_iface_refs(child, parent_pkg);
+        mark_native_iface_refs(child, parent_pkg, parent_version);
     }
 }
 
@@ -3881,7 +3895,9 @@ mod tests {
 
         // Query it back via the store.
         let store = Store::from_conn(conn);
-        let components = store.get_components_for_manifest(manifest_id).unwrap();
+        let components = store
+            .get_components_for_manifest(manifest_id, None)
+            .unwrap();
 
         assert_eq!(components.len(), 1, "should have one component");
         let comp = &components[0];

--- a/crates/wasm-package-manager/src/types/parser.rs
+++ b/crates/wasm-package-manager/src/types/parser.rs
@@ -136,20 +136,7 @@ pub(crate) fn extract_wit_metadata(wasm_bytes: &[u8]) -> Option<WitMetadata> {
 #[must_use]
 pub fn extract_wit_text(wasm_bytes: &[u8]) -> Option<String> {
     let decoded = decode(wasm_bytes).ok()?;
-    match &decoded {
-        DecodedWasm::WitPackage(resolve, package_id) => {
-            let nested: Vec<_> = resolve
-                .packages
-                .iter()
-                .filter(|(id, _)| *id != *package_id)
-                .map(|(id, _)| id)
-                .collect();
-            let mut printer = WitPrinter::default();
-            printer.print(resolve, *package_id, &nested).ok()?;
-            Some(printer.output.to_string())
-        }
-        DecodedWasm::Component(..) => None,
-    }
+    wit_printer_text(&decoded)
 }
 
 /// Extract world metadata from all worlds in the decoded component.
@@ -282,23 +269,25 @@ fn extract_dependencies(
 
 /// Produce well-formed WIT text via `WitPrinter`.
 ///
-/// Returns `Some` only for WIT packages; components have no lossless
-/// textual representation.
+/// Works for WIT packages and for components: in both cases the decoded
+/// `Resolve` contains a primary package we can hand to the printer.
 fn wit_printer_text(decoded: &DecodedWasm) -> Option<String> {
-    match decoded {
-        DecodedWasm::WitPackage(resolve, package_id) => {
-            let nested: Vec<_> = resolve
-                .packages
-                .iter()
-                .filter(|(id, _)| *id != *package_id)
-                .map(|(id, _)| id)
-                .collect();
-            let mut printer = WitPrinter::default();
-            printer.print(resolve, *package_id, &nested).ok()?;
-            Some(printer.output.to_string())
+    let (resolve, package_id) = match decoded {
+        DecodedWasm::WitPackage(resolve, package_id) => (resolve, *package_id),
+        DecodedWasm::Component(resolve, world_id) => {
+            let world = resolve.worlds.get(*world_id)?;
+            (resolve, world.package?)
         }
-        DecodedWasm::Component(..) => None,
-    }
+    };
+    let nested: Vec<_> = resolve
+        .packages
+        .iter()
+        .filter(|(id, _)| *id != package_id)
+        .map(|(id, _)| id)
+        .collect();
+    let mut printer = WitPrinter::default();
+    printer.print(resolve, package_id, &nested).ok()?;
+    Some(printer.output.to_string())
 }
 
 /// Generate WIT text representation from decoded component.
@@ -982,15 +971,16 @@ mod tests {
     }
 
     #[test]
-    fn extract_wit_text_returns_none_for_component() {
-        // A minimal component header (not a WIT package)
+    fn extract_wit_text_works_for_minimal_component() {
+        // A minimal component header decodes successfully; we should now
+        // produce some WIT text from its inferred world rather than None.
         let minimal_component = [
             0x00, 0x61, 0x73, 0x6d, // \0asm magic
             0x0d, 0x00, 0x01, 0x00, // component version
         ];
         assert!(
-            extract_wit_text(&minimal_component).is_none(),
-            "components should return None"
+            extract_wit_text(&minimal_component).is_some(),
+            "components should now produce WIT text"
         );
     }
 

--- a/crates/wasm-package-manager/src/types/parser.rs
+++ b/crates/wasm-package-manager/src/types/parser.rs
@@ -117,12 +117,15 @@ pub(crate) fn extract_wit_metadata(wasm_bytes: &[u8]) -> Option<WitMetadata> {
     })
 }
 
-/// Decode a binary WIT package (`.wasm`) into its textual WIT representation.
+/// Decode a binary WIT package or WebAssembly component (`.wasm`) into its
+/// textual WIT representation.
 ///
 /// Uses `wit-component`'s [`WitPrinter`] to produce well-formed WIT text that
-/// is round-trippable through `wit-parser`.
+/// is round-trippable through `wit-parser`. Accepts both binary WIT packages
+/// and compiled WebAssembly components — components have their interface types
+/// extracted and printed as WIT text.
 ///
-/// Returns `None` if the bytes are not a valid WIT package.
+/// Returns `None` if the bytes are not a valid WIT package or component.
 ///
 /// # Example
 ///

--- a/registry/microsoft.toml
+++ b/registry/microsoft.toml
@@ -27,10 +27,6 @@ name = "time-server-js"
 repository = "time-server-js"
 
 [[component]]
-name = "arxiv-rs"
-repository = "arxiv-rs"
-
-[[component]]
 name = "github-js"
 repository = "github-js"
 

--- a/registry/yoshuawuyts.toml
+++ b/registry/yoshuawuyts.toml
@@ -5,3 +5,7 @@ registry = "ghcr.io/yoshuawuyts"
 [[component]]
 name = "fetch"
 repository = "fetch"
+
+[[component]]
+name = "wordmark"
+repository = "components/wordmark"

--- a/registry/yoshuawuyts.toml
+++ b/registry/yoshuawuyts.toml
@@ -9,3 +9,7 @@ repository = "fetch"
 [[component]]
 name = "wordmark"
 repository = "components/wordmark"
+
+[[component]]
+name = "tablemark"
+repository = "components/tablemark"


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the WIT (WebAssembly Interface Types) documentation frontend, focusing on better handling of synthetic worlds, improved routing and function detail pages, and more intuitive presentation of imports/exports. The changes enhance the user experience by flattening synthetic worlds, preventing duplication of interface listings, and providing direct links to freestanding functions. The most important changes are grouped below: