### PR TITLE
registry-entry: auto close/reopen auto-merge PRs to trigger CI

### DIFF
--- a/.github/workflows/registry-entry.yml
+++ b/.github/workflows/registry-entry.yml
@@ -91,6 +91,7 @@ jobs:
           KIND: ${{ steps.process.outputs.kind }}
           PACKAGE: ${{ steps.process.outputs.package }}
           MESSAGE: ${{ steps.process.outputs.message }}
+          AUTOMERGE_PAT: ${{ secrets.AUTOMERGE_PAT }}
         run: |
           set -euo pipefail
           BRANCH="registry-entry/issue-${ISSUE}"
@@ -127,6 +128,21 @@ jobs:
             gh pr edit "$PR_URL" --add-label needs-namespace-review
           else
             gh pr edit "$PR_URL" --add-label auto-merge
+
+            # GitHub does not run CI for pull requests opened by the default
+            # GITHUB_TOKEN, so close and immediately reopen the PR to kick the
+            # checks off (the same close/reopen dance we used to do by hand).
+            # The reopen must come from a real (non-GITHUB_TOKEN) identity,
+            # otherwise the reopened event is also suppressed and CI still does
+            # not run -- hence the dedicated AUTOMERGE_PAT below. Closing a PR
+            # cancels auto-merge, so it is re-enabled afterwards.
+            if [ -n "$AUTOMERGE_PAT" ]; then
+              GH_TOKEN="$AUTOMERGE_PAT" gh pr close "$PR_URL"
+              GH_TOKEN="$AUTOMERGE_PAT" gh pr reopen "$PR_URL"
+            else
+              echo "::warning::AUTOMERGE_PAT is not set; skipping close/reopen. CI will not run until the PR is closed and reopened by a real user."
+            fi
+
             gh pr merge "$PR_URL" --squash --auto \
               || echo "::warning::Could not enable auto-merge; merge $PR_URL manually"
           fi


### PR DESCRIPTION
## Why

Pull requests opened by the registry-entry automation use the default `GITHUB_TOKEN`. GitHub deliberately does not start new workflow runs (like CI) from events caused by `GITHUB_TOKEN`, so the auto-merge PRs it creates never got CI and we had to close and reopen them by hand to kick the checks off (see #391).

## What

In `.github/workflows/registry-entry.yml`, the existing-namespace (auto-merge) path now automates that close/reopen dance: after labelling the PR `auto-merge`, it closes and immediately reopens the PR, then re-enables auto-merge afterwards.

Two non-obvious details worth a careful look:

- **The reopen uses a dedicated `AUTOMERGE_PAT` secret, not `GITHUB_TOKEN`.** If the reopen came from `GITHUB_TOKEN` the reopened event would be suppressed too and CI still would not run, defeating the purpose. The PAT needs `pull_requests: write` (plus `contents: read`) on this repo.
- **Closing a PR cancels auto-merge**, so auto-merge is re-enabled after the reopen.

If `AUTOMERGE_PAT` is not configured, the step is skipped with a warning rather than failing, so the workflow degrades gracefully.

## Follow-up required

Create a repo secret named `AUTOMERGE_PAT` (a PAT, fine-grained token, or GitHub App token with `pull_requests: write` and `contents: read`). Without it the close/reopen is skipped and CI will not auto-trigger.