### PR TITLE
Add issue-driven registry entry automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/registry-entry.yml
+++ b/.github/ISSUE_TEMPLATE/registry-entry.yml
@@ -1,0 +1,67 @@
+name: Registry entry
+description: Add a new component or interface to the registry
+title: "registry: add new entry"
+labels: ["registry-entry"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to add a new **component** or **interface** to the
+        registry. When you submit it, automation opens a pull request that adds
+        the entry to `registry/<namespace>.toml`.
+
+        - If the namespace **already exists**, the pull request can be merged
+          automatically.
+        - If the namespace is **new**, the pull request is flagged for manual
+          review so a maintainer can approve creating the namespace.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      description: Is this entry a component or an interface?
+      options:
+        - component
+        - interface
+    validations:
+      required: true
+  - type: input
+    id: namespace
+    attributes:
+      label: Namespace
+      description: >-
+        The registry namespace. Maps to `registry/<namespace>.toml`
+        (e.g. `wasi`, `yosh`).
+      placeholder: my-namespace
+    validations:
+      required: true
+  - type: input
+    id: package
+    attributes:
+      label: Package name
+      description: >-
+        The name of the component or interface within the namespace
+        (e.g. `http`, `fetch`).
+      placeholder: my-package
+    validations:
+      required: true
+  - type: input
+    id: repository
+    attributes:
+      label: Repository
+      description: >-
+        Path within the OCI registry where this package is published
+        (e.g. `components/wordmark`).
+      placeholder: components/my-package
+    validations:
+      required: true
+  - type: input
+    id: registry
+    attributes:
+      label: OCI registry (new namespaces only)
+      description: >-
+        Only required when creating a **new** namespace. The OCI registry base
+        for the namespace (e.g. `ghcr.io/yoshuawuyts`). Leave blank if the
+        namespace already exists.
+      placeholder: ghcr.io/my-org
+    validations:
+      required: false

--- a/.github/scripts/registry-entry.mjs
+++ b/.github/scripts/registry-entry.mjs
@@ -1,0 +1,221 @@
+// Parse a "Registry entry" issue form and add the requested component or
+// interface to the matching `registry/<namespace>.toml` file.
+//
+// Inputs (environment variables):
+//   ISSUE_BODY     - the raw markdown body of the issue form submission
+//
+// Outputs (written to $GITHUB_OUTPUT):
+//   ok             - "true" if the registry file was created/updated
+//   message        - human-readable status/error message for an issue comment
+//   new_namespace  - "true" when a brand new namespace file was created
+//   namespace      - the parsed namespace
+//   kind           - "component" or "interface"
+//   package        - the parsed package name
+//   repository     - the parsed repository path
+//
+// The script always exits 0; callers branch on the `ok` output. This keeps the
+// workflow in control of commenting and labelling.
+
+import { readFileSync, writeFileSync, existsSync, appendFileSync } from "node:fs";
+import { join } from "node:path";
+
+const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+const REGISTRY_RE = /^[A-Za-z0-9][A-Za-z0-9._:/-]*$/;
+
+const outputs = {};
+
+function setOutput(key, value) {
+  outputs[key] = value;
+}
+
+function flushOutputs() {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) {
+    for (const [k, v] of Object.entries(outputs)) console.log(`${k}=${v}`);
+    return;
+  }
+  let data = "";
+  for (const [k, v] of Object.entries(outputs)) {
+    const str = String(v);
+    if (str.includes("\n")) {
+      const delim = `EOF_${k}_${Math.random().toString(36).slice(2)}`;
+      data += `${k}<<${delim}\n${str}\n${delim}\n`;
+    } else {
+      data += `${k}=${str}\n`;
+    }
+  }
+  appendFileSync(file, data);
+}
+
+function fail(message) {
+  setOutput("ok", "false");
+  setOutput("message", message);
+  flushOutputs();
+  process.exit(0);
+}
+
+// Parse the GitHub issue-form body into a { label: value } map. Form responses
+// are rendered as `### <Label>` headings followed by the value on later lines.
+function parseForm(body) {
+  const fields = {};
+  let label = null;
+  let buffer = [];
+  const commit = () => {
+    if (label !== null) {
+      fields[label] = buffer.join("\n").trim();
+    }
+  };
+  for (const rawLine of body.split(/\r?\n/)) {
+    const heading = rawLine.match(/^###\s+(.*\S)\s*$/);
+    if (heading) {
+      commit();
+      label = heading[1].trim().toLowerCase();
+      buffer = [];
+    } else if (label !== null) {
+      buffer.push(rawLine);
+    }
+  }
+  commit();
+  return fields;
+}
+
+function normalize(value) {
+  if (value === undefined) return "";
+  const trimmed = value.trim();
+  if (trimmed === "_No response_") return "";
+  return trimmed;
+}
+
+// Walk a TOML file's array-of-tables and collect { kind, name } pairs plus the
+// declared namespace name. Intentionally lightweight: only understands the flat
+// shape used by registry files.
+function inspectToml(text) {
+  let namespaceName = null;
+  let section = null;
+  const entries = [];
+  let current = null;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line === "[namespace]") {
+      section = "namespace";
+      current = null;
+      continue;
+    }
+    const array = line.match(/^\[\[(component|interface)\]\]$/);
+    if (array) {
+      section = array[1];
+      current = { kind: array[1], name: null };
+      entries.push(current);
+      continue;
+    }
+    if (line.startsWith("[")) {
+      section = null;
+      current = null;
+      continue;
+    }
+    const kv = line.match(/^name\s*=\s*"([^"]*)"/);
+    if (kv) {
+      if (section === "namespace") namespaceName = kv[1];
+      else if (current) current.name = kv[1];
+    }
+  }
+  return { namespaceName, entries };
+}
+
+function buildEntry(kind, name, repository) {
+  return `[[${kind}]]\nname = "${name}"\nrepository = "${repository}"\n`;
+}
+
+function main() {
+  const body = process.env.ISSUE_BODY || "";
+  const fields = parseForm(body);
+
+  const kind = normalize(fields["kind"]).toLowerCase();
+  const namespace = normalize(fields["namespace"]);
+  const pkg = normalize(fields["package name"]);
+  const repository = normalize(fields["repository"]);
+  const registry = normalize(fields["oci registry (new namespaces only)"]);
+
+  if (kind !== "component" && kind !== "interface") {
+    fail("**Kind** must be either `component` or `interface`.");
+  }
+  if (!NAME_RE.test(namespace)) {
+    fail(
+      "**Namespace** is missing or invalid. Use letters, numbers, `.`, `_`, or `-` (e.g. `wasi`).",
+    );
+  }
+  if (!NAME_RE.test(pkg)) {
+    fail(
+      "**Package name** is missing or invalid. Use letters, numbers, `.`, `_`, or `-` (e.g. `http`).",
+    );
+  }
+  if (!REPO_RE.test(repository)) {
+    fail(
+      "**Repository** is missing or invalid. Use a path like `components/my-package`.",
+    );
+  }
+
+  setOutput("kind", kind);
+  setOutput("namespace", namespace);
+  setOutput("package", pkg);
+  setOutput("repository", repository);
+
+  const file = join("registry", `${namespace}.toml`);
+  const exists = existsSync(file);
+
+  if (!exists) {
+    if (!REGISTRY_RE.test(registry)) {
+      fail(
+        `Namespace \`${namespace}\` does not exist yet, so the **OCI registry** ` +
+          "field is required (e.g. `ghcr.io/my-org`). Please edit the issue and " +
+          "fill it in.",
+      );
+    }
+    const content =
+      `[namespace]\nname = "${namespace}"\nregistry = "${registry}"\n\n` +
+      buildEntry(kind, pkg, repository);
+    writeFileSync(file, content);
+    setOutput("new_namespace", "true");
+    setOutput("ok", "true");
+    setOutput(
+      "message",
+      `Created new namespace \`${namespace}\` with ${kind} \`${pkg}\`. ` +
+        "Because this creates a **new namespace**, the pull request needs " +
+        "manual review before it can be merged.",
+    );
+    flushOutputs();
+    return;
+  }
+
+  const existing = readFileSync(file, "utf8");
+  const { namespaceName, entries } = inspectToml(existing);
+
+  if (namespaceName && namespaceName !== namespace) {
+    fail(
+      `\`${file}\` declares namespace \`${namespaceName}\`, which does not ` +
+        `match the requested namespace \`${namespace}\`.`,
+    );
+  }
+
+  const duplicate = entries.some((e) => e.kind === kind && e.name === pkg);
+  if (duplicate) {
+    fail(
+      `\`${namespace}\` already has a ${kind} named \`${pkg}\`. Nothing to do.`,
+    );
+  }
+
+  const prefix = existing.endsWith("\n") ? "" : "\n";
+  writeFileSync(file, `${existing}${prefix}\n${buildEntry(kind, pkg, repository)}`);
+  setOutput("new_namespace", "false");
+  setOutput("ok", "true");
+  setOutput(
+    "message",
+    `Added ${kind} \`${pkg}\` to existing namespace \`${namespace}\`. ` +
+      "Because the namespace already exists, the pull request can be merged " +
+      "automatically.",
+  );
+  flushOutputs();
+}
+
+main();

