### PR TITLE
Fix silent integer truncation and de-duplicate install variants

### DIFF
--- a/crates/component-package-manager/src/convert.rs
+++ b/crates/component-package-manager/src/convert.rs
@@ -1,0 +1,74 @@
+//! Checked integer conversions for size and index metadata.
+//!
+//! These helpers replace silent saturating conversions (e.g.
+//! `i64::try_from(len).unwrap_or(i64::MAX)`) that would corrupt size or layer
+//! index metadata on overflow. Each helper surfaces a descriptive error via
+//! `anyhow` instead.
+
+use anyhow::{Context as _, Result};
+
+/// Convert a layer position/index (`usize`) into the `i32` the database schema
+/// uses, returning an error instead of silently saturating on overflow.
+pub(crate) fn index_to_i32(index: usize) -> Result<i32> {
+    i32::try_from(index).with_context(|| format!("layer index {index} exceeds i32::MAX"))
+}
+
+/// Convert a byte length (`usize`) into the `i64` the database schema uses for
+/// layer/manifest sizes, returning an error instead of silently saturating.
+pub(crate) fn len_to_i64(len: usize) -> Result<i64> {
+    i64::try_from(len).with_context(|| format!("byte length {len} exceeds i64::MAX"))
+}
+
+/// Convert an aggregate size (`u64`) into the `i64` the database schema uses,
+/// returning an error instead of silently saturating on overflow.
+pub(crate) fn size_to_i64(size: u64) -> Result<i64> {
+    i64::try_from(size).with_context(|| format!("size {size} exceeds i64::MAX"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_to_i32_in_range() {
+        assert_eq!(index_to_i32(0).unwrap(), 0);
+        assert_eq!(index_to_i32(42).unwrap(), 42);
+        assert_eq!(
+            index_to_i32(i32::MAX as usize).unwrap(),
+            i32::MAX,
+            "the largest valid index must round-trip"
+        );
+    }
+
+    #[test]
+    fn index_to_i32_overflow_errors() {
+        let too_big = i32::MAX as usize + 1;
+        let err = index_to_i32(too_big).expect_err("overflow must be rejected");
+        assert!(
+            err.to_string().contains("exceeds i32::MAX"),
+            "error should carry overflow context, got: {err}"
+        );
+    }
+
+    #[test]
+    fn len_to_i64_in_range() {
+        assert_eq!(len_to_i64(0).unwrap(), 0);
+        assert_eq!(len_to_i64(1024).unwrap(), 1024);
+    }
+
+    #[test]
+    fn size_to_i64_in_range() {
+        assert_eq!(size_to_i64(0).unwrap(), 0);
+        assert_eq!(size_to_i64(i64::MAX as u64).unwrap(), i64::MAX);
+    }
+
+    #[test]
+    fn size_to_i64_overflow_errors() {
+        let too_big = i64::MAX as u64 + 1;
+        let err = size_to_i64(too_big).expect_err("overflow must be rejected");
+        assert!(
+            err.to_string().contains("exceeds i64::MAX"),
+            "error should carry overflow context, got: {err}"
+        );
+    }
+}

--- a/crates/component-package-manager/src/convert.rs
+++ b/crates/component-package-manager/src/convert.rs
@@ -56,6 +56,18 @@ mod tests {
         assert_eq!(len_to_i64(1024).unwrap(), 1024);
     }
 
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn len_to_i64_overflow_errors() {
+        // `usize` only exceeds `i64::MAX` on 64-bit targets.
+        let too_big = i64::MAX as usize + 1;
+        let err = len_to_i64(too_big).expect_err("overflow must be rejected");
+        assert!(
+            err.to_string().contains("exceeds i64::MAX"),
+            "error should carry overflow context, got: {err}"
+        );
+    }
+
     #[test]
     fn size_to_i64_in_range() {
         assert_eq!(size_to_i64(0).unwrap(), 0);

--- a/crates/component-package-manager/src/lib.rs
+++ b/crates/component-package-manager/src/lib.rs
@@ -41,6 +41,7 @@
 #[cfg(feature = "compose")]
 pub mod compose;
 mod config;
+mod convert;
 mod credential_helper;
 /// Core manager functionality for pulling, installing, and listing packages.
 pub mod manager;

--- a/crates/component-package-manager/src/manager/logic.rs
+++ b/crates/component-package-manager/src/manager/logic.rs
@@ -73,6 +73,8 @@ pub fn vendor_filename(name: &str, version: Option<&str>) -> String {
 #[must_use]
 pub fn should_sync(last_synced_epoch: Option<i64>, sync_interval: u64, now_epoch: i64) -> bool {
     match last_synced_epoch {
+        // `sync_interval` is a config-supplied second count; saturating to
+        // `i64::MAX` only makes the threshold unreachable, never syncing early.
         Some(last) => now_epoch - last >= i64::try_from(sync_interval).unwrap_or(i64::MAX),
         None => true,
     }

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -444,9 +444,11 @@ impl Manager {
     ) -> anyhow::Result<InstallResult> {
         use crate::oci::filter_wasm_layers;
 
+        // `Box::pin` keeps the (large) pull futures on the heap so this shared
+        // method's own future stays small enough to satisfy `clippy::large_futures`.
         let pull_result = match progress_tx {
-            Some(tx) => self.pull_with_progress(reference.clone(), tx).await?,
-            None => self.pull(reference.clone()).await?,
+            Some(tx) => Box::pin(self.pull_with_progress(reference.clone(), tx)).await?,
+            None => Box::pin(self.pull(reference.clone())).await?,
         };
 
         let mut vendored_files = Vec::new();

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -434,7 +434,7 @@ impl Manager {
     /// [`install_with_progress`](Self::install_with_progress).
     ///
     /// When `progress_tx` is `Some`, layers are pulled with per-layer progress
-    /// reporting and an [`ProgressEvent::InstallComplete`] event is emitted at
+    /// reporting and a [`ProgressEvent::InstallComplete`] event is emitted at
     /// the end; when `None`, the package is pulled without progress reporting.
     async fn install_inner(
         &self,
@@ -464,39 +464,19 @@ impl Manager {
         if let Some(ref manifest) = pull_result.manifest {
             let wasm_layers = filter_wasm_layers(&manifest.layers);
 
-            // Inspect cached wasm layers up-front to learn the WIT package
-            // name; this lets us name the vendored artifact after
-            // `namespace:package@version` rather than the OCI reference.
-            for layer in &wasm_layers {
-                if package_name.is_none() {
-                    self.try_extract_layer_metadata(
-                        &layer.digest,
-                        &mut package_name,
-                        &mut is_component,
-                        &mut dependencies,
-                    )
-                    .await;
-                }
-            }
+            let inspected = self.inspect_wasm_layers(&wasm_layers).await;
+            package_name = inspected.0;
+            is_component = inspected.1;
+            dependencies = inspected.2;
 
             if !wasm_layers.is_empty() {
                 let name = package_name.as_deref().ok_or_else(|| {
                     anyhow::anyhow!("could not determine WIT package name from `{reference}`")
                 })?;
                 let filename = vendor_filename(name, reference.tag());
-
-                for layer in &wasm_layers {
-                    let dest = vendor_dir.join(&filename);
-
-                    // Ensure vendor directory exists
-                    tokio::fs::create_dir_all(vendor_dir).await?;
-
-                    // Remove existing file if present before reflinking
-                    let _ = tokio::fs::remove_file(&dest).await;
-
-                    self.vendor(&layer.digest, &dest).await?;
-                    vendored_files.push(dest);
-                }
+                vendored_files = self
+                    .vendor_wasm_layers(&wasm_layers, vendor_dir, &filename)
+                    .await?;
             }
         }
 
@@ -515,6 +495,61 @@ impl Manager {
             is_component,
             dependencies,
         })
+    }
+
+    /// Inspect cached wasm layers up-front to learn the WIT package name; this
+    /// lets us name the vendored artifact after `namespace:package@version`
+    /// rather than the OCI reference.
+    ///
+    /// Returns the discovered package name, whether the artifact is a component
+    /// (vs. a WIT package), and its dependencies.
+    async fn inspect_wasm_layers(
+        &self,
+        wasm_layers: &[&oci_client::manifest::OciDescriptor],
+    ) -> (Option<String>, bool, Vec<crate::types::DependencyItem>) {
+        let mut package_name = None;
+        let mut is_component = true; // Default to component
+        let mut dependencies = Vec::new();
+
+        for layer in wasm_layers {
+            if package_name.is_none() {
+                self.try_extract_layer_metadata(
+                    &layer.digest,
+                    &mut package_name,
+                    &mut is_component,
+                    &mut dependencies,
+                )
+                .await;
+            }
+        }
+
+        (package_name, is_component, dependencies)
+    }
+
+    /// Reflink each wasm layer into the vendor directory under `filename`,
+    /// returning the vendored file paths.
+    async fn vendor_wasm_layers(
+        &self,
+        wasm_layers: &[&oci_client::manifest::OciDescriptor],
+        vendor_dir: &Path,
+        filename: &str,
+    ) -> anyhow::Result<Vec<std::path::PathBuf>> {
+        let mut vendored_files = Vec::new();
+
+        for layer in wasm_layers {
+            let dest = vendor_dir.join(filename);
+
+            // Ensure vendor directory exists
+            tokio::fs::create_dir_all(vendor_dir).await?;
+
+            // Remove existing file if present before reflinking
+            let _ = tokio::fs::remove_file(&dest).await;
+
+            self.vendor(&layer.digest, &dest).await?;
+            vendored_files.push(dest);
+        }
+
+        Ok(vendored_files)
     }
 
     /// List all stored images and their metadata.

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -240,6 +240,8 @@ impl Manager {
         let size_on_disk: u64 = manifest
             .layers
             .iter()
+            // `max(0)` clamps any negative descriptor size to 0, so the
+            // remaining non-negative `i64` always fits in a `u64`.
             .map(|l| u64::try_from(l.size.max(0)).unwrap_or(0))
             .sum();
 
@@ -252,6 +254,7 @@ impl Manager {
         if result == InsertResult::Inserted {
             // Stream and store each layer individually with progress
             for (index, layer_descriptor) in manifest.layers.iter().enumerate() {
+                // Guarded by `size > 0`, so the positive `i64` always fits `u64`.
                 let total_bytes = if layer_descriptor.size > 0 {
                     Some(u64::try_from(layer_descriptor.size).unwrap_or(0))
                 } else {
@@ -282,6 +285,7 @@ impl Manager {
 
                 while let Some(chunk) = stream.next().await {
                     let chunk = chunk?;
+                    // `usize` always fits in `u64` on supported platforms.
                     bytes_downloaded += u64::try_from(chunk.len()).unwrap_or(0);
                     layer_data.extend_from_slice(&chunk);
 
@@ -304,7 +308,7 @@ impl Manager {
                         &layer_data,
                         image_id,
                         Some(layer_descriptor.media_type.as_str()),
-                        i32::try_from(index).unwrap_or(i32::MAX),
+                        crate::convert::index_to_i32(index)?,
                         layer_descriptor.annotations.as_ref(),
                     )
                     .await?;
@@ -314,6 +318,7 @@ impl Manager {
         } else {
             // Package already cached — show layers as completed
             for (index, layer_descriptor) in manifest.layers.iter().enumerate() {
+                // Guarded by `size > 0`, so the positive `i64` always fits `u64`.
                 let total_bytes = if layer_descriptor.size > 0 {
                     Some(u64::try_from(layer_descriptor.size).unwrap_or(0))
                 } else {
@@ -404,72 +409,7 @@ impl Manager {
         reference: Reference,
         vendor_dir: &Path,
     ) -> anyhow::Result<InstallResult> {
-        use crate::oci::filter_wasm_layers;
-
-        let pull_result = self.pull(reference.clone()).await?;
-
-        let mut vendored_files = Vec::new();
-        let mut package_name = None;
-        let mut is_component = true; // Default to component
-        let mut dependencies = Vec::new();
-
-        // Extract the OCI image.title annotation from the manifest.
-        let oci_title = pull_result
-            .manifest
-            .as_ref()
-            .and_then(|m| m.annotations.as_ref())
-            .and_then(|a| a.get("org.opencontainers.image.title").cloned());
-
-        if let Some(ref manifest) = pull_result.manifest {
-            let wasm_layers = filter_wasm_layers(&manifest.layers);
-
-            // Inspect cached wasm layers up-front to learn the WIT package
-            // name; this lets us name the vendored artifact after
-            // `namespace:package@version` rather than the OCI reference.
-            for layer in &wasm_layers {
-                if package_name.is_none() {
-                    self.try_extract_layer_metadata(
-                        &layer.digest,
-                        &mut package_name,
-                        &mut is_component,
-                        &mut dependencies,
-                    )
-                    .await;
-                }
-            }
-
-            if !wasm_layers.is_empty() {
-                let name = package_name.as_deref().ok_or_else(|| {
-                    anyhow::anyhow!("could not determine WIT package name from `{reference}`")
-                })?;
-                let filename = vendor_filename(name, reference.tag());
-
-                for layer in &wasm_layers {
-                    let dest = vendor_dir.join(&filename);
-
-                    // Ensure vendor directory exists
-                    tokio::fs::create_dir_all(vendor_dir).await?;
-
-                    // Remove existing file if present before reflinking
-                    let _ = tokio::fs::remove_file(&dest).await;
-
-                    self.vendor(&layer.digest, &dest).await?;
-                    vendored_files.push(dest);
-                }
-            }
-        }
-
-        Ok(InstallResult {
-            registry: reference.registry().to_string(),
-            repository: reference.repository().to_string(),
-            tag: reference.tag().map(str::to_string),
-            digest: pull_result.digest,
-            package_name,
-            oci_title,
-            vendored_files,
-            is_component,
-            dependencies,
-        })
+        self.install_inner(reference, vendor_dir, None).await
     }
 
     /// Install a package from the registry with per-layer progress reporting.
@@ -486,11 +426,28 @@ impl Manager {
         vendor_dir: &Path,
         progress_tx: &tokio::sync::mpsc::Sender<ProgressEvent>,
     ) -> anyhow::Result<InstallResult> {
+        self.install_inner(reference, vendor_dir, Some(progress_tx))
+            .await
+    }
+
+    /// Shared implementation for [`install`](Self::install) and
+    /// [`install_with_progress`](Self::install_with_progress).
+    ///
+    /// When `progress_tx` is `Some`, layers are pulled with per-layer progress
+    /// reporting and an [`ProgressEvent::InstallComplete`] event is emitted at
+    /// the end; when `None`, the package is pulled without progress reporting.
+    async fn install_inner(
+        &self,
+        reference: Reference,
+        vendor_dir: &Path,
+        progress_tx: Option<&tokio::sync::mpsc::Sender<ProgressEvent>>,
+    ) -> anyhow::Result<InstallResult> {
         use crate::oci::filter_wasm_layers;
 
-        let pull_result = self
-            .pull_with_progress(reference.clone(), progress_tx)
-            .await?;
+        let pull_result = match progress_tx {
+            Some(tx) => self.pull_with_progress(reference.clone(), tx).await?,
+            None => self.pull(reference.clone()).await?,
+        };
 
         let mut vendored_files = Vec::new();
         let mut package_name = None;
@@ -543,7 +500,9 @@ impl Manager {
             }
         }
 
-        let _ = progress_tx.send(ProgressEvent::InstallComplete).await;
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressEvent::InstallComplete).await;
+        }
 
         Ok(InstallResult {
             registry: reference.registry().to_string(),

--- a/crates/component-package-manager/src/storage/models/mod.rs
+++ b/crates/component-package-manager/src/storage/models/mod.rs
@@ -32,6 +32,8 @@ pub struct Migrations {
 impl Migrations {
     /// Total number of migrations defined.
     pub(crate) fn total_count() -> u32 {
+        // The migration count is a small compile-time list; it cannot overflow
+        // `u32`, so the saturating default is unreachable in practice.
         u32::try_from(component_package_manager_migration::Migrator::migrations().len())
             .unwrap_or(u32::MAX)
     }
@@ -51,6 +53,8 @@ impl Migrations {
         let stmt =
             Statement::from_string(backend, "SELECT COUNT(*) AS count FROM seaql_migrations");
         match Row::find_by_statement(stmt).one(db).await {
+            // The applied-migration count is small and non-negative; treat any
+            // unexpected value as "0 applied".
             Ok(Some(row)) => u32::try_from(row.count).unwrap_or(0),
             _ => 0,
         }

--- a/crates/component-package-manager/src/storage/store.rs
+++ b/crates/component-package-manager/src/storage/store.rs
@@ -2119,6 +2119,7 @@ impl Store {
         let size_on_disk: u64 = image
             .layers
             .iter()
+            // `usize` byte length always fits in `u64` on supported platforms.
             .map(|l| u64::try_from(l.data.len()).unwrap_or(u64::MAX))
             .sum();
 
@@ -2149,7 +2150,7 @@ impl Store {
                 .as_ref()
                 .and_then(|m| m.media_type.as_deref()),
             Some(&manifest_str),
-            Some(i64::try_from(size_on_disk).unwrap_or(i64::MAX)),
+            Some(crate::convert::size_to_i64(size_on_disk)?),
             image
                 .manifest
                 .as_ref()
@@ -2206,7 +2207,7 @@ impl Store {
                     layer_digest,
                     layer_media_type,
                     layer_size.map(|s| s.max(0)),
-                    i32::try_from(idx).unwrap_or(i32::MAX),
+                    crate::convert::index_to_i32(idx)?,
                 )
                 .await?;
 
@@ -2265,7 +2266,7 @@ impl Store {
             digest.unwrap_or("unknown"),
             manifest.media_type.as_deref(),
             Some(&manifest_str),
-            Some(i64::try_from(size_on_disk).unwrap_or(i64::MAX)),
+            Some(crate::convert::size_to_i64(size_on_disk)?),
             manifest.artifact_type.as_deref(),
             Some(manifest.config.media_type.as_str()),
             Some(manifest.config.digest.as_str()),
@@ -2313,7 +2314,7 @@ impl Store {
             manifest_id,
             layer_digest,
             media_type,
-            Some(i64::try_from(data.len()).unwrap_or(i64::MAX)),
+            Some(crate::convert::len_to_i64(data.len())?),
             position,
         )
         .await?;
@@ -2484,6 +2485,8 @@ impl Store {
                 ref_tag: tag,
                 ref_digest: Some(m.digest),
                 manifest,
+                // `size_bytes` is stored as a non-negative count, so reading it
+                // back as `u64` cannot realistically truncate; default to 0.
                 size_on_disk: u64::try_from(m.size_bytes.unwrap_or(0)).unwrap_or(0),
             });
         }
@@ -2775,6 +2778,8 @@ impl Store {
         tag: &str,
         max_age_secs: u64,
     ) -> bool {
+        // A freshness window in seconds; saturating to `i64::MAX` only widens
+        // the window, which is harmless for the freshness check below.
         let max_age = i64::try_from(max_age_secs).unwrap_or(i64::MAX);
         let cutoff = Utc::now() - chrono::Duration::seconds(max_age);
         // Tag is "fresh" iff:


### PR DESCRIPTION
## Why

Several size/index conversions in `component-package-manager` used `try_from(...).unwrap_or(<saturating-default>)`, which silently corrupts metadata on overflow: an oversized layer would be recorded as `i64::MAX` bytes, and an out-of-range layer index would collapse to `i32::MAX`. Separately, `Manager::install` and `install_with_progress` had drifted into ~76 lines of near-identical code differing only in progress reporting, which is easy to let diverge over time.

## What

**Task 1 — checked conversions.** Added a small `convert` helper module (`index_to_i32`, `len_to_i64`, `size_to_i64`) that attaches `anyhow` context instead of saturating. Conversions that can realistically overflow and corrupt persisted metadata now propagate an error through the existing `Result` paths:

- `manager/mod.rs`: layer index -> `i32`
- `storage/store.rs`: `size_on_disk` -> `i64` (two sites), layer index -> `i32`, `data.len()` -> `i64`

Conversions that provably cannot overflow, or where a saturating default is genuinely harmless (e.g. clamped non-negative sizes guarded by `size > 0`, `usize`->`u64` byte counts, a freshness window, migration counts), were kept with a short justifying comment.

**Task 2 — de-duplicate install.** Extracted the shared body into a private `install_inner` that takes an optional progress sink (`Option<&Sender<ProgressEvent>>`). `install` passes `None`; `install_with_progress` passes `Some` and emits `InstallComplete`. Public signatures and behavior are unchanged.

## Notes for reviewers

- This is the focused fix only; the larger `store.rs` file split is intentionally out of scope.
- `pull` vs `pull_with_progress` were left as-is: they differ structurally (bulk `store.insert` vs per-layer streaming), so merging them would be a behavior change rather than a pure refactor.
- Added unit tests for the checked conversions (in-range and overflow paths); existing install/pull tests guard the refactor.
- `cargo xtask test` passes (fmt, clippy `-Dwarnings`, tests, sql check).