### PR TITLE
Add `component registry publish` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ from a project that has a `[package]` section in its `wasm.toml`:
 component registry publish
 ```
 
-It reads the package's `name`, `kind`, `registry_ref`, and `registry_repository`
+It reads the package's `name`, `kind`, `registry`, and `repository`
 from `wasm.toml`, checks whether the package is already in the registry, and (if
 not) opens the **Registry entry** issue form in your browser with the fields
 already filled in. If the package already exists in the registry, it reports
@@ -131,15 +131,17 @@ The relevant `[package]` fields look like this:
 
 ```toml
 [package]
-name = "wasi:http"                              # namespace:package
+name = "wasi:http"                # namespace:package
 version = "0.2.0"
-kind = "interface"                              # or "component"
-registry_ref = "ghcr.io/webassembly/wasi/http"  # full OCI ref, no tag
-registry_repository = "wasi/http"               # catalog path in the registry
+kind = "interface"                # or "component"
+registry = "ghcr.io/webassembly"  # OCI registry base (host + optional path)
+repository = "wasi/http"          # catalog path within the registry
 ```
 
-The namespace's registry base (`ghcr.io/webassembly`) is derived by stripping
-`registry_repository` from the end of `registry_ref`.
+The full OCI location is `<registry>/<repository>` (e.g.
+`ghcr.io/webassembly/wasi/http`), matching the registry entry's `registry`
+and `repository` fields. `component publish` pushes to
+`<registry>/<repository>:<version>`.
 
 [registry-entry-issue]: https://github.com/yoshuawuyts/component-registry/issues/new?template=registry-entry.yml
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ from a project that has a `[package]` section in its `wasm.toml`:
 component registry publish
 ```
 
-It reads the package's `name`, `kind`, `registry`, and `repository`
+It reads the package's `name`, `kind`, and `registry`
 from `wasm.toml`, checks whether the package is already in the registry, and (if
 not) opens the **Registry entry** issue form in your browser with the fields
 already filled in. If the package already exists in the registry, it reports
@@ -131,17 +131,16 @@ The relevant `[package]` fields look like this:
 
 ```toml
 [package]
-name = "wasi:http"                # namespace:package
+name = "wasi:http"                          # namespace:package
+kind = "interface"                          # or "component"
 version = "0.2.0"
-kind = "interface"                # or "component"
-registry = "ghcr.io/webassembly"  # OCI registry base (host + optional path)
-repository = "wasi/http"          # catalog path within the registry
+registry = "ghcr.io/webassembly/wasi/http"  # full OCI location, no tag
 ```
 
-The full OCI location is `<registry>/<repository>` (e.g.
-`ghcr.io/webassembly/wasi/http`), matching the registry entry's `registry`
-and `repository` fields. `component publish` pushes to
-`<registry>/<repository>:<version>`.
+`registry` is the full OCI location (host + path). `component publish` pushes
+to `<registry>:<version>`. When opening a registry-entry issue, the namespace
+base (`ghcr.io/webassembly`) and catalog path (`wasi/http`) are derived from it
+to match the registry entry's `registry` and `repository` fields.
 
 [registry-entry-issue]: https://github.com/yoshuawuyts/component-registry/issues/new?template=registry-entry.yml
 

--- a/README.md
+++ b/README.md
@@ -110,37 +110,9 @@ You can also add components and interfaces without editing files by hand:
 open a [**Registry entry** issue][registry-entry-issue]. Automation opens a
 pull request that adds the entry to the matching `registry/<namespace>.toml`.
 Entries in an existing namespace are merged automatically; creating a brand new