--- a/.github/scripts/registry-entry.mjs
+++ b/.github/scripts/registry-entry.mjs
@@ -132,9 +132,9 @@ function main() {
   const fields = parseForm(body);
 
   const kind = normalize(fields["kind"]).toLowerCase();
-  const namespace = normalize(fields["namespace"]);
-  const pkg = normalize(fields["package name"]);
-  const repository = normalize(fields["repository"]);
+  const namespace = normalize(fields["namespace"]).toLowerCase();
+  const pkg = normalize(fields["package name"]).toLowerCase();
+  const repository = normalize(fields["repository"]).toLowerCase();
   const registry = normalize(fields["oci registry (new namespaces only)"]);
 
   if (kind !== "component" && kind !== "interface") {

--- a/.github/scripts/upsert-comment.sh
+++ b/.github/scripts/upsert-comment.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Post or update the registry-entry bot comment on an issue. Reuses a single
+# marked comment so repeated edits/re-runs don't spam the thread.
+#
+# Required environment: REPO (owner/name), ISSUE (number), GH_TOKEN.
+# Usage: upsert-comment.sh "<body markdown>"
+set -euo pipefail
+
+MARKER="<!-- registry-entry-bot -->"
+BODY="${MARKER}
+$1"
+
+CID="$(gh api "repos/${REPO}/issues/${ISSUE}/comments" \
+  --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -n1)"
+
+if [ -n "$CID" ]; then
+  gh api -X PATCH "repos/${REPO}/issues/comments/${CID}" -f body="$BODY" >/dev/null
+else
+  gh api -X POST "repos/${REPO}/issues/${ISSUE}/comments" -f body="$BODY" >/dev/null
+fi

--- a/.github/scripts/upsert-comment.sh
+++ b/.github/scripts/upsert-comment.sh
@@ -11,6 +11,7 @@ BODY="${MARKER}
 $1"
 
 CID="$(gh api "repos/${REPO}/issues/${ISSUE}/comments" \
+  --paginate \
   --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -n1)"
 
 if [ -n "$CID" ]; then

--- a/.github/workflows/registry-entry.yml
+++ b/.github/workflows/registry-entry.yml
@@ -1,0 +1,129 @@
+name: Registry entry
+
+# Turns "Registry entry" issue-form submissions into pull requests that add a
+# component or interface to the registry.
+#
+#   - Existing namespace -> the PR is labelled `auto-merge` and auto-merge is
+#     enabled, so it merges once it is mergeable.
+#   - New namespace      -> the PR is labelled `needs-namespace-review` so a
+#     maintainer approves creating the namespace before it merges.
+#
+# This runs as a single job on issue open/edit rather than a label-triggered
+# follow-up workflow: events caused by the default GITHUB_TOKEN (such as adding
+# a label) do not trigger other workflows, so a label-then-pickup design would
+# not fire reliably. The label is still applied here for organisation.
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: registry-entry-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  open-pr:
+    # Only act on issues created from the registry-entry form.
+    if: >-
+      contains(github.event.issue.body, '### Kind') &&
+      contains(github.event.issue.body, '### Namespace') &&
+      contains(github.event.issue.body, '### Package name')
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      ISSUE: ${{ github.event.issue.number }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+    steps:
+      - name: Ensure labels exist and tag the issue
+        run: |
+          gh label create registry-entry \
+            --color 0E8A16 --description "Request to add a new registry entry" \
+            --force --repo "$REPO" || true
+          gh label create auto-merge \
+            --color 1D76DB --description "PR may be merged automatically" \
+            --force --repo "$REPO" || true
+          gh label create needs-namespace-review \
+            --color D93F0B --description "Creates a new registry namespace; needs manual review" \
+            --force --repo "$REPO" || true
+          gh issue edit "$ISSUE" --add-label registry-entry --repo "$REPO" || true
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Apply registry entry
+        id: process
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: node .github/scripts/registry-entry.mjs
+
+      - name: Comment on invalid submission
+        if: steps.process.outputs.ok != 'true'
+        env:
+          MESSAGE: ${{ steps.process.outputs.message }}
+        run: |
+          .github/scripts/upsert-comment.sh \
+            "$(printf 'Could not process this registry request:\n\n%s' "$MESSAGE")"
+
+      - name: Open or update pull request
+        if: steps.process.outputs.ok == 'true'
+        id: pr
+        env:
+          NEW_NAMESPACE: ${{ steps.process.outputs.new_namespace }}
+          NAMESPACE: ${{ steps.process.outputs.namespace }}
+          KIND: ${{ steps.process.outputs.kind }}
+          PACKAGE: ${{ steps.process.outputs.package }}
+          MESSAGE: ${{ steps.process.outputs.message }}
+        run: |
+          set -euo pipefail
+          BRANCH="registry-entry/issue-${ISSUE}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+          git add registry/
+          git commit -m "registry: add ${KIND} ${NAMESPACE}:${PACKAGE} (#${ISSUE})"
+          git push --force origin "$BRANCH"
+
+          TITLE="registry: add ${KIND} ${NAMESPACE}:${PACKAGE}"
+          BODY="$(printf '%s\n\nCloses #%s' "$MESSAGE" "$ISSUE")"
+
+          PR_URL="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+            --json url --jq '.[0].url // empty')"
+          if [ -z "$PR_URL" ]; then
+            PR_URL="$(gh pr create --repo "$REPO" --base "$DEFAULT_BRANCH" \
+              --head "$BRANCH" --title "$TITLE" --body "$BODY")"
+          else
+            gh pr edit "$PR_URL" --title "$TITLE" --body "$BODY"
+          fi
+          echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+          # Reset any stale state so a reused PR reflects the current request.
+          gh pr edit "$PR_URL" --remove-label auto-merge || true
+          gh pr edit "$PR_URL" --remove-label needs-namespace-review || true
+          gh pr merge "$PR_URL" --disable-auto || true
+
+          if [ "$NEW_NAMESPACE" = "true" ]; then
+            gh pr edit "$PR_URL" --add-label needs-namespace-review
+          else
+            gh pr edit "$PR_URL" --add-label auto-merge
+            gh pr merge "$PR_URL" --squash --auto \
+              || echo "::warning::Could not enable auto-merge; merge $PR_URL manually"
+          fi
+
+      - name: Comment with pull request link
+        if: steps.process.outputs.ok == 'true'
+        env:
+          MESSAGE: ${{ steps.process.outputs.message }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+        run: |
+          .github/scripts/upsert-comment.sh \
+            "$(printf '%s\n\nPull request: %s' "$MESSAGE" "$PR_URL")"

--- a/.github/workflows/registry-entry.yml
+++ b/.github/workflows/registry-entry.yml
@@ -69,8 +69,18 @@ jobs:
         env:
           MESSAGE: ${{ steps.process.outputs.message }}
         run: |
+          set -euo pipefail
+          BRANCH="registry-entry/issue-${ISSUE}"
+          PR_URL="$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+            --json url --jq '.[0].url // empty')"
+          if [ -n "$PR_URL" ]; then
+            gh pr merge "$PR_URL" --disable-auto || true
+            gh pr edit "$PR_URL" --remove-label auto-merge || true
+            gh pr ready "$PR_URL" --undo || true
+          fi
+
           .github/scripts/upsert-comment.sh \
-            "$(printf 'Could not process this registry request:\n\n%s' "$MESSAGE")"
+            "$(printf 'Could not process this registry request:\n\n%s\n\nIf a pull request was already open for this issue, it has been paused (converted to draft, auto-merge cancelled) until the request is fixed.' "$MESSAGE")"
 
       - name: Open or update pull request
         if: steps.process.outputs.ok == 'true'
@@ -107,6 +117,8 @@ jobs:
           echo "url=$PR_URL" >> "$GITHUB_OUTPUT"
 
           # Reset any stale state so a reused PR reflects the current request.
+          # `--ready` clears a draft set by a previous invalid submission.
+          gh pr ready "$PR_URL" || true
           gh pr edit "$PR_URL" --remove-label auto-merge || true
           gh pr edit "$PR_URL" --remove-label needs-namespace-review || true
           gh pr merge "$PR_URL" --disable-auto || true

--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ docker compose build backend
 docker compose up -d backend
 ```
 
+You can also add components and interfaces without editing files by hand:
+open a [**Registry entry** issue][registry-entry-issue]. Automation opens a
+pull request that adds the entry to the matching `registry/<namespace>.toml`.
+Entries in an existing namespace are merged automatically; creating a brand new
+namespace is flagged for manual review.
+
+[registry-entry-issue]: https://github.com/yoshuawuyts/component-registry/issues/new?template=registry-entry.yml
+
 ## Crates
 
 This project is composed of several crates:


### PR DESCRIPTION
## Why

Adding a component or interface to the registry currently means hand-editing a `registry/<namespace>.toml` file and opening a PR. That is a barrier for contributors who just want to list a package, and it makes every addition look like a code change. This lets people request an entry through a structured issue form, while still keeping a human in the loop for the one decision that actually matters: creating a new namespace.

## What

- **Issue form** (`.github/ISSUE_TEMPLATE/registry-entry.yml`): a dropdown for component vs interface, plus fields for namespace, package name, repository, and an OCI registry field that is only needed when creating a new namespace.
- **Workflow** (`.github/workflows/registry-entry.yml`): on issue open/edit it labels the issue, runs the parser, commits to a deterministic branch, and opens (or updates) a PR that closes the issue.
  - Entry in an **existing** namespace -> labelled `auto-merge` and auto-merge is enabled.
  - **New** namespace -> labelled `needs-namespace-review` so a maintainer approves it.
- **Parser** (`.github/scripts/registry-entry.mjs`): reads the form body, validates every field with strict regexes (rejects TOML injection), then either appends a `[[component]]`/`[[interface]]` block to the existing namespace file or creates a new one. Detects duplicates and namespace/file mismatches.
- **Comment helper** (`.github/scripts/upsert-comment.sh`): keeps a single bot status comment instead of spamming the thread on edits/re-runs.
- README note pointing contributors at the new form.

## Notes for reviewers

- **Single workflow on `issues: [opened, edited]` rather than a label-triggered second workflow.** Events caused by the default `GITHUB_TOKEN` (like adding a label) do not trigger other workflows, so a "label then pick up" design would silently never fire. The label is still applied for organisation; the work happens in the same run. The workflow also resets stale `auto-merge`/review labels when a PR branch is reused after an issue edit, so a request that flips from existing to new namespace cannot keep an old auto-merge state.
- **CI gating caveat:** PRs created by `GITHUB_TOKEN` do not trigger the `pull_request` CI workflow, so required checks may not run on these auto-PRs. If you want CI to gate auto-merge, this needs a GitHub App token or PAT. Happy to wire that up as a follow-up.
- The parser was exercised locally across existing-namespace, new-namespace, duplicate, missing-registry, and injection cases; all YAML/bash/JS syntax validated.