-namespace is flagged for manual review.
-
-To prefill that issue from the command line, run `component registry publish`
-from a project that has a `[package]` section in its `wasm.toml`:
-
-```sh
-component registry publish
-```
-
-It reads the package's `name`, `kind`, and `registry`
-from `wasm.toml`, checks whether the package is already in the registry, and (if
-not) opens the **Registry entry** issue form in your browser with the fields
-already filled in. If the package already exists in the registry, it reports
-that and exits without opening an issue. The issue URL is always printed to
-stdout; pass `--no-open` to skip launching the browser, and `--manifest-path
-<dir>` to point at a project other than the current directory.
-
-The relevant `[package]` fields look like this:
-
-```toml
-[package]
-name = "wasi:http"                          # namespace:package
-kind = "interface"                          # or "component"
-version = "0.2.0"
-registry = "ghcr.io/webassembly/wasi/http"  # full OCI location, no tag
-```
-
-`registry` is the full OCI location (host + path). `component publish` pushes
-to `<registry>:<version>`. When opening a registry-entry issue, the namespace
-base (`ghcr.io/webassembly`) and catalog path (`wasi/http`) are derived from it
-to match the registry entry's `registry` and `repository` fields.
+namespace is flagged for manual review. You can prefill that issue from a
+project's `wasm.toml` with `component registry publish` — see
+[Submitting a Registry Entry](docs/usage.md#submitting-a-registry-entry).
 
 [registry-entry-issue]: https://github.com/yoshuawuyts/component-registry/issues/new?template=registry-entry.yml
 

--- a/README.md
+++ b/README.md
@@ -112,15 +112,33 @@ pull request that adds the entry to the matching `registry/<namespace>.toml`.
 Entries in an existing namespace are merged automatically; creating a brand new
 namespace is flagged for manual review.
 
-To prefill that issue from the command line, run `component registry publish`:
+To prefill that issue from the command line, run `component registry publish`
+from a project that has a `[package]` section in its `wasm.toml`:
 
 ```sh
-component registry publish wasi:http --kind interface --repository wasi/http
+component registry publish
 ```
 
-This opens the **Registry entry** issue form in your browser with the fields
-already filled in. Pass `--no-open` to print the URL instead of launching a
-browser, and `--registry ghcr.io/my-org` when creating a brand new namespace.
+It reads the package's `name`, `kind`, `registry_ref`, and `registry_repository`
+from `wasm.toml`, checks whether the package is already in the registry, and (if
+not) opens the **Registry entry** issue form in your browser with the fields
+already filled in. If the package already exists in the registry it does
+nothing. Pass `--no-open` to print the URL instead of launching a browser, and
+`--manifest-path <dir>` to point at a project other than the current directory.
+
+The relevant `[package]` fields look like this:
+
+```toml
+[package]
+name = "wasi:http"                              # namespace:package
+version = "0.2.0"
+kind = "interface"                              # or "component"
+registry_ref = "ghcr.io/webassembly/wasi/http"  # full OCI ref, no tag
+registry_repository = "wasi/http"               # catalog path in the registry
+```
+
+The namespace's registry base (`ghcr.io/webassembly`) is derived by stripping
+`registry_repository` from the end of `registry_ref`.
 
 [registry-entry-issue]: https://github.com/yoshuawuyts/component-registry/issues/new?template=registry-entry.yml
 

--- a/README.md
+++ b/README.md
@@ -122,9 +122,10 @@ component registry publish
 It reads the package's `name`, `kind`, `registry_ref`, and `registry_repository`
 from `wasm.toml`, checks whether the package is already in the registry, and (if
 not) opens the **Registry entry** issue form in your browser with the fields
-already filled in. If the package already exists in the registry it does
-nothing. Pass `--no-open` to print the URL instead of launching a browser, and
-`--manifest-path <dir>` to point at a project other than the current directory.
+already filled in. If the package already exists in the registry, it reports
+that and exits without opening an issue. The issue URL is always printed to
+stdout; pass `--no-open` to skip launching the browser, and `--manifest-path
+<dir>` to point at a project other than the current directory.
 
 The relevant `[package]` fields look like this:
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ pull request that adds the entry to the matching `registry/<namespace>.toml`.
 Entries in an existing namespace are merged automatically; creating a brand new
 namespace is flagged for manual review.
 
+To prefill that issue from the command line, run `component registry publish`:
+
+```sh
+component registry publish wasi:http --kind interface --repository wasi/http
+```
+
+This opens the **Registry entry** issue form in your browser with the fields
+already filled in. Pass `--no-open` to print the URL instead of launching a
+browser, and `--registry ghcr.io/my-org` when creating a brand new namespace.
+
 [registry-entry-issue]: https://github.com/yoshuawuyts/component-registry/issues/new?template=registry-entry.yml
 
 ## Crates

--- a/crates/component-cli/src/registry/mod.rs
+++ b/crates/component-cli/src/registry/mod.rs
@@ -9,6 +9,7 @@ use component_package_manager::{Reference, format_size};
 mod errors;
 mod inspect;
 mod notify;
+mod publish;
 mod search;
 mod sync;
 
@@ -27,6 +28,8 @@ pub(crate) enum Opts {
     Sync(sync::SyncOpts),
     /// Notify a meta-registry that a new version of a package is available
     Notify(notify::NotifyOpts),
+    /// Open a prefilled issue to add a component or interface to the registry
+    Publish(publish::PublishOpts),
     /// Delete a package from the local store
     Delete(DeleteOpts),
     /// List all installed packages
@@ -76,6 +79,11 @@ pub(crate) struct KnownOpts {
 
 impl Opts {
     pub(crate) async fn run(self, offline: bool) -> Result<()> {
+        // `publish` only builds a URL; it needs neither the store nor network.
+        if let Opts::Publish(opts) = self {
+            return opts.run();
+        }
+
         let store = if offline {
             Manager::open_offline().await?
         } else {
@@ -142,6 +150,8 @@ impl Opts {
             Opts::Search(opts) => opts.run(offline).await,
             Opts::Sync(opts) => opts.run().await,
             Opts::Notify(opts) => opts.run(offline).await,
+            // Handled before the store is opened; see the early return above.
+            Opts::Publish(_) => unreachable!("publish is handled before opening the store"),
             Opts::Delete(opts) => {
                 let deleted = store.delete(opts.reference.clone()).await?;
                 if deleted {

--- a/crates/component-cli/src/registry/mod.rs
+++ b/crates/component-cli/src/registry/mod.rs
@@ -79,11 +79,6 @@ pub(crate) struct KnownOpts {
 
 impl Opts {
     pub(crate) async fn run(self, offline: bool) -> Result<()> {
-        // `publish` only builds a URL; it needs neither the store nor network.
-        if let Opts::Publish(opts) = self {
-            return opts.run();
-        }
-
         let store = if offline {
             Manager::open_offline().await?
         } else {
@@ -150,8 +145,7 @@ impl Opts {
             Opts::Search(opts) => opts.run(offline).await,
             Opts::Sync(opts) => opts.run().await,
             Opts::Notify(opts) => opts.run(offline).await,
-            // Handled before the store is opened; see the early return above.
-            Opts::Publish(_) => unreachable!("publish is handled before opening the store"),
+            Opts::Publish(opts) => opts.run(&store).await,
             Opts::Delete(opts) => {
                 let deleted = store.delete(opts.reference.clone()).await?;
                 if deleted {

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -84,7 +84,7 @@ impl PublishOpts {
         let package = manifest.package.with_context(|| {
             format!(
                 "`{}` has no `[package]` section; add one (name, version, \
-                 registry_ref, kind, registry_repository) before publishing to \
+                 registry, repository, kind) before publishing to \
                  the registry",
                 manifest_file.display()
             )
@@ -113,23 +113,15 @@ impl RegistryEntry {
     fn from_package(package: &component_manifest::Package) -> Result<Self> {
         let (namespace, name) = parse_wit_name(&package.name)?;
 
-        let repository = package.registry_repository.as_deref().with_context(|| {
-            "`[package]` is missing `registry_repository` (the catalog path \
-             within the namespace registry, e.g. `wasi/http`); add it before \
-             publishing to the registry"
-                .to_string()
-        })?;
-        validate_repository(repository)?;
-        validate_registry_ref(&package.registry_ref)?;
-
-        let registry = registry_base(&package.registry_ref, repository)?;
+        validate_registry(&package.registry)?;
+        validate_repository(&package.repository)?;
 
         Ok(Self {
             namespace: namespace.to_string(),
             package: name.to_string(),
             kind: package.kind.as_str(),
-            repository: repository.to_string(),
-            registry: registry.to_string(),
+            repository: package.repository.clone(),
+            registry: package.registry.clone(),
         })
     }
 }
@@ -188,14 +180,17 @@ fn parse_wit_name(name: &str) -> Result<(&str, &str)> {
 /// `repository` field).
 fn validate_repository(repository: &str) -> Result<()> {
     if repository.is_empty() {
-        bail!("`[package].registry_repository` must not be empty");
+        bail!("`[package].repository` must not be empty");
     }
     if repository.starts_with('/') || repository.ends_with('/') {
-        bail!("`[package].registry_repository` '{repository}' must not start or end with '/'");
+        bail!("`[package].repository` '{repository}' must not start or end with '/'");
+    }
+    if repository.split('/').any(str::is_empty) {
+        bail!("`[package].repository` '{repository}' must not contain empty path segments");
     }
     if !is_valid_repository_path(repository) {
         bail!(
-            "`[package].registry_repository` '{repository}' must start with an \
+            "`[package].repository` '{repository}' must start with an \
              alphanumeric and contain only ASCII letters, digits, `.`, `_`, `-`, \
              and `/`"
         );
@@ -213,44 +208,41 @@ fn is_valid_repository_path(repository: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/'))
 }
 
-/// Validate that `registry_ref` is a tag-less, digest-less OCI location.
-fn validate_registry_ref(registry_ref: &str) -> Result<()> {
-    if registry_ref.is_empty() {
-        bail!("`[package].registry_ref` must not be empty");
+/// Validate the namespace's OCI registry base (the issue form's `registry`
+/// field), e.g. `ghcr.io/webassembly`.
+///
+/// Mirrors `REGISTRY_RE` in `.github/scripts/registry-entry.mjs`, which allows
+/// `:` so the host may carry a `:port`.
+fn validate_registry(registry: &str) -> Result<()> {
+    if registry.is_empty() {
+        bail!("`[package].registry` must not be empty");
     }
-    if registry_ref.contains('@') {
-        bail!("`[package].registry_ref` '{registry_ref}' must not pin a digest");
+    if registry.starts_with('/') || registry.ends_with('/') {
+        bail!("`[package].registry` '{registry}' must not start or end with '/'");
     }
-    // A tag would appear as a ':' in the final path segment; the registry host
-    // may legitimately contain a ':port', which lives in the first segment.
-    let last_segment = registry_ref.rsplit('/').next().unwrap_or(registry_ref);
-    if last_segment.contains(':') {
-        bail!("`[package].registry_ref` '{registry_ref}' must not include a tag");
+    if registry.split('/').any(str::is_empty) {
+        bail!("`[package].registry` '{registry}' must not contain empty path segments");
+    }
+    if registry.contains('@') {
+        bail!("`[package].registry` '{registry}' must not pin a digest");
+    }
+    if !is_valid_registry(registry) {
+        bail!(
+            "`[package].registry` '{registry}' must start with an alphanumeric \
+             and contain only ASCII letters, digits, `.`, `_`, `-`, `:`, and `/`"
+        );
     }
     Ok(())
 }
 
-/// Derive the namespace's registry base by stripping the catalog `repository`
-/// from the end of `registry_ref`.
-///
-/// Errors when the two disagree, since that would register an entry pointing
-/// at a different OCI location than `component publish` pushes to.
-fn registry_base<'a>(registry_ref: &'a str, repository: &str) -> Result<&'a str> {
-    let suffix = format!("/{repository}");
-    let base = registry_ref.strip_suffix(&suffix).with_context(|| {
-        format!(
-            "`[package].registry_ref` '{registry_ref}' does not end with \
-             `/{repository}`; `registry_ref` must equal \
-             `<registry base>/<registry_repository>`"
-        )
-    })?;
-    if base.is_empty() {
-        bail!(
-            "`[package].registry_ref` '{registry_ref}' has no registry base \
-             before `/{repository}`"
-        );
-    }
-    Ok(base)
+fn is_valid_registry(registry: &str) -> bool {
+    registry
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && registry
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | ':' | '/'))
 }
 
 /// Validate a `owner/name` GitHub repository slug used in the URL path.
@@ -358,7 +350,8 @@ mod tests {
         Package {
             name: "wasi:http".into(),
             version: "0.1.0".into(),
-            registry_ref: "ghcr.io/webassembly/wasi/http".into(),
+            registry: "ghcr.io/webassembly".into(),
+            repository: "wasi/http".into(),
             kind: PackageKind::Interface,
             file: None,
             wit: None,
@@ -368,7 +361,6 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: Some("wasi/http".into()),
         }
     }
 
@@ -383,24 +375,23 @@ mod tests {
     }
 
     #[test]
-    fn entry_requires_registry_repository() {
+    fn entry_requires_registry() {
         let mut pkg = sample_package();
-        pkg.registry_repository = None;
+        pkg.registry = String::new();
         assert!(RegistryEntry::from_package(&pkg).is_err());
     }
 
     #[test]
-    fn entry_rejects_ref_repository_mismatch() {
+    fn entry_requires_repository() {
         let mut pkg = sample_package();
-        pkg.registry_repository = Some("other/path".into());
+        pkg.repository = String::new();
         assert!(RegistryEntry::from_package(&pkg).is_err());
     }
 
     #[test]
-    fn entry_rejects_tagged_registry_ref() {
+    fn entry_rejects_registry_with_digest() {
         let mut pkg = sample_package();
-        pkg.registry_ref = "ghcr.io/webassembly/wasi/http:0.2.0".into();
-        pkg.registry_repository = Some("wasi/http".into());
+        pkg.registry = "ghcr.io/webassembly@sha256:abc".into();
         assert!(RegistryEntry::from_package(&pkg).is_err());
     }
 
@@ -439,13 +430,19 @@ mod tests {
     }
 
     #[test]
-    fn derives_registry_base() {
-        assert_eq!(
-            registry_base("ghcr.io/webassembly/wasi/http", "wasi/http").unwrap(),
-            "ghcr.io/webassembly"
-        );
-        assert!(registry_base("ghcr.io/webassembly/wasi/http", "other").is_err());
-        assert!(registry_base("wasi/http", "wasi/http").is_err());
+    fn validates_registry() {
+        assert!(validate_registry("ghcr.io/webassembly").is_ok());
+        assert!(validate_registry("ghcr.io").is_ok());
+        assert!(validate_registry("localhost:5000/team").is_ok());
+        assert!(validate_registry("registry.example.com:8443/org/sub").is_ok());
+        assert!(validate_registry("").is_err());
+        assert!(validate_registry("/leading").is_err());
+        assert!(validate_registry("trailing/").is_err());
+        assert!(validate_registry("ghcr.io//double").is_err());
+        assert!(validate_registry("ghcr.io/webassembly@sha256:abc").is_err());
+        assert!(validate_registry("ghcr.io/web assembly").is_err());
+        assert!(validate_registry(".ghcr.io/webassembly").is_err());
+        assert!(validate_registry("ghcr.io/caf\u{e9}").is_err());
     }
 
     #[test]

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -109,15 +109,24 @@ struct RegistryEntry {
 }
 
 impl RegistryEntry {
+    /// Build an entry from a manifest's `[package]` section.
+    ///
+    /// `namespace`, `package`, and `repository` are lowercased to mirror the
+    /// registry-entry automation (`.github/scripts/registry-entry.mjs`), which
+    /// lowercases these fields before validating and writing
+    /// `registry/<namespace>.toml`. Normalizing here keeps the
+    /// "already registered" lookup accurate and avoids prefilling issues that
+    /// downstream automation would normalize to a different value. The
+    /// `registry` base is left as-is, matching the automation.
     fn from_package(package: &component_manifest::Package) -> Result<Self> {
         let (namespace, name) = parse_wit_name(&package.name)?;
         let (registry, repository) = split_registry_ref(&package.registry)?;
 
         Ok(Self {
-            namespace: namespace.to_string(),
-            package: name.to_string(),
+            namespace: namespace.to_lowercase(),
+            package: name.to_lowercase(),
             kind: package.kind.as_str(),
-            repository,
+            repository: repository.to_lowercase(),
             registry,
         })
     }
@@ -401,6 +410,19 @@ mod tests {
         assert_eq!(entry.kind, "interface");
         assert_eq!(entry.repository, "wasi/http");
         assert_eq!(entry.registry, "ghcr.io/webassembly");
+    }
+
+    #[test]
+    fn entry_lowercases_namespace_package_and_repository() {
+        let mut pkg = sample_package();
+        pkg.name = "WASI:HTTP".into();
+        pkg.registry = "ghcr.io/WebAssembly/WASI/HTTP".into();
+        let entry = RegistryEntry::from_package(&pkg).unwrap();
+        assert_eq!(entry.namespace, "wasi");
+        assert_eq!(entry.package, "http");
+        assert_eq!(entry.repository, "wasi/http");
+        // The registry base is left as-is, matching the automation.
+        assert_eq!(entry.registry, "ghcr.io/WebAssembly");
     }
 
     #[test]

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -254,10 +254,18 @@ fn validate_repo(repo: &str) -> Result<()> {
             "--repo '{repo}' must be in `owner/name` form (e.g., `yoshuawuyts/component-registry`)"
         );
     }
-    if repo.contains(['?', '#', ' ']) {
-        bail!("--repo '{repo}' contains characters that are not valid in a repository name");
+    if !valid_repo_segment(owner) || !valid_repo_segment(name) {
+        bail!("--repo '{repo}' contains characters that are not valid in a GitHub repository slug");
     }
     Ok(())
+}
+
+/// Whether `segment` is a valid GitHub `owner` or repository-name path
+/// segment: an allowlist of ASCII alphanumerics plus `-`, `_`, and `.`.
+fn valid_repo_segment(segment: &str) -> bool {
+    segment
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
 }
 
 /// Build the prefilled GitHub issue-form URL.
@@ -424,7 +432,14 @@ mod tests {
     #[test]
     fn validates_repo() {
         assert!(validate_repo("yoshuawuyts/component-registry").is_ok());
+        assert!(validate_repo("owner-1/repo_2.name").is_ok());
+        assert!(validate_repo("o/%2Fetc").is_err());
+        assert!(validate_repo("owner/re%2Fpo").is_err());
+        assert!(validate_repo("owner/re po").is_err());
+        assert!(validate_repo("owner/re\tpo").is_err());
+        assert!(validate_repo("owner/re\npo").is_err());
         assert!(validate_repo("noslash").is_err());
+        assert!(validate_repo("/name").is_err());
         assert!(validate_repo("owner/").is_err());
         assert!(validate_repo("a/b/c").is_err());
     }

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -449,6 +449,8 @@ mod tests {
         assert!(parse_wit_name("wasi:comp/onents").is_err());
         assert!(parse_wit_name("wasi:ht tp").is_err());
         assert!(parse_wit_name("wasi:bad?name").is_err());
+        assert!(parse_wit_name("wasi:htt\u{00e9}p").is_err());
+        assert!(parse_wit_name("w\u{00e9}si:http").is_err());
         assert!(parse_wit_name(".wasi:http").is_err());
         assert!(parse_wit_name("_wasi:http").is_err());
         assert!(parse_wit_name("-wasi:http").is_err());

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -83,9 +83,8 @@ impl PublishOpts {
 
         let package = manifest.package.with_context(|| {
             format!(
-                "`{}` has no `[package]` section; add one (name, version, \
-                 registry, repository, kind) before publishing to \
-                 the registry",
+                "`{}` has no `[package]` section; add one (name, kind, \
+                 version, registry) before publishing to the registry",
                 manifest_file.display()
             )
         })?;
@@ -112,16 +111,14 @@ struct RegistryEntry {
 impl RegistryEntry {
     fn from_package(package: &component_manifest::Package) -> Result<Self> {
         let (namespace, name) = parse_wit_name(&package.name)?;
-
-        validate_registry(&package.registry)?;
-        validate_repository(&package.repository)?;
+        let (registry, repository) = split_registry_ref(&package.registry)?;
 
         Ok(Self {
             namespace: namespace.to_string(),
             package: name.to_string(),
             kind: package.kind.as_str(),
-            repository: package.repository.clone(),
-            registry: package.registry.clone(),
+            repository,
+            registry,
         })
     }
 }
@@ -176,26 +173,65 @@ fn parse_wit_name(name: &str) -> Result<(&str, &str)> {
     Ok((namespace, package))
 }
 
-/// Validate the registry-catalog repository path (the issue form's
-/// `repository` field).
-fn validate_repository(repository: &str) -> Result<()> {
-    if repository.is_empty() {
-        bail!("`[package].repository` must not be empty");
+/// Split the manifest's full OCI `registry` reference into the registry
+/// schema's two parts: the namespace's registry base (the issue form's
+/// `registry` field, e.g. `ghcr.io/webassembly`) and the catalog path
+/// (the issue form's `repository` field, e.g. `wasi/http`).
+///
+/// The base is taken as the first two `/`-separated segments (host plus
+/// namespace org) and the repository is everything after. This matches the
+/// `<host>/<org>` + `<repository>` convention used by every existing
+/// `registry/<namespace>.toml`. The result only ever prefills a
+/// human-reviewed issue form, so the split does not need to be authoritative.
+///
+/// Mirrors `REGISTRY_RE`/`REPO_RE` in `.github/scripts/registry-entry.mjs`
+/// (the base allows `:` for a host `:port`; the repository does not).
+fn split_registry_ref(reference: &str) -> Result<(String, String)> {
+    if reference.is_empty() {
+        bail!("`[package].registry` must not be empty");
     }
-    if repository.starts_with('/') || repository.ends_with('/') {
-        bail!("`[package].repository` '{repository}' must not start or end with '/'");
+    if reference.contains('@') {
+        bail!("`[package].registry` '{reference}' must not pin a digest");
     }
-    if repository.split('/').any(str::is_empty) {
-        bail!("`[package].repository` '{repository}' must not contain empty path segments");
+    if reference.starts_with('/') || reference.ends_with('/') {
+        bail!("`[package].registry` '{reference}' must not start or end with '/'");
     }
-    if !is_valid_repository_path(repository) {
+    let segments: Vec<&str> = reference.split('/').collect();
+    if segments.iter().any(|s| s.is_empty()) {
+        bail!("`[package].registry` '{reference}' must not contain empty path segments");
+    }
+    let [host, org, rest @ ..] = segments.as_slice() else {
         bail!(
-            "`[package].repository` '{repository}' must start with an \
-             alphanumeric and contain only ASCII letters, digits, `.`, `_`, `-`, \
-             and `/`"
+            "`[package].registry` '{reference}' must include a host, namespace, \
+             and at least one repository segment (e.g. `ghcr.io/my-org/my-package`)"
+        );
+    };
+    if rest.is_empty() {
+        bail!(
+            "`[package].registry` '{reference}' must include a host, namespace, \
+             and at least one repository segment (e.g. `ghcr.io/my-org/my-package`)"
         );
     }
-    Ok(())
+    // Only the host (first segment) may carry a `:port`; a `:` elsewhere is a tag.
+    if org.contains(':') || rest.iter().any(|s| s.contains(':')) {
+        bail!("`[package].registry` '{reference}' must not include a tag");
+    }
+
+    let registry = format!("{host}/{org}");
+    let repository = rest.join("/");
+    if !is_valid_registry(&registry) {
+        bail!(
+            "`[package].registry` base '{registry}' must start with an alphanumeric \
+             and contain only ASCII letters, digits, `.`, `_`, `-`, `:`, and `/`"
+        );
+    }
+    if !is_valid_repository_path(&repository) {
+        bail!(
+            "`[package].registry` repository path '{repository}' must start with an \
+             alphanumeric and contain only ASCII letters, digits, `.`, `_`, `-`, and `/`"
+        );
+    }
+    Ok((registry, repository))
 }
 
 fn is_valid_repository_path(repository: &str) -> bool {
@@ -206,33 +242,6 @@ fn is_valid_repository_path(repository: &str) -> bool {
         && repository
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/'))
-}
-
-/// Validate the namespace's OCI registry base (the issue form's `registry`
-/// field), e.g. `ghcr.io/webassembly`.
-///
-/// Mirrors `REGISTRY_RE` in `.github/scripts/registry-entry.mjs`, which allows
-/// `:` so the host may carry a `:port`.
-fn validate_registry(registry: &str) -> Result<()> {
-    if registry.is_empty() {
-        bail!("`[package].registry` must not be empty");
-    }
-    if registry.starts_with('/') || registry.ends_with('/') {
-        bail!("`[package].registry` '{registry}' must not start or end with '/'");
-    }
-    if registry.split('/').any(str::is_empty) {
-        bail!("`[package].registry` '{registry}' must not contain empty path segments");
-    }
-    if registry.contains('@') {
-        bail!("`[package].registry` '{registry}' must not pin a digest");
-    }
-    if !is_valid_registry(registry) {
-        bail!(
-            "`[package].registry` '{registry}' must start with an alphanumeric \
-             and contain only ASCII letters, digits, `.`, `_`, `-`, `:`, and `/`"
-        );
-    }
-    Ok(())
 }
 
 fn is_valid_registry(registry: &str) -> bool {
@@ -350,8 +359,7 @@ mod tests {
         Package {
             name: "wasi:http".into(),
             version: "0.1.0".into(),
-            registry: "ghcr.io/webassembly".into(),
-            repository: "wasi/http".into(),
+            registry: "ghcr.io/webassembly/wasi/http".into(),
             kind: PackageKind::Interface,
             file: None,
             wit: None,
@@ -382,16 +390,23 @@ mod tests {
     }
 
     #[test]
-    fn entry_requires_repository() {
+    fn entry_rejects_registry_without_repository_segment() {
         let mut pkg = sample_package();
-        pkg.repository = String::new();
+        pkg.registry = "ghcr.io/webassembly".into();
         assert!(RegistryEntry::from_package(&pkg).is_err());
     }
 
     #[test]
     fn entry_rejects_registry_with_digest() {
         let mut pkg = sample_package();
-        pkg.registry = "ghcr.io/webassembly@sha256:abc".into();
+        pkg.registry = "ghcr.io/webassembly/wasi/http@sha256:abc".into();
+        assert!(RegistryEntry::from_package(&pkg).is_err());
+    }
+
+    #[test]
+    fn entry_rejects_tagged_registry() {
+        let mut pkg = sample_package();
+        pkg.registry = "ghcr.io/webassembly/wasi/http:0.2.0".into();
         assert!(RegistryEntry::from_package(&pkg).is_err());
     }
 
@@ -410,39 +425,41 @@ mod tests {
     }
 
     #[test]
-    fn validates_repository_path() {
-        assert!(validate_repository("wasi/http").is_ok());
-        assert!(validate_repository("components/http-server").is_ok());
-        assert!(validate_repository("wasm-pkg/fermyon-experimental/azure-client").is_ok());
-        assert!(validate_repository("just-a-name").is_ok());
-        assert!(validate_repository("").is_err());
-        assert!(validate_repository("/leading").is_err());
-        assert!(validate_repository("trailing/").is_err());
-        assert!(validate_repository("with:tag").is_err());
-        assert!(validate_repository("with space").is_err());
-        assert!(validate_repository("wasi/ht%2Ftp").is_err());
-        assert!(validate_repository("wasi/ht\ttp").is_err());
-        assert!(validate_repository("wasi/ht\ntp").is_err());
-        assert!(validate_repository(".wasi/http").is_err());
-        assert!(validate_repository("_wasi/http").is_err());
-        assert!(validate_repository("-wasi/http").is_err());
-        assert!(validate_repository("wasi/café").is_err());
-    }
+    fn splits_registry_ref() {
+        // Splits host+org base from the catalog path, matching the
+        // conventions used by every existing registry/<namespace>.toml.
+        assert_eq!(
+            split_registry_ref("ghcr.io/webassembly/wasi/http").unwrap(),
+            ("ghcr.io/webassembly".to_string(), "wasi/http".to_string())
+        );
+        assert_eq!(
+            split_registry_ref("ghcr.io/microsoft/fetch-rs").unwrap(),
+            ("ghcr.io/microsoft".to_string(), "fetch-rs".to_string())
+        );
+        assert_eq!(
+            split_registry_ref("ghcr.io/fermyon/wasm-pkg/fermyon/hello-world").unwrap(),
+            (
+                "ghcr.io/fermyon".to_string(),
+                "wasm-pkg/fermyon/hello-world".to_string()
+            )
+        );
+        assert_eq!(
+            split_registry_ref("localhost:5000/team/my-pkg").unwrap(),
+            ("localhost:5000/team".to_string(), "my-pkg".to_string())
+        );
 
-    #[test]
-    fn validates_registry() {
-        assert!(validate_registry("ghcr.io/webassembly").is_ok());
-        assert!(validate_registry("ghcr.io").is_ok());
-        assert!(validate_registry("localhost:5000/team").is_ok());
-        assert!(validate_registry("registry.example.com:8443/org/sub").is_ok());
-        assert!(validate_registry("").is_err());
-        assert!(validate_registry("/leading").is_err());
-        assert!(validate_registry("trailing/").is_err());
-        assert!(validate_registry("ghcr.io//double").is_err());
-        assert!(validate_registry("ghcr.io/webassembly@sha256:abc").is_err());
-        assert!(validate_registry("ghcr.io/web assembly").is_err());
-        assert!(validate_registry(".ghcr.io/webassembly").is_err());
-        assert!(validate_registry("ghcr.io/caf\u{e9}").is_err());
+        // Rejections.
+        assert!(split_registry_ref("").is_err());
+        assert!(split_registry_ref("ghcr.io/webassembly").is_err()); // no repo segment
+        assert!(split_registry_ref("/leading/foo/bar").is_err());
+        assert!(split_registry_ref("ghcr.io/webassembly/wasi/http/").is_err());
+        assert!(split_registry_ref("ghcr.io//wasi/http").is_err());
+        assert!(split_registry_ref("ghcr.io/webassembly/wasi/http:0.2.0").is_err()); // tag
+        assert!(split_registry_ref("ghcr.io/webassembly/wasi/http@sha256:abc").is_err());
+        assert!(split_registry_ref("ghcr.io/web assembly/wasi/http").is_err());
+        assert!(split_registry_ref("ghcr.io/webassembly/wasi/ht%2Ftp").is_err());
+        assert!(split_registry_ref("ghcr.io/webassembly/wasi/ht\ttp").is_err());
+        assert!(split_registry_ref("ghcr.io/webassembly/wasi/caf\u{e9}").is_err());
     }
 
     #[test]

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -149,8 +149,9 @@ async fn package_already_registered(store: &Manager, entry: &RegistryEntry) -> R
 
 /// Split a WIT-style `namespace:package` name into its two parts.
 ///
-/// Rejects versions (`@`), path separators (`/`), and anything that is not
-/// exactly one non-empty namespace and one non-empty package.
+/// Rejects versions (`@`), path separators (`/`), invalid registry-entry
+/// names, and anything that is not exactly one non-empty namespace and one
+/// non-empty package.
 fn parse_wit_name(name: &str) -> Result<(&str, &str)> {
     let Some((namespace, package)) = name.split_once(':') else {
         bail!(
@@ -170,7 +171,27 @@ fn parse_wit_name(name: &str) -> Result<(&str, &str)> {
     if namespace.contains('/') || package.contains('/') {
         bail!("`[package].name` '{name}' must not contain '/'");
     }
+    validate_wit_name_part(name, "namespace", namespace)?;
+    validate_wit_name_part(name, "package", package)?;
     Ok((namespace, package))
+}
+
+fn validate_wit_name_part(full_name: &str, label: &str, part: &str) -> Result<()> {
+    if is_valid_registry_entry_name(part) {
+        return Ok(());
+    }
+    bail!(
+        "`[package].name` '{full_name}' has an invalid {label}; use ASCII letters,          digits, `.`, `_`, or `-`, starting with a letter or digit"
+    );
+}
+
+fn is_valid_registry_entry_name(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
 }
 
 /// Split the manifest's full OCI `registry` reference into the registry
@@ -413,6 +434,10 @@ mod tests {
     #[test]
     fn parses_wit_name() {
         assert_eq!(parse_wit_name("wasi:http").unwrap(), ("wasi", "http"));
+        assert_eq!(
+            parse_wit_name("wasi-1:ht.tp_2").unwrap(),
+            ("wasi-1", "ht.tp_2")
+        );
     }
 
     #[test]
@@ -422,6 +447,14 @@ mod tests {
         assert!(parse_wit_name("wasi:").is_err());
         assert!(parse_wit_name("wasi:http@0.2.0").is_err());
         assert!(parse_wit_name("wasi:comp/onents").is_err());
+        assert!(parse_wit_name("wasi:ht tp").is_err());
+        assert!(parse_wit_name("wasi:bad?name").is_err());
+        assert!(parse_wit_name(".wasi:http").is_err());
+        assert!(parse_wit_name("_wasi:http").is_err());
+        assert!(parse_wit_name("-wasi:http").is_err());
+        assert!(parse_wit_name("wasi:.http").is_err());
+        assert!(parse_wit_name("wasi:_http").is_err());
+        assert!(parse_wit_name("wasi:-http").is_err());
     }
 
     #[test]

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -43,7 +43,7 @@ pub(crate) struct PublishOpts {
     #[arg(long, default_value = DEFAULT_REGISTRY_REPO)]
     repo: String,
 
-    /// Print the issue URL without launching a browser.
+    /// Do not launch a browser; the issue URL is always printed to stdout.
     #[arg(long)]
     no_open: bool,
 }
@@ -193,13 +193,24 @@ fn validate_repository(repository: &str) -> Result<()> {
     if repository.starts_with('/') || repository.ends_with('/') {
         bail!("`[package].registry_repository` '{repository}' must not start or end with '/'");
     }
-    if repository.contains([' ', '?', '#', '@', ':']) {
+    if !is_valid_repository_path(repository) {
         bail!(
-            "`[package].registry_repository` '{repository}' contains characters \
-             that are not valid in an OCI path"
+            "`[package].registry_repository` '{repository}' must start with an \
+             alphanumeric and contain only ASCII letters, digits, `.`, `_`, `-`, \
+             and `/`"
         );
     }
     Ok(())
+}
+
+fn is_valid_repository_path(repository: &str) -> bool {
+    repository
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphanumeric())
+        && repository
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | '/'))
 }
 
 /// Validate that `registry_ref` is a tag-less, digest-less OCI location.
@@ -411,12 +422,20 @@ mod tests {
     fn validates_repository_path() {
         assert!(validate_repository("wasi/http").is_ok());
         assert!(validate_repository("components/http-server").is_ok());
+        assert!(validate_repository("wasm-pkg/fermyon-experimental/azure-client").is_ok());
         assert!(validate_repository("just-a-name").is_ok());
         assert!(validate_repository("").is_err());
         assert!(validate_repository("/leading").is_err());
         assert!(validate_repository("trailing/").is_err());
         assert!(validate_repository("with:tag").is_err());
         assert!(validate_repository("with space").is_err());
+        assert!(validate_repository("wasi/ht%2Ftp").is_err());
+        assert!(validate_repository("wasi/ht\ttp").is_err());
+        assert!(validate_repository("wasi/ht\ntp").is_err());
+        assert!(validate_repository(".wasi/http").is_err());
+        assert!(validate_repository("_wasi/http").is_err());
+        assert!(validate_repository("-wasi/http").is_err());
+        assert!(validate_repository("wasi/café").is_err());
     }
 
     #[test]

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -190,7 +190,7 @@ fn validate_wit_name_part(full_name: &str, label: &str, part: &str) -> Result<()
         return Ok(());
     }
     bail!(
-        "`[package].name` '{full_name}' has an invalid {label}; use ASCII letters,          digits, `.`, `_`, or `-`, starting with a letter or digit"
+        "`[package].name` '{full_name}' has an invalid {label}; use ASCII letters, digits, `.`, `_`, or `-`, starting with a letter or digit"
     );
 }
 

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -1,15 +1,21 @@
 //! `component registry publish` subcommand.
 //!
-//! Opens a prefilled "Registry entry" issue on the registry's GitHub
-//! repository so a maintainer's automation can turn it into a pull request.
-//! This does not touch the local store or the network directly; it only
-//! constructs a URL (and optionally launches the system browser).
+//! Reads the project's `wasm.toml` `[package]` section, checks whether the
+//! package is already in the component registry, and—when it is not—opens a
+//! prefilled "Registry entry" issue on the registry's GitHub repository so a
+//! maintainer's automation can turn it into a pull request.
+//!
+//! This only reads the local package index and constructs a URL (optionally
+//! launching the system browser); it never publishes artifacts itself.
 
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use anyhow::{Result, bail};
-use std::fmt;
 use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use component_manifest::Manifest;
+use component_package_manager::manager::Manager;
 
 /// Default GitHub repository hosting the component registry.
 ///
@@ -20,52 +26,18 @@ const DEFAULT_REGISTRY_REPO: &str = "yoshuawuyts/component-registry";
 /// File name of the registry-entry issue form template.
 const ISSUE_TEMPLATE: &str = "registry-entry.yml";
 
-/// Whether a registry entry describes a component or a WIT interface.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
-pub(crate) enum Kind {
-    /// A Wasm Component.
-    Component,
-    /// A WIT interface.
-    Interface,
-}
-
-impl fmt::Display for Kind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Kind::Component => "component",
-            Kind::Interface => "interface",
-        };
-        f.write_str(s)
-    }
-}
-
-/// Open a prefilled registry-entry issue to add a component or interface.
+/// Open a prefilled registry-entry issue from a project's `wasm.toml`.
 ///
-/// The package is given as a WIT-style `namespace:package` name; combined with
-/// `--kind` and `--repository` this prefills the registry's issue form so the
-/// entry can be reviewed and merged.
+/// Reads the `[package]` section of the manifest, and—unless the package is
+/// already present in the registry—opens the registry's issue form prefilled
+/// with the package's namespace, name, kind, repository, and registry base so
+/// the entry can be reviewed and merged.
 #[derive(clap::Args)]
 pub(crate) struct PublishOpts {
-    /// The package to add, as a WIT-style name (e.g., `wasi:http`).
-    ///
-    /// A trailing `@version` is not accepted; the registry tracks packages,
-    /// not individual versions.
-    name: String,
-
-    /// Whether the entry is a component or a WIT interface.
-    #[arg(long, value_enum)]
-    kind: Kind,
-
-    /// Path within the OCI registry where the package is published
-    /// (e.g., `components/wordmark`).
-    #[arg(long)]
-    repository: String,
-
-    /// OCI registry base for a brand-new namespace (e.g., `ghcr.io/my-org`).
-    ///
-    /// Only required when the namespace does not yet exist.
-    #[arg(long)]
-    registry: Option<String>,
+    /// Path to the project directory containing `wasm.toml`. Defaults to the
+    /// current directory.
+    #[arg(long, default_value = ".")]
+    manifest_path: PathBuf,
 
     /// GitHub repository hosting the registry, as `owner/name`.
     #[arg(long, default_value = DEFAULT_REGISTRY_REPO)]
@@ -77,19 +49,18 @@ pub(crate) struct PublishOpts {
 }
 
 impl PublishOpts {
-    pub(crate) fn run(self) -> Result<()> {
-        let (namespace, package) = parse_wit_name(&self.name)?;
-        validate_repo(&self.repo)?;
+    pub(crate) async fn run(self, store: &Manager) -> Result<()> {
+        let entry = self.load_entry()?;
 
-        let url = build_issue_url(
-            &self.repo,
-            self.kind,
-            namespace,
-            package,
-            &self.repository,
-            self.registry.as_deref(),
-        );
+        if package_already_registered(store, &entry).await? {
+            println!(
+                "{}:{} is already in the registry; nothing to publish.",
+                entry.namespace, entry.package
+            );
+            return Ok(());
+        }
 
+        let url = build_issue_url(&self.repo, &entry);
         println!("{url}");
 
         if !self.no_open
@@ -97,8 +68,93 @@ impl PublishOpts {
         {
             eprintln!("Could not open a browser ({err}); open the URL above manually.");
         }
-
         Ok(())
+    }
+
+    /// Read and validate the `[package]` section into a [`RegistryEntry`].
+    fn load_entry(&self) -> Result<RegistryEntry> {
+        validate_repo(&self.repo)?;
+
+        let manifest_file = self.manifest_path.join("wasm.toml");
+        let text = std::fs::read_to_string(&manifest_file)
+            .with_context(|| format!("failed to read `{}`", manifest_file.display()))?;
+        let manifest: Manifest = toml::from_str(&text)
+            .with_context(|| format!("failed to parse `{}`", manifest_file.display()))?;
+
+        let package = manifest.package.with_context(|| {
+            format!(
+                "`{}` has no `[package]` section; add one (name, version, \
+                 registry_ref, kind, registry_repository) before publishing to \
+                 the registry",
+                manifest_file.display()
+            )
+        })?;
+        package.validate()?;
+
+        RegistryEntry::from_package(&package)
+    }
+}
+
+/// The registry-entry fields derived from a manifest's `[package]` section.
+struct RegistryEntry {
+    /// WIT namespace (e.g. `wasi`).
+    namespace: String,
+    /// WIT package name (e.g. `http`).
+    package: String,
+    /// `"component"` or `"interface"`.
+    kind: &'static str,
+    /// Catalog path within the namespace's registry (e.g. `wasi/http`).
+    repository: String,
+    /// Namespace's OCI registry base (e.g. `ghcr.io/webassembly`).
+    registry: String,
+}
+
+impl RegistryEntry {
+    fn from_package(package: &component_manifest::Package) -> Result<Self> {
+        let (namespace, name) = parse_wit_name(&package.name)?;
+
+        let repository = package.registry_repository.as_deref().with_context(|| {
+            "`[package]` is missing `registry_repository` (the catalog path \
+             within the namespace registry, e.g. `wasi/http`); add it before \
+             publishing to the registry"
+                .to_string()
+        })?;
+        validate_repository(repository)?;
+        validate_registry_ref(&package.registry_ref)?;
+
+        let registry = registry_base(&package.registry_ref, repository)?;
+
+        Ok(Self {
+            namespace: namespace.to_string(),
+            package: name.to_string(),
+            kind: package.kind.as_str(),
+            repository: repository.to_string(),
+            registry: registry.to_string(),
+        })
+    }
+}
+
+/// Return whether the package is already present in the local registry index.
+///
+/// Uses an exact `(wit_namespace, wit_name)` identity match. A lookup error
+/// (e.g. an unsynced or offline index) is treated as "unknown": it is
+/// reported and the caller proceeds to open the issue rather than silently
+/// suppressing it.
+async fn package_already_registered(store: &Manager, entry: &RegistryEntry) -> Result<bool> {
+    let wit_name = format!("{}:{}", entry.namespace, entry.package);
+    match store.find_known_package_by_wit_name(&wit_name).await {
+        Ok(Some(found)) => Ok(
+            found.wit_namespace.as_deref() == Some(entry.namespace.as_str())
+                && found.wit_name.as_deref() == Some(entry.package.as_str()),
+        ),
+        Ok(None) => Ok(false),
+        Err(err) => {
+            eprintln!(
+                "warning: could not check the registry index ({err}); \
+                 proceeding to open an issue."
+            );
+            Ok(false)
+        }
     }
 }
 
@@ -108,23 +164,82 @@ impl PublishOpts {
 /// exactly one non-empty namespace and one non-empty package.
 fn parse_wit_name(name: &str) -> Result<(&str, &str)> {
     let Some((namespace, package)) = name.split_once(':') else {
-        bail!("'{name}' is not a WIT-style name; expected `namespace:package` (e.g., `wasi:http`)");
+        bail!(
+            "`[package].name` '{name}' is not a WIT-style name; expected \
+             `namespace:package` (e.g., `wasi:http`)"
+        );
     };
-
     if namespace.is_empty() || package.is_empty() {
-        bail!("'{name}' must have a non-empty namespace and package (e.g., `wasi:http`)");
+        bail!("`[package].name` '{name}' must have a non-empty namespace and package");
     }
     if package.contains(':') {
-        bail!("'{name}' has too many ':' separators; expected `namespace:package`");
+        bail!("`[package].name` '{name}' has too many ':' separators");
     }
     if name.contains('@') {
-        bail!("'{name}' must not include a version; the registry tracks packages, not versions");
+        bail!("`[package].name` '{name}' must not include a version");
     }
     if namespace.contains('/') || package.contains('/') {
-        bail!("'{name}' must not contain '/'; use --repository for the OCI path");
+        bail!("`[package].name` '{name}' must not contain '/'");
     }
-
     Ok((namespace, package))
+}
+
+/// Validate the registry-catalog repository path (the issue form's
+/// `repository` field).
+fn validate_repository(repository: &str) -> Result<()> {
+    if repository.is_empty() {
+        bail!("`[package].registry_repository` must not be empty");
+    }
+    if repository.starts_with('/') || repository.ends_with('/') {
+        bail!("`[package].registry_repository` '{repository}' must not start or end with '/'");
+    }
+    if repository.contains([' ', '?', '#', '@', ':']) {
+        bail!(
+            "`[package].registry_repository` '{repository}' contains characters \
+             that are not valid in an OCI path"
+        );
+    }
+    Ok(())
+}
+
+/// Validate that `registry_ref` is a tag-less, digest-less OCI location.
+fn validate_registry_ref(registry_ref: &str) -> Result<()> {
+    if registry_ref.is_empty() {
+        bail!("`[package].registry_ref` must not be empty");
+    }
+    if registry_ref.contains('@') {
+        bail!("`[package].registry_ref` '{registry_ref}' must not pin a digest");
+    }
+    // A tag would appear as a ':' in the final path segment; the registry host
+    // may legitimately contain a ':port', which lives in the first segment.
+    let last_segment = registry_ref.rsplit('/').next().unwrap_or(registry_ref);
+    if last_segment.contains(':') {
+        bail!("`[package].registry_ref` '{registry_ref}' must not include a tag");
+    }
+    Ok(())
+}
+
+/// Derive the namespace's registry base by stripping the catalog `repository`
+/// from the end of `registry_ref`.
+///
+/// Errors when the two disagree, since that would register an entry pointing
+/// at a different OCI location than `component publish` pushes to.
+fn registry_base<'a>(registry_ref: &'a str, repository: &str) -> Result<&'a str> {
+    let suffix = format!("/{repository}");
+    let base = registry_ref.strip_suffix(&suffix).with_context(|| {
+        format!(
+            "`[package].registry_ref` '{registry_ref}' does not end with \
+             `/{repository}`; `registry_ref` must equal \
+             `<registry base>/<registry_repository>`"
+        )
+    })?;
+    if base.is_empty() {
+        bail!(
+            "`[package].registry_ref` '{registry_ref}' has no registry base \
+             before `/{repository}`"
+        );
+    }
+    Ok(base)
 }
 
 /// Validate a `owner/name` GitHub repository slug used in the URL path.
@@ -149,23 +264,18 @@ fn validate_repo(repo: &str) -> Result<()> {
 ///
 /// Each query key matches a field `id` in `registry-entry.yml`, so GitHub
 /// populates the corresponding form fields. Query values are percent-encoded.
+/// The `registry` base is always included: the automation ignores it when the
+/// namespace already exists and uses it when creating a new namespace.
 #[must_use]
-fn build_issue_url(
-    repo: &str,
-    kind: Kind,
-    namespace: &str,
-    package: &str,
-    repository: &str,
-    registry: Option<&str>,
-) -> String {
+fn build_issue_url(repo: &str, entry: &RegistryEntry) -> String {
     let mut url = format!("https://github.com/{repo}/issues/new?template={ISSUE_TEMPLATE}");
-    write!(url, "&kind={}", encode(&kind.to_string())).expect("writing to a String cannot fail");
-    write!(url, "&namespace={}", encode(namespace)).expect("writing to a String cannot fail");
-    write!(url, "&package={}", encode(package)).expect("writing to a String cannot fail");
-    write!(url, "&repository={}", encode(repository)).expect("writing to a String cannot fail");
-    if let Some(registry) = registry.filter(|r| !r.is_empty()) {
-        write!(url, "&registry={}", encode(registry)).expect("writing to a String cannot fail");
-    }
+    write!(url, "&kind={}", encode(entry.kind)).expect("writing to a String cannot fail");
+    write!(url, "&namespace={}", encode(&entry.namespace))
+        .expect("writing to a String cannot fail");
+    write!(url, "&package={}", encode(&entry.package)).expect("writing to a String cannot fail");
+    write!(url, "&repository={}", encode(&entry.repository))
+        .expect("writing to a String cannot fail");
+    write!(url, "&registry={}", encode(&entry.registry)).expect("writing to a String cannot fail");
     url
 }
 
@@ -223,11 +333,61 @@ fn open_in_browser(url: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use component_manifest::{Package, PackageKind};
+
+    fn sample_package() -> Package {
+        Package {
+            name: "wasi:http".into(),
+            version: "0.1.0".into(),
+            registry_ref: "ghcr.io/webassembly/wasi/http".into(),
+            kind: PackageKind::Interface,
+            file: None,
+            wit: None,
+            description: None,
+            source: None,
+            homepage: None,
+            documentation: None,
+            license: None,
+            authors: vec![],
+            registry_repository: Some("wasi/http".into()),
+        }
+    }
+
+    #[test]
+    fn entry_from_package_derives_fields() {
+        let entry = RegistryEntry::from_package(&sample_package()).unwrap();
+        assert_eq!(entry.namespace, "wasi");
+        assert_eq!(entry.package, "http");
+        assert_eq!(entry.kind, "interface");
+        assert_eq!(entry.repository, "wasi/http");
+        assert_eq!(entry.registry, "ghcr.io/webassembly");
+    }
+
+    #[test]
+    fn entry_requires_registry_repository() {
+        let mut pkg = sample_package();
+        pkg.registry_repository = None;
+        assert!(RegistryEntry::from_package(&pkg).is_err());
+    }
+
+    #[test]
+    fn entry_rejects_ref_repository_mismatch() {
+        let mut pkg = sample_package();
+        pkg.registry_repository = Some("other/path".into());
+        assert!(RegistryEntry::from_package(&pkg).is_err());
+    }
+
+    #[test]
+    fn entry_rejects_tagged_registry_ref() {
+        let mut pkg = sample_package();
+        pkg.registry_ref = "ghcr.io/webassembly/wasi/http:0.2.0".into();
+        pkg.registry_repository = Some("wasi/http".into());
+        assert!(RegistryEntry::from_package(&pkg).is_err());
+    }
 
     #[test]
     fn parses_wit_name() {
         assert_eq!(parse_wit_name("wasi:http").unwrap(), ("wasi", "http"));
-        assert_eq!(parse_wit_name("yosh:fetch").unwrap(), ("yosh", "fetch"));
     }
 
     #[test]
@@ -236,8 +396,29 @@ mod tests {
         assert!(parse_wit_name(":http").is_err());
         assert!(parse_wit_name("wasi:").is_err());
         assert!(parse_wit_name("wasi:http@0.2.0").is_err());
-        assert!(parse_wit_name("wasi:http:extra").is_err());
         assert!(parse_wit_name("wasi:comp/onents").is_err());
+    }
+
+    #[test]
+    fn validates_repository_path() {
+        assert!(validate_repository("wasi/http").is_ok());
+        assert!(validate_repository("components/http-server").is_ok());
+        assert!(validate_repository("just-a-name").is_ok());
+        assert!(validate_repository("").is_err());
+        assert!(validate_repository("/leading").is_err());
+        assert!(validate_repository("trailing/").is_err());
+        assert!(validate_repository("with:tag").is_err());
+        assert!(validate_repository("with space").is_err());
+    }
+
+    #[test]
+    fn derives_registry_base() {
+        assert_eq!(
+            registry_base("ghcr.io/webassembly/wasi/http", "wasi/http").unwrap(),
+            "ghcr.io/webassembly"
+        );
+        assert!(registry_base("ghcr.io/webassembly/wasi/http", "other").is_err());
+        assert!(registry_base("wasi/http", "wasi/http").is_err());
     }
 
     #[test]
@@ -245,64 +426,25 @@ mod tests {
         assert!(validate_repo("yoshuawuyts/component-registry").is_ok());
         assert!(validate_repo("noslash").is_err());
         assert!(validate_repo("owner/").is_err());
-        assert!(validate_repo("/name").is_err());
         assert!(validate_repo("a/b/c").is_err());
-        assert!(validate_repo("owner/na me").is_err());
     }
 
     #[test]
     fn encodes_query_values() {
         assert_eq!(encode("components/wordmark"), "components%2Fwordmark");
         assert_eq!(encode("ghcr.io/my-org"), "ghcr.io%2Fmy-org");
-        assert_eq!(encode("ghcr.io:5000/org"), "ghcr.io%3A5000%2Forg");
         assert_eq!(encode("plain-name_1.0"), "plain-name_1.0");
     }
 
     #[test]
-    fn builds_url_without_registry() {
-        let url = build_issue_url(
-            "yoshuawuyts/component-registry",
-            Kind::Component,
-            "yosh",
-            "fetch",
-            "components/fetch",
-            None,
-        );
+    fn builds_url() {
+        let entry = RegistryEntry::from_package(&sample_package()).unwrap();
+        let url = build_issue_url("yoshuawuyts/component-registry", &entry);
         assert_eq!(
             url,
             "https://github.com/yoshuawuyts/component-registry/issues/new\
-             ?template=registry-entry.yml&kind=component&namespace=yosh\
-             &package=fetch&repository=components%2Ffetch"
+             ?template=registry-entry.yml&kind=interface&namespace=wasi\
+             &package=http&repository=wasi%2Fhttp&registry=ghcr.io%2Fwebassembly"
         );
-    }
-
-    #[test]
-    fn builds_url_with_registry_for_new_namespace() {
-        let url = build_issue_url(
-            "yoshuawuyts/component-registry",
-            Kind::Interface,
-            "acme",
-            "types",
-            "iface/types",
-            Some("ghcr.io/acme"),
-        );
-        assert!(url.contains("&kind=interface"));
-        assert!(url.contains("&namespace=acme"));
-        assert!(url.contains("&package=types"));
-        assert!(url.contains("&repository=iface%2Ftypes"));
-        assert!(url.contains("&registry=ghcr.io%2Facme"));
-    }
-
-    #[test]
-    fn omits_empty_registry() {
-        let url = build_issue_url(
-            "owner/repo",
-            Kind::Component,
-            "ns",
-            "pkg",
-            "ns/pkg",
-            Some(""),
-        );
-        assert!(!url.contains("registry="));
     }
 }

--- a/crates/component-cli/src/registry/publish.rs
+++ b/crates/component-cli/src/registry/publish.rs
@@ -1,0 +1,308 @@
+//! `component registry publish` subcommand.
+//!
+//! Opens a prefilled "Registry entry" issue on the registry's GitHub
+//! repository so a maintainer's automation can turn it into a pull request.
+//! This does not touch the local store or the network directly; it only
+//! constructs a URL (and optionally launches the system browser).
+
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
+use anyhow::{Result, bail};
+use std::fmt;
+use std::fmt::Write as _;
+
+/// Default GitHub repository hosting the component registry.
+///
+/// This mirrors the manager's compile-time default registry: the registry's
+/// issue forms live in this repository.
+const DEFAULT_REGISTRY_REPO: &str = "yoshuawuyts/component-registry";
+
+/// File name of the registry-entry issue form template.
+const ISSUE_TEMPLATE: &str = "registry-entry.yml";
+
+/// Whether a registry entry describes a component or a WIT interface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum Kind {
+    /// A Wasm Component.
+    Component,
+    /// A WIT interface.
+    Interface,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Kind::Component => "component",
+            Kind::Interface => "interface",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Open a prefilled registry-entry issue to add a component or interface.
+///
+/// The package is given as a WIT-style `namespace:package` name; combined with
+/// `--kind` and `--repository` this prefills the registry's issue form so the
+/// entry can be reviewed and merged.
+#[derive(clap::Args)]
+pub(crate) struct PublishOpts {
+    /// The package to add, as a WIT-style name (e.g., `wasi:http`).
+    ///
+    /// A trailing `@version` is not accepted; the registry tracks packages,
+    /// not individual versions.
+    name: String,
+
+    /// Whether the entry is a component or a WIT interface.
+    #[arg(long, value_enum)]
+    kind: Kind,
+
+    /// Path within the OCI registry where the package is published
+    /// (e.g., `components/wordmark`).
+    #[arg(long)]
+    repository: String,
+
+    /// OCI registry base for a brand-new namespace (e.g., `ghcr.io/my-org`).
+    ///
+    /// Only required when the namespace does not yet exist.
+    #[arg(long)]
+    registry: Option<String>,
+
+    /// GitHub repository hosting the registry, as `owner/name`.
+    #[arg(long, default_value = DEFAULT_REGISTRY_REPO)]
+    repo: String,
+
+    /// Print the issue URL without launching a browser.
+    #[arg(long)]
+    no_open: bool,
+}
+
+impl PublishOpts {
+    pub(crate) fn run(self) -> Result<()> {
+        let (namespace, package) = parse_wit_name(&self.name)?;
+        validate_repo(&self.repo)?;
+
+        let url = build_issue_url(
+            &self.repo,
+            self.kind,
+            namespace,
+            package,
+            &self.repository,
+            self.registry.as_deref(),
+        );
+
+        println!("{url}");
+
+        if !self.no_open
+            && let Err(err) = open_in_browser(&url)
+        {
+            eprintln!("Could not open a browser ({err}); open the URL above manually.");
+        }
+
+        Ok(())
+    }
+}
+
+/// Split a WIT-style `namespace:package` name into its two parts.
+///
+/// Rejects versions (`@`), path separators (`/`), and anything that is not
+/// exactly one non-empty namespace and one non-empty package.
+fn parse_wit_name(name: &str) -> Result<(&str, &str)> {
+    let Some((namespace, package)) = name.split_once(':') else {
+        bail!("'{name}' is not a WIT-style name; expected `namespace:package` (e.g., `wasi:http`)");
+    };
+
+    if namespace.is_empty() || package.is_empty() {
+        bail!("'{name}' must have a non-empty namespace and package (e.g., `wasi:http`)");
+    }
+    if package.contains(':') {
+        bail!("'{name}' has too many ':' separators; expected `namespace:package`");
+    }
+    if name.contains('@') {
+        bail!("'{name}' must not include a version; the registry tracks packages, not versions");
+    }
+    if namespace.contains('/') || package.contains('/') {
+        bail!("'{name}' must not contain '/'; use --repository for the OCI path");
+    }
+
+    Ok((namespace, package))
+}
+
+/// Validate a `owner/name` GitHub repository slug used in the URL path.
+fn validate_repo(repo: &str) -> Result<()> {
+    let Some((owner, name)) = repo.split_once('/') else {
+        bail!(
+            "--repo '{repo}' must be in `owner/name` form (e.g., `yoshuawuyts/component-registry`)"
+        );
+    };
+    if owner.is_empty() || name.is_empty() || name.contains('/') {
+        bail!(
+            "--repo '{repo}' must be in `owner/name` form (e.g., `yoshuawuyts/component-registry`)"
+        );
+    }
+    if repo.contains(['?', '#', ' ']) {
+        bail!("--repo '{repo}' contains characters that are not valid in a repository name");
+    }
+    Ok(())
+}
+
+/// Build the prefilled GitHub issue-form URL.
+///
+/// Each query key matches a field `id` in `registry-entry.yml`, so GitHub
+/// populates the corresponding form fields. Query values are percent-encoded.
+#[must_use]
+fn build_issue_url(
+    repo: &str,
+    kind: Kind,
+    namespace: &str,
+    package: &str,
+    repository: &str,
+    registry: Option<&str>,
+) -> String {
+    let mut url = format!("https://github.com/{repo}/issues/new?template={ISSUE_TEMPLATE}");
+    write!(url, "&kind={}", encode(&kind.to_string())).expect("writing to a String cannot fail");
+    write!(url, "&namespace={}", encode(namespace)).expect("writing to a String cannot fail");
+    write!(url, "&package={}", encode(package)).expect("writing to a String cannot fail");
+    write!(url, "&repository={}", encode(repository)).expect("writing to a String cannot fail");
+    if let Some(registry) = registry.filter(|r| !r.is_empty()) {
+        write!(url, "&registry={}", encode(registry)).expect("writing to a String cannot fail");
+    }
+    url
+}
+
+/// Percent-encode a query value, passing through only RFC 3986 unreserved
+/// characters and encoding every other UTF-8 byte as `%XX`.
+#[must_use]
+fn encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for &byte in value.as_bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(byte as char);
+        } else {
+            write!(out, "%{byte:02X}").expect("writing to a String cannot fail");
+        }
+    }
+    out
+}
+
+/// Launch the system browser for `url` using a platform-native handler.
+///
+/// Uses `Command` directly (never a shell) so URL metacharacters such as `&`
+/// and `%` cannot be reinterpreted.
+fn open_in_browser(url: &str) -> Result<()> {
+    use std::process::Command;
+
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut c = Command::new("open");
+        c.arg(url);
+        c
+    };
+
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        // Avoid `cmd /C start`, which reinterprets `&` and `%` in the URL.
+        let mut c = Command::new("rundll32.exe");
+        c.args(["url.dll,FileProtocolHandler", url]);
+        c
+    };
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let mut command = {
+        let mut c = Command::new("xdg-open");
+        c.arg(url);
+        c
+    };
+
+    let status = command.status()?;
+    if !status.success() {
+        bail!("browser launcher exited with status {status}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_wit_name() {
+        assert_eq!(parse_wit_name("wasi:http").unwrap(), ("wasi", "http"));
+        assert_eq!(parse_wit_name("yosh:fetch").unwrap(), ("yosh", "fetch"));
+    }
+
+    #[test]
+    fn rejects_invalid_wit_names() {
+        assert!(parse_wit_name("nocolon").is_err());
+        assert!(parse_wit_name(":http").is_err());
+        assert!(parse_wit_name("wasi:").is_err());
+        assert!(parse_wit_name("wasi:http@0.2.0").is_err());
+        assert!(parse_wit_name("wasi:http:extra").is_err());
+        assert!(parse_wit_name("wasi:comp/onents").is_err());
+    }
+
+    #[test]
+    fn validates_repo() {
+        assert!(validate_repo("yoshuawuyts/component-registry").is_ok());
+        assert!(validate_repo("noslash").is_err());
+        assert!(validate_repo("owner/").is_err());
+        assert!(validate_repo("/name").is_err());
+        assert!(validate_repo("a/b/c").is_err());
+        assert!(validate_repo("owner/na me").is_err());
+    }
+
+    #[test]
+    fn encodes_query_values() {
+        assert_eq!(encode("components/wordmark"), "components%2Fwordmark");
+        assert_eq!(encode("ghcr.io/my-org"), "ghcr.io%2Fmy-org");
+        assert_eq!(encode("ghcr.io:5000/org"), "ghcr.io%3A5000%2Forg");
+        assert_eq!(encode("plain-name_1.0"), "plain-name_1.0");
+    }
+
+    #[test]
+    fn builds_url_without_registry() {
+        let url = build_issue_url(
+            "yoshuawuyts/component-registry",
+            Kind::Component,
+            "yosh",
+            "fetch",
+            "components/fetch",
+            None,
+        );
+        assert_eq!(
+            url,
+            "https://github.com/yoshuawuyts/component-registry/issues/new\
+             ?template=registry-entry.yml&kind=component&namespace=yosh\
+             &package=fetch&repository=components%2Ffetch"
+        );
+    }
+
+    #[test]
+    fn builds_url_with_registry_for_new_namespace() {
+        let url = build_issue_url(
+            "yoshuawuyts/component-registry",
+            Kind::Interface,
+            "acme",
+            "types",
+            "iface/types",
+            Some("ghcr.io/acme"),
+        );
+        assert!(url.contains("&kind=interface"));
+        assert!(url.contains("&namespace=acme"));
+        assert!(url.contains("&package=types"));
+        assert!(url.contains("&repository=iface%2Ftypes"));
+        assert!(url.contains("&registry=ghcr.io%2Facme"));
+    }
+
+    #[test]
+    fn omits_empty_registry() {
+        let url = build_issue_url(
+            "owner/repo",
+            Kind::Component,
+            "ns",
+            "pkg",
+            "ns/pkg",
+            Some(""),
+        );
+        assert!(!url.contains("registry="));
+    }
+}

--- a/crates/component-cli/tests/snapshots/test__cli_registry_help_snapshot.snap
+++ b/crates/component-cli/tests/snapshots/test__cli_registry_help_snapshot.snap
@@ -13,6 +13,7 @@ Commands:
   search   Search for packages across configured registries
   sync     Force-sync the package index from the configured meta-registry
   notify   Notify a meta-registry that a new version of a package is available
+  publish  Open a prefilled issue to add a component or interface to the registry
   delete   Delete a package from the local store
   list     List all installed packages
   known    List all known packages (previously synced or pulled)

--- a/crates/component-cli/tests/test.rs
+++ b/crates/component-cli/tests/test.rs
@@ -746,7 +746,8 @@ fn test_publish_dry_run_interface() {
         "[package]\n\
          name = \"example:hello\"\n\
          version = \"0.1.0\"\n\
-         registry_ref = \"ghcr.io/example/hello\"\n\
+         registry = \"ghcr.io/example\"\n\
+         repository = \"hello\"\n\
          kind = \"interface\"\n\
          wit = \"wit\"\n\
          description = \"An example greeting interface\"\n\
@@ -789,7 +790,8 @@ fn test_publish_dry_run_rejects_versioned_wit() {
         "[package]\n\
          name = \"example:hello\"\n\
          version = \"0.1.0\"\n\
-         registry_ref = \"ghcr.io/example/hello\"\n\
+         registry = \"ghcr.io/example\"\n\
+         repository = \"hello\"\n\
          kind = \"interface\"\n\
          wit = \"wit\"\n",
     )

--- a/crates/component-cli/tests/test.rs
+++ b/crates/component-cli/tests/test.rs
@@ -745,10 +745,9 @@ fn test_publish_dry_run_interface() {
         dir.path().join("wasm.toml"),
         "[package]\n\
          name = \"example:hello\"\n\
-         version = \"0.1.0\"\n\
-         registry = \"ghcr.io/example\"\n\
-         repository = \"hello\"\n\
          kind = \"interface\"\n\
+         version = \"0.1.0\"\n\
+         registry = \"ghcr.io/example/hello\"\n\
          wit = \"wit\"\n\
          description = \"An example greeting interface\"\n\
          license = \"Apache-2.0\"\n",
@@ -789,10 +788,9 @@ fn test_publish_dry_run_rejects_versioned_wit() {
         dir.path().join("wasm.toml"),
         "[package]\n\
          name = \"example:hello\"\n\
-         version = \"0.1.0\"\n\
-         registry = \"ghcr.io/example\"\n\
-         repository = \"hello\"\n\
          kind = \"interface\"\n\
+         version = \"0.1.0\"\n\
+         registry = \"ghcr.io/example/hello\"\n\
          wit = \"wit\"\n",
     )
     .unwrap();

--- a/crates/component-manifest/src/package.rs
+++ b/crates/component-manifest/src/package.rs
@@ -74,10 +74,9 @@ impl From<PackageKind> for PackageType {
 /// let toml = r#"
 /// [package]
 /// name = "my-org:my-component"
-/// version = "0.1.0"
-/// registry = "ghcr.io/my-org"
-/// repository = "my-component"
 /// kind = "component"
+/// version = "0.1.0"
+/// registry = "ghcr.io/my-org/my-component"
 /// file = "build/my-component.wasm"
 /// description = "An example component"
 /// "#;
@@ -86,8 +85,7 @@ impl From<PackageKind> for PackageType {
 /// let pkg = manifest.package.expect("package section");
 /// assert_eq!(pkg.kind, PackageKind::Component);
 /// assert_eq!(pkg.version, "0.1.0");
-/// assert_eq!(pkg.registry, "ghcr.io/my-org");
-/// assert_eq!(pkg.repository, "my-component");
+/// assert_eq!(pkg.registry, "ghcr.io/my-org/my-component");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[must_use]
@@ -99,25 +97,22 @@ pub struct Package {
     /// During publish this version is the single source of truth: WIT
     /// package decls are stamped with it, and it becomes the OCI tag.
     pub version: String,
-    /// The OCI registry base this package is published under, for
-    /// example `ghcr.io/webassembly`. This is the same value recorded as
-    /// `registry` in the registry's `registry/<namespace>.toml` entry.
+    /// The full OCI location this package is published to, without a tag,
+    /// for example `ghcr.io/webassembly/wasi/http`.
     ///
-    /// Combined with [`repository`](Self::repository), the full OCI
-    /// location is `<registry>/<repository>` and the published reference
-    /// is `<registry>/<repository>:<version>`. There is intentionally no
-    /// default and no shorthand: every manifest spells out its full
-    /// destination so that publishing is fully reproducible from the
-    /// manifest alone.
-    pub registry: String,
-    /// The OCI repository (catalog) path for this package within its
-    /// registry, for example `wasi/http`. This is the same value
-    /// recorded as `repository` in the registry's
-    /// `registry/<namespace>.toml` entry.
+    /// The published reference is `<registry>:<version>`. There is
+    /// intentionally no default and no shorthand: every manifest spells
+    /// out its full destination so that publishing is fully reproducible
+    /// from the manifest alone.
     ///
-    /// This is the OCI repository path, **not** a source-code URL; use
+    /// This maps onto the registry schema's split of a namespace-level
+    /// `registry` base (e.g. `ghcr.io/webassembly`) plus a per-entry
+    /// `repository` catalog path (e.g. `wasi/http`); `component registry
+    /// publish` derives those two parts from this single value.
+    ///
+    /// This is the OCI publish location, **not** a source-code URL; use
     /// [`source`](Self::source) for the project's source repository.
-    pub repository: String,
+    pub registry: String,
     /// What kind of artifact this manifest describes.
     pub kind: PackageKind,
     /// Path to the compiled component artifact, relative to the manifest
@@ -173,8 +168,6 @@ pub enum PackageError {
     EmptyName,
     /// The `registry` field is empty.
     EmptyRegistry,
-    /// The `repository` field is empty.
-    EmptyRepository,
 }
 
 impl std::fmt::Display for PackageError {
@@ -195,9 +188,6 @@ impl std::fmt::Display for PackageError {
             PackageError::EmptyName => write!(f, "[package] name must not be empty"),
             PackageError::EmptyRegistry => {
                 write!(f, "[package] registry must not be empty")
-            }
-            PackageError::EmptyRepository => {
-                write!(f, "[package] repository must not be empty")
             }
         }
     }
@@ -240,16 +230,13 @@ impl Package {
     /// * `kind` and `file`/`wit` disagree.
     /// * `version` is not a valid semver string.
     /// * `name` is empty.
-    /// * `registry` or `repository` is empty.
+    /// * `registry` is empty.
     pub fn validate(&self) -> Result<(), PackageError> {
         if self.name.is_empty() {
             return Err(PackageError::EmptyName);
         }
         if self.registry.is_empty() {
             return Err(PackageError::EmptyRegistry);
-        }
-        if self.repository.is_empty() {
-            return Err(PackageError::EmptyRepository);
         }
         match self.kind {
             PackageKind::Component if self.wit.is_some() => {
@@ -279,10 +266,9 @@ mod tests {
         let toml = r#"
             [package]
             name = "yoshuawuyts:fetch"
-            version = "0.1.0"
-            registry = "ghcr.io/yoshuawuyts"
-            repository = "fetch"
             kind = "component"
+            version = "0.1.0"
+            registry = "ghcr.io/yoshuawuyts/fetch"
             file = "build/fetch.wasm"
             description = "Tiny HTTP fetch helper"
             license = "Apache-2.0"
@@ -291,8 +277,7 @@ mod tests {
         let manifest: Manifest = toml::from_str(toml).expect("parse");
         let pkg = manifest.package.expect("package");
         assert_eq!(pkg.name, "yoshuawuyts:fetch");
-        assert_eq!(pkg.registry, "ghcr.io/yoshuawuyts");
-        assert_eq!(pkg.repository, "fetch");
+        assert_eq!(pkg.registry, "ghcr.io/yoshuawuyts/fetch");
         assert_eq!(pkg.kind, PackageKind::Component);
         assert_eq!(
             pkg.file.as_deref(),
@@ -309,17 +294,15 @@ mod tests {
         let toml = r#"
             [package]
             name = "wasi:logging"
-            version = "1.2.3"
-            registry = "ghcr.io/yoshuawuyts"
-            repository = "fetch"
             kind = "interface"
+            version = "1.2.3"
+            registry = "ghcr.io/wasi/logging"
             wit = "wit"
         "#;
         let manifest: Manifest = toml::from_str(toml).expect("parse");
         let pkg = manifest.package.expect("package");
         assert_eq!(pkg.kind, PackageKind::Interface);
-        assert_eq!(pkg.registry, "ghcr.io/yoshuawuyts");
-        assert_eq!(pkg.repository, "fetch");
+        assert_eq!(pkg.registry, "ghcr.io/wasi/logging");
         pkg.validate().expect("valid");
     }
 
@@ -338,7 +321,6 @@ mod tests {
             name: "a:b".into(),
             version: "0.1.0".into(),
             registry: "ghcr.io/a".into(),
-            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: Some(PathBuf::from("wit")),
@@ -359,7 +341,6 @@ mod tests {
             name: "a:b".into(),
             version: "0.1.0".into(),
             registry: "ghcr.io/a".into(),
-            repository: "b".into(),
             kind: PackageKind::Interface,
             file: Some(PathBuf::from("x.wasm")),
             wit: None,
@@ -380,7 +361,6 @@ mod tests {
             name: "a:b".into(),
             version: "not-a-version".into(),
             registry: "ghcr.io/a".into(),
-            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -404,7 +384,6 @@ mod tests {
             name: String::new(),
             version: "0.1.0".into(),
             registry: "ghcr.io/a".into(),
-            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -425,7 +404,6 @@ mod tests {
             name: "a:b".into(),
             version: "0.1.0".into(),
             registry: String::new(),
-            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -439,27 +417,6 @@ mod tests {
         assert_eq!(pkg.validate(), Err(PackageError::EmptyRegistry));
     }
 
-    // r[verify manifest.package.empty-repository]
-    #[test]
-    fn empty_repository_is_rejected() {
-        let pkg = Package {
-            name: "a:b".into(),
-            version: "0.1.0".into(),
-            registry: "ghcr.io/a".into(),
-            repository: String::new(),
-            kind: PackageKind::Component,
-            file: None,
-            wit: None,
-            description: None,
-            source: None,
-            homepage: None,
-            documentation: None,
-            license: None,
-            authors: vec![],
-        };
-        assert_eq!(pkg.validate(), Err(PackageError::EmptyRepository));
-    }
-
     // r[verify manifest.package.default-paths]
     #[test]
     fn default_paths() {
@@ -467,7 +424,6 @@ mod tests {
             name: "yoshuawuyts:fetch".into(),
             version: "0.1.0".into(),
             registry: "ghcr.io/a".into(),
-            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,

--- a/crates/component-manifest/src/package.rs
+++ b/crates/component-manifest/src/package.rs
@@ -75,7 +75,8 @@ impl From<PackageKind> for PackageType {
 /// [package]
 /// name = "my-org:my-component"
 /// version = "0.1.0"
-/// registry_ref = "ghcr.io/my-org/my-component"
+/// registry = "ghcr.io/my-org"
+/// repository = "my-component"
 /// kind = "component"
 /// file = "build/my-component.wasm"
 /// description = "An example component"
@@ -85,7 +86,8 @@ impl From<PackageKind> for PackageType {
 /// let pkg = manifest.package.expect("package section");
 /// assert_eq!(pkg.kind, PackageKind::Component);
 /// assert_eq!(pkg.version, "0.1.0");
-/// assert_eq!(pkg.registry_ref, "ghcr.io/my-org/my-component");
+/// assert_eq!(pkg.registry, "ghcr.io/my-org");
+/// assert_eq!(pkg.repository, "my-component");
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[must_use]
@@ -97,15 +99,25 @@ pub struct Package {
     /// During publish this version is the single source of truth: WIT
     /// package decls are stamped with it, and it becomes the OCI tag.
     pub version: String,
-    /// The fully-formed OCI repository reference this package is
-    /// published to, **without** a tag — for example
-    /// `ghcr.io/yoshuawuyts/fetch`. The published reference is
-    /// `<registry_ref>:<version>`.
+    /// The OCI registry base this package is published under, for
+    /// example `ghcr.io/webassembly`. This is the same value recorded as
+    /// `registry` in the registry's `registry/<namespace>.toml` entry.
     ///
-    /// There is intentionally no default and no shorthand: every
-    /// manifest must spell out the full destination so that publishing
-    /// is fully reproducible from the manifest alone.
-    pub registry_ref: String,
+    /// Combined with [`repository`](Self::repository), the full OCI
+    /// location is `<registry>/<repository>` and the published reference
+    /// is `<registry>/<repository>:<version>`. There is intentionally no
+    /// default and no shorthand: every manifest spells out its full
+    /// destination so that publishing is fully reproducible from the
+    /// manifest alone.
+    pub registry: String,
+    /// The OCI repository (catalog) path for this package within its
+    /// registry, for example `wasi/http`. This is the same value
+    /// recorded as `repository` in the registry's
+    /// `registry/<namespace>.toml` entry.
+    ///
+    /// This is the OCI repository path, **not** a source-code URL; use
+    /// [`source`](Self::source) for the project's source repository.
+    pub repository: String,
     /// What kind of artifact this manifest describes.
     pub kind: PackageKind,
     /// Path to the compiled component artifact, relative to the manifest
@@ -140,21 +152,6 @@ pub struct Package {
     /// `Name <email>`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub authors: Vec<String>,
-    /// Catalog path for this package within its namespace's OCI registry,
-    /// e.g. `wasi/http`.
-    ///
-    /// This is the `repository` value recorded in the registry's
-    /// `registry/<namespace>.toml` entry. The package's full OCI location is
-    /// `<namespace registry base>/<registry_repository>`. `component registry
-    /// publish` requires this to equal [`registry_ref`](Self::registry_ref) and
-    /// derives the namespace's registry base by stripping this path from the
-    /// end of `registry_ref`; note that [`Package::validate()`](Self::validate)
-    /// does not check this invariant.
-    ///
-    /// Optional: only needed to register the package with the component
-    /// registry via `component registry publish`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub registry_repository: Option<String>,
 }
 
 /// Errors produced when validating a [`Package`] section.
@@ -174,8 +171,10 @@ pub enum PackageError {
     },
     /// The `name` field is empty.
     EmptyName,
-    /// The `registry_ref` field is empty.
-    EmptyRegistryRef,
+    /// The `registry` field is empty.
+    EmptyRegistry,
+    /// The `repository` field is empty.
+    EmptyRepository,
 }
 
 impl std::fmt::Display for PackageError {
@@ -194,8 +193,11 @@ impl std::fmt::Display for PackageError {
                 "[package] version '{version}' is not a valid semver: {reason}"
             ),
             PackageError::EmptyName => write!(f, "[package] name must not be empty"),
-            PackageError::EmptyRegistryRef => {
-                write!(f, "[package] registry_ref must not be empty")
+            PackageError::EmptyRegistry => {
+                write!(f, "[package] registry must not be empty")
+            }
+            PackageError::EmptyRepository => {
+                write!(f, "[package] repository must not be empty")
             }
         }
     }
@@ -238,12 +240,16 @@ impl Package {
     /// * `kind` and `file`/`wit` disagree.
     /// * `version` is not a valid semver string.
     /// * `name` is empty.
+    /// * `registry` or `repository` is empty.
     pub fn validate(&self) -> Result<(), PackageError> {
         if self.name.is_empty() {
             return Err(PackageError::EmptyName);
         }
-        if self.registry_ref.is_empty() {
-            return Err(PackageError::EmptyRegistryRef);
+        if self.registry.is_empty() {
+            return Err(PackageError::EmptyRegistry);
+        }
+        if self.repository.is_empty() {
+            return Err(PackageError::EmptyRepository);
         }
         match self.kind {
             PackageKind::Component if self.wit.is_some() => {
@@ -274,7 +280,8 @@ mod tests {
             [package]
             name = "yoshuawuyts:fetch"
             version = "0.1.0"
-            registry_ref = "ghcr.io/yoshuawuyts/fetch"
+            registry = "ghcr.io/yoshuawuyts"
+            repository = "fetch"
             kind = "component"
             file = "build/fetch.wasm"
             description = "Tiny HTTP fetch helper"
@@ -284,7 +291,8 @@ mod tests {
         let manifest: Manifest = toml::from_str(toml).expect("parse");
         let pkg = manifest.package.expect("package");
         assert_eq!(pkg.name, "yoshuawuyts:fetch");
-        assert_eq!(pkg.registry_ref, "ghcr.io/yoshuawuyts/fetch");
+        assert_eq!(pkg.registry, "ghcr.io/yoshuawuyts");
+        assert_eq!(pkg.repository, "fetch");
         assert_eq!(pkg.kind, PackageKind::Component);
         assert_eq!(
             pkg.file.as_deref(),
@@ -302,14 +310,16 @@ mod tests {
             [package]
             name = "wasi:logging"
             version = "1.2.3"
-            registry_ref = "ghcr.io/yoshuawuyts/fetch"
+            registry = "ghcr.io/yoshuawuyts"
+            repository = "fetch"
             kind = "interface"
             wit = "wit"
         "#;
         let manifest: Manifest = toml::from_str(toml).expect("parse");
         let pkg = manifest.package.expect("package");
         assert_eq!(pkg.kind, PackageKind::Interface);
-        assert_eq!(pkg.registry_ref, "ghcr.io/yoshuawuyts/fetch");
+        assert_eq!(pkg.registry, "ghcr.io/yoshuawuyts");
+        assert_eq!(pkg.repository, "fetch");
         pkg.validate().expect("valid");
     }
 
@@ -327,7 +337,8 @@ mod tests {
         let pkg = Package {
             name: "a:b".into(),
             version: "0.1.0".into(),
-            registry_ref: "ghcr.io/a/b".into(),
+            registry: "ghcr.io/a".into(),
+            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: Some(PathBuf::from("wit")),
@@ -337,7 +348,6 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::ComponentWithWit));
     }
@@ -348,7 +358,8 @@ mod tests {
         let pkg = Package {
             name: "a:b".into(),
             version: "0.1.0".into(),
-            registry_ref: "ghcr.io/a/b".into(),
+            registry: "ghcr.io/a".into(),
+            repository: "b".into(),
             kind: PackageKind::Interface,
             file: Some(PathBuf::from("x.wasm")),
             wit: None,
@@ -358,7 +369,6 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::InterfaceWithFile));
     }
@@ -369,7 +379,8 @@ mod tests {
         let pkg = Package {
             name: "a:b".into(),
             version: "not-a-version".into(),
-            registry_ref: "ghcr.io/a/b".into(),
+            registry: "ghcr.io/a".into(),
+            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -379,7 +390,6 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: None,
         };
         assert!(matches!(
             pkg.validate(),
@@ -393,7 +403,8 @@ mod tests {
         let pkg = Package {
             name: String::new(),
             version: "0.1.0".into(),
-            registry_ref: "ghcr.io/a/b".into(),
+            registry: "ghcr.io/a".into(),
+            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -403,18 +414,18 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::EmptyName));
     }
 
-    // r[verify manifest.package.empty-registry-ref]
+    // r[verify manifest.package.empty-registry]
     #[test]
-    fn empty_registry_ref_is_rejected() {
+    fn empty_registry_is_rejected() {
         let pkg = Package {
             name: "a:b".into(),
             version: "0.1.0".into(),
-            registry_ref: String::new(),
+            registry: String::new(),
+            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -424,9 +435,29 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: None,
         };
-        assert_eq!(pkg.validate(), Err(PackageError::EmptyRegistryRef));
+        assert_eq!(pkg.validate(), Err(PackageError::EmptyRegistry));
+    }
+
+    // r[verify manifest.package.empty-repository]
+    #[test]
+    fn empty_repository_is_rejected() {
+        let pkg = Package {
+            name: "a:b".into(),
+            version: "0.1.0".into(),
+            registry: "ghcr.io/a".into(),
+            repository: String::new(),
+            kind: PackageKind::Component,
+            file: None,
+            wit: None,
+            description: None,
+            source: None,
+            homepage: None,
+            documentation: None,
+            license: None,
+            authors: vec![],
+        };
+        assert_eq!(pkg.validate(), Err(PackageError::EmptyRepository));
     }
 
     // r[verify manifest.package.default-paths]
@@ -435,7 +466,8 @@ mod tests {
         let pkg = Package {
             name: "yoshuawuyts:fetch".into(),
             version: "0.1.0".into(),
-            registry_ref: "ghcr.io/a/b".into(),
+            registry: "ghcr.io/a".into(),
+            repository: "b".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -445,7 +477,6 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
-            registry_repository: None,
         };
         assert_eq!(pkg.artifact_path(), PathBuf::from("build/fetch.wasm"));
 

--- a/crates/component-manifest/src/package.rs
+++ b/crates/component-manifest/src/package.rs
@@ -145,10 +145,11 @@ pub struct Package {
     ///
     /// This is the `repository` value recorded in the registry's
     /// `registry/<namespace>.toml` entry. The package's full OCI location is
-    /// `<namespace registry base>/<registry_repository>`, which must equal
-    /// [`registry_ref`](Self::registry_ref); `component registry publish`
+    /// `<namespace registry base>/<registry_repository>`. `component registry
+    /// publish` requires this to equal [`registry_ref`](Self::registry_ref) and
     /// derives the namespace's registry base by stripping this path from the
-    /// end of `registry_ref`.
+    /// end of `registry_ref`; note that [`Package::validate()`](Self::validate)
+    /// does not check this invariant.
     ///
     /// Optional: only needed to register the package with the component
     /// registry via `component registry publish`.

--- a/crates/component-manifest/src/package.rs
+++ b/crates/component-manifest/src/package.rs
@@ -140,6 +140,20 @@ pub struct Package {
     /// `Name <email>`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub authors: Vec<String>,
+    /// Catalog path for this package within its namespace's OCI registry,
+    /// e.g. `wasi/http`.
+    ///
+    /// This is the `repository` value recorded in the registry's
+    /// `registry/<namespace>.toml` entry. The package's full OCI location is
+    /// `<namespace registry base>/<registry_repository>`, which must equal
+    /// [`registry_ref`](Self::registry_ref); `component registry publish`
+    /// derives the namespace's registry base by stripping this path from the
+    /// end of `registry_ref`.
+    ///
+    /// Optional: only needed to register the package with the component
+    /// registry via `component registry publish`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry_repository: Option<String>,
 }
 
 /// Errors produced when validating a [`Package`] section.
@@ -322,6 +336,7 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
+            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::ComponentWithWit));
     }
@@ -342,6 +357,7 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
+            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::InterfaceWithFile));
     }
@@ -362,6 +378,7 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
+            registry_repository: None,
         };
         assert!(matches!(
             pkg.validate(),
@@ -385,6 +402,7 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
+            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::EmptyName));
     }
@@ -405,6 +423,7 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
+            registry_repository: None,
         };
         assert_eq!(pkg.validate(), Err(PackageError::EmptyRegistryRef));
     }
@@ -425,6 +444,7 @@ mod tests {
             documentation: None,
             license: None,
             authors: vec![],
+            registry_repository: None,
         };
         assert_eq!(pkg.artifact_path(), PathBuf::from("build/fetch.wasm"));
 

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -1709,8 +1709,8 @@ impl Manager {
     /// via [`crate::publish::build_wit_package`] (which stamps the
     /// manifest version onto the WIT package decl).
     ///
-    /// The target registry comes from the manifest's
-    /// `[package].registry_ref` field — there is no implicit default.
+    /// The target registry comes from the manifest's `[package].registry`
+    /// and `[package].repository` fields — there is no implicit default.
     pub async fn publish(
         &self,
         manifest: &component_manifest::Manifest,

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -1710,7 +1710,7 @@ impl Manager {
     /// manifest version onto the WIT package decl).
     ///
     /// The target registry comes from the manifest's `[package].registry`
-    /// and `[package].repository` fields — there is no implicit default.
+    /// field (the full OCI location) — there is no implicit default.
     pub async fn publish(
         &self,
         manifest: &component_manifest::Manifest,

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -893,6 +893,19 @@ impl Manager {
         }
     }
 
+    /// Look up a known package by its WIT name (`namespace:name`) in the
+    /// local index, returning `None` when no matching package is indexed.
+    ///
+    /// The lookup is an exact `(wit_namespace, wit_name)` match with a fuzzy
+    /// repository fallback, so callers that need a strict identity match
+    /// should verify the returned package's `wit_namespace`/`wit_name`.
+    pub async fn find_known_package_by_wit_name(
+        &self,
+        wit_name: &str,
+    ) -> anyhow::Result<Option<KnownPackage>> {
+        self.store.search_known_package_by_wit_name(wit_name).await
+    }
+
     /// Index a package from the registry, also extracting WIT dependency
     /// metadata from the package's wasm layer.
     ///

--- a/crates/component-package-manager/src/publish/mod.rs
+++ b/crates/component-package-manager/src/publish/mod.rs
@@ -293,7 +293,7 @@ mod tests {
 
     // r[verify publish.reference.resolves]
     #[test]
-    fn reference_is_built_from_registry_and_repository() {
+    fn reference_is_built_from_registry_and_version() {
         let pkg = sample_pkg();
         let r = resolve_reference(&pkg).expect("ok");
         assert_eq!(r.registry(), "ghcr.io");

--- a/crates/component-package-manager/src/publish/mod.rs
+++ b/crates/component-package-manager/src/publish/mod.rs
@@ -162,16 +162,17 @@ pub fn build_annotations(pkg: &Package, created: DateTime<Utc>) -> BTreeMap<Stri
 
 /// Resolve the OCI reference for a given `[package]` section.
 ///
-/// The reference is built directly from `[package].registry_ref` and
-/// `[package].version` as `<registry_ref>:<version>` — `registry_ref`
-/// is expected to be a fully-formed repository URI (host + path),
-/// e.g. `ghcr.io/yoshuawuyts/fetch`.
+/// The reference is built from `[package].registry`,
+/// `[package].repository`, and `[package].version` as
+/// `<registry>/<repository>:<version>` — `registry` is the OCI registry
+/// base (host + optional path, e.g. `ghcr.io/yoshuawuyts`) and
+/// `repository` is the catalog path within it (e.g. `yoshuawuyts/fetch`).
 ///
 /// # Errors
 ///
 /// Returns an error when the resulting reference cannot be parsed.
 pub fn resolve_reference(pkg: &Package) -> Result<Reference> {
-    let s = format!("{}:{}", pkg.registry_ref, pkg.version);
+    let s = format!("{}/{}:{}", pkg.registry, pkg.repository, pkg.version);
     s.parse::<Reference>()
         .with_context(|| format!("failed to parse OCI reference `{s}`"))
 }
@@ -197,8 +198,9 @@ pub fn require_package(manifest: &Manifest) -> Result<&Package> {
 ///
 /// `manifest_dir` is the directory containing `wasm.toml` (used to
 /// resolve relative paths in `[package].file` / `[package].wit`). The
-/// target reference is read from the manifest's `[package].registry_ref`
-/// and `[package].version` fields — there is no implicit default.
+/// target reference is read from the manifest's `[package].registry`,
+/// `[package].repository`, and `[package].version` fields — there is no
+/// implicit default.
 pub async fn plan(manifest: &Manifest, manifest_dir: &Path) -> Result<PublishPlan> {
     let pkg = require_package(manifest)?;
     let reference = resolve_reference(pkg)?;
@@ -224,7 +226,8 @@ mod tests {
         Package {
             name: "yoshuawuyts:fetch".into(),
             version: "0.1.0".into(),
-            registry_ref: "ghcr.io/yoshuawuyts/fetch".into(),
+            registry: "ghcr.io/yoshuawuyts".into(),
+            repository: "fetch".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,
@@ -234,7 +237,6 @@ mod tests {
             documentation: Some("https://docs.example.com".into()),
             license: Some("Apache-2.0".into()),
             authors: vec!["Yosh <yosh@example.com>".into()],
-            registry_repository: None,
         }
     }
 
@@ -295,7 +297,7 @@ mod tests {
 
     // r[verify publish.reference.resolves]
     #[test]
-    fn reference_is_built_from_registry_ref_and_version() {
+    fn reference_is_built_from_registry_and_repository() {
         let pkg = sample_pkg();
         let r = resolve_reference(&pkg).expect("ok");
         assert_eq!(r.registry(), "ghcr.io");
@@ -307,7 +309,7 @@ mod tests {
     #[test]
     fn reference_rejects_unparseable_ref() {
         let mut pkg = sample_pkg();
-        pkg.registry_ref = "not a valid ref".into();
+        pkg.registry = "not a valid ref".into();
         assert!(resolve_reference(&pkg).is_err());
     }
 

--- a/crates/component-package-manager/src/publish/mod.rs
+++ b/crates/component-package-manager/src/publish/mod.rs
@@ -162,17 +162,15 @@ pub fn build_annotations(pkg: &Package, created: DateTime<Utc>) -> BTreeMap<Stri
 
 /// Resolve the OCI reference for a given `[package]` section.
 ///
-/// The reference is built from `[package].registry`,
-/// `[package].repository`, and `[package].version` as
-/// `<registry>/<repository>:<version>` — `registry` is the OCI registry
-/// base (host + optional path, e.g. `ghcr.io/yoshuawuyts`) and
-/// `repository` is the catalog path within it (e.g. `yoshuawuyts/fetch`).
+/// The reference is built from `[package].registry` and
+/// `[package].version` as `<registry>:<version>` — `registry` is the full
+/// OCI location (host + path, no tag), e.g. `ghcr.io/yoshuawuyts/fetch`.
 ///
 /// # Errors
 ///
 /// Returns an error when the resulting reference cannot be parsed.
 pub fn resolve_reference(pkg: &Package) -> Result<Reference> {
-    let s = format!("{}/{}:{}", pkg.registry, pkg.repository, pkg.version);
+    let s = format!("{}:{}", pkg.registry, pkg.version);
     s.parse::<Reference>()
         .with_context(|| format!("failed to parse OCI reference `{s}`"))
 }
@@ -198,9 +196,8 @@ pub fn require_package(manifest: &Manifest) -> Result<&Package> {
 ///
 /// `manifest_dir` is the directory containing `wasm.toml` (used to
 /// resolve relative paths in `[package].file` / `[package].wit`). The
-/// target reference is read from the manifest's `[package].registry`,
-/// `[package].repository`, and `[package].version` fields — there is no
-/// implicit default.
+/// target reference is read from the manifest's `[package].registry` and
+/// `[package].version` fields — there is no implicit default.
 pub async fn plan(manifest: &Manifest, manifest_dir: &Path) -> Result<PublishPlan> {
     let pkg = require_package(manifest)?;
     let reference = resolve_reference(pkg)?;
@@ -226,8 +223,7 @@ mod tests {
         Package {
             name: "yoshuawuyts:fetch".into(),
             version: "0.1.0".into(),
-            registry: "ghcr.io/yoshuawuyts".into(),
-            repository: "fetch".into(),
+            registry: "ghcr.io/yoshuawuyts/fetch".into(),
             kind: PackageKind::Component,
             file: None,
             wit: None,

--- a/crates/component-package-manager/src/publish/mod.rs
+++ b/crates/component-package-manager/src/publish/mod.rs
@@ -234,6 +234,7 @@ mod tests {
             documentation: Some("https://docs.example.com".into()),
             license: Some("Apache-2.0".into()),
             authors: vec!["Yosh <yosh@example.com>".into()],
+            registry_repository: None,
         }
     }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -126,6 +126,46 @@ annotations populated from the `[package]` section.
 **Note**: You must be authenticated to push packages. See [Authentication](authentication.md) for details.
 
 
+### Submitting a Registry Entry
+
+Publishing an artifact uploads the bytes to an OCI registry, but it does not
+list the package in the meta-registry's searchable index. To do that, open a
+**Registry entry** issue. Automation opens a pull request that adds the entry to
+the matching `registry/<namespace>.toml`. Entries in an existing namespace are
+merged automatically; creating a brand new namespace is flagged for manual
+review.
+
+To prefill that issue from the command line, run `component registry publish`
+from a project that has a `[package]` section in its `wasm.toml`:
+
+```bash
+component registry publish
+```
+
+It reads the package's `name`, `kind`, and `registry` from `wasm.toml`, checks
+whether the package is already in the registry, and (if not) opens the
+**Registry entry** issue form in your browser with the fields already filled in.
+If the package already exists in the registry, it reports that and exits without
+opening an issue. The issue URL is always printed to stdout; pass `--no-open` to
+skip launching the browser, and `--manifest-path <dir>` to point at a project
+other than the current directory.
+
+The relevant `[package]` fields look like this:
+
+```toml
+[package]
+name = "wasi:http"                          # namespace:package
+kind = "interface"                          # or "component"
+version = "0.2.0"
+registry = "ghcr.io/webassembly/wasi/http"  # full OCI location, no tag
+```
+
+`registry` is the full OCI location (host + path). `component publish` pushes to
+`<registry>:<version>`. When opening a registry-entry issue, the namespace base
+(`ghcr.io/webassembly`) and catalog path (`wasi/http`) are derived from it to
+match the registry entry's `registry` and `repository` fields.
+
+
 ### Listing Packages
 
 View all locally stored packages:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,7 +96,7 @@ For an interface package, point `wit` at the WIT directory:
 name = "wasi:logging"
 kind = "interface"
 version = "1.0.0"
-registry = "ghcr.io/wasi/logging"
+registry = "ghcr.io/webassembly/wasi/logging"
 # Path to the WIT directory, relative to the manifest. Defaults to "wit".
 wit = "wit"
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,17 +71,15 @@ default and no shorthand — so publishing is fully reproducible from
 # Package identity in `namespace:name` form. Used as the OCI artifact
 # title and (for interfaces) stamped onto WIT package decls.
 name = "yoshuawuyts:fetch"
+# What kind of artifact this manifest publishes: "component" or "interface".
+kind = "component"
 # Semver version. The single source of truth: WIT files must not
 # declare their own `@version` — the publisher stamps this onto every
 # top-level `package` decl during build. Becomes the OCI tag.
 version = "0.1.0"
-# OCI registry base (host + optional path), without a repository or tag.
-# The published reference is `<registry>/<repository>:<version>`.
-registry = "ghcr.io/yoshuawuyts"
-# Catalog path within the registry (the namespace/package location).
-repository = "yoshuawuyts/fetch"
-# What kind of artifact this manifest publishes: "component" or "interface".
-kind = "component"
+# Full OCI location (host + path), without a tag. The published reference
+# is `<registry>:<version>`.
+registry = "ghcr.io/yoshuawuyts/fetch"
 # Path to the compiled component, relative to the manifest directory.
 # Defaults to `build/<name-after-colon>.wasm` if omitted.
 file = "build/fetch.wasm"
@@ -96,10 +94,9 @@ For an interface package, point `wit` at the WIT directory:
 ```toml
 [package]
 name = "wasi:logging"
-version = "1.0.0"
-registry = "ghcr.io/wasi"
-repository = "wasi/logging"
 kind = "interface"
+version = "1.0.0"
+registry = "ghcr.io/wasi/logging"
 # Path to the WIT directory, relative to the manifest. Defaults to "wit".
 wit = "wit"
 ```
@@ -117,7 +114,7 @@ component publish --dry-run
 Publish for real:
 
 ```bash
-component publish                       # uses [package].registry + repository
+component publish                       # uses [package].registry
 component publish --file build/x.wasm   # override the artifact path
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -75,9 +75,11 @@ name = "yoshuawuyts:fetch"
 # declare their own `@version` — the publisher stamps this onto every
 # top-level `package` decl during build. Becomes the OCI tag.
 version = "0.1.0"
-# Fully-formed OCI repository reference (host + path), without a tag.
-# The published reference is `<registry_ref>:<version>`.
-registry_ref = "ghcr.io/yoshuawuyts/fetch"
+# OCI registry base (host + optional path), without a repository or tag.
+# The published reference is `<registry>/<repository>:<version>`.
+registry = "ghcr.io/yoshuawuyts"
+# Catalog path within the registry (the namespace/package location).
+repository = "yoshuawuyts/fetch"
 # What kind of artifact this manifest publishes: "component" or "interface".
 kind = "component"
 # Path to the compiled component, relative to the manifest directory.
@@ -95,7 +97,8 @@ For an interface package, point `wit` at the WIT directory:
 [package]
 name = "wasi:logging"
 version = "1.0.0"
-registry_ref = "ghcr.io/wasi/logging"
+registry = "ghcr.io/wasi"
+repository = "wasi/logging"
 kind = "interface"
 # Path to the WIT directory, relative to the manifest. Defaults to "wit".
 wit = "wit"
@@ -114,7 +117,7 @@ component publish --dry-run
 Publish for real:
 
 ```bash
-component publish                       # uses [package].registry_ref
+component publish                       # uses [package].registry + repository
 component publish --file build/x.wasm   # override the artifact path
 ```
 


### PR DESCRIPTION
## Why

After the issue-driven registry automation landed (#389), the natural next step is a CLI affordance that opens the "Registry entry" issue for you. Rather than make the user retype metadata they already declared, `component registry publish` reads it straight from the project's `wasm.toml` and only bothers you when the package is actually missing from the registry.

## What

`component registry publish` now:

- Reads the `[package]` section of `wasm.toml` (no positional args or `--kind`/`--repository`/`--registry` flags anymore).
- Derives the namespace, package name, kind, registry repository path, and registry base from the manifest.
- Checks the local registry index for an existing entry by exact WIT identity. If the package is already registered, it does nothing. Otherwise it opens (or, with `--no-open`, prints) the prefilled issue URL.

Flags are now just `--manifest-path` (default `.`), `--repo` (default `yoshuawuyts/component-registry`), and `--no-open`.

## Manifest change

This required teaching `wasm.toml` to track the package's registry location. A new optional `registry_repository` field is added to `[package]`:

- The OCI repository path within a namespace's registry is not derivable from the package name. Existing entries use varied paths (`wasi/http`, `components/http-server`, `wasm-pkg/.../azure-client`), so the manifest has to carry it.
- The namespace's registry base is derived by stripping `registry_repository` off the end of `registry_ref`, and the two are required to agree. This guarantees a registry entry never points at a different OCI location than `component publish` pushes to.

The field is serde-optional with `skip_serializing_if`, so existing manifests stay valid.

## Notes for review

- The existence check uses exact WIT identity (namespace + package), with a fuzzy repository fallback whose false positives are rejected, so a near-miss never silently suppresses the issue.
- The lookup is best-effort: on an index/lookup error it warns loudly and still opens the issue, and it respects `--offline` (empty index, opens the issue).
- `registry_ref` is validated to be tag-less and digest-less.

## Testing

- `cargo xtask test` passes (fmt, clippy, test, sql check, readme check).
- Unit tests cover URL building, validation, and the existence check.
- Manual runs verified: a valid new package prints the correct URL; missing `registry_repository`, a ref/repo mismatch, and a missing `[package]` all error helpfully; and a live lookup of `wasi:clocks` correctly reports it is already in the registry.

> Note: this branch's latest commit is unsigned because the local 1Password SSH signing agent was unavailable at commit time; the squash-merge commit will be signed by GitHub.