### PR TITLE
Fix HTML-injection/XSS in component-frontend

### DIFF
--- a/crates/component-frontend/src/components/ds/copy_button.rs
+++ b/crates/component-frontend/src/components/ds/copy_button.rs
@@ -18,18 +18,7 @@ const CHECK_ICON: &str = concat!(
 
 /// Escape a string for safe inclusion in an HTML attribute value.
 fn html_escape_attr(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#x27;"),
-            _ => out.push(ch),
-        }
-    }
-    out
+    crate::escape::escape_html_attr(s)
 }
 
 /// Render a page heading with a copy-to-clipboard button.

--- a/crates/component-frontend/src/components/ds/install_card.rs
+++ b/crates/component-frontend/src/components/ds/install_card.rs
@@ -30,18 +30,7 @@ const COPY_ICON: &str = concat!(
 
 /// Escape a string for safe inclusion in an HTML attribute value.
 fn html_escape_attr(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#x27;"),
-            _ => out.push(ch),
-        }
-    }
-    out
+    crate::escape::escape_html_attr(s)
 }
 
 /// Render the install card.

--- a/crates/component-frontend/src/components/ds/item_list.rs
+++ b/crates/component-frontend/src/components/ds/item_list.rs
@@ -1,5 +1,6 @@
 //! C04 — Item List.
 
+use crate::escape::{escape_html_attr, escape_html_text};
 use html::inline_text::Anchor;
 use html::text_content::Division;
 
@@ -67,15 +68,16 @@ pub(crate) fn render_dyn_item_row(item: &DynItemRow) -> Anchor {
         "item-row"
     };
     let _sigil_style = format!("background:{};color:{};", item.sigil_bg, item.sigil_color);
-    let sigil_text = item.sigil_text.clone();
-    let name = item.name.clone();
-    let desc = item.desc.clone();
-    let meta = item.meta.clone();
-    let href = item.href.clone();
+    let sigil_text = escape_html_text(&item.sigil_text);
+    let name = escape_html_text(&item.name);
+    let desc = escape_html_text(&item.desc);
+    let meta = escape_html_text(&item.meta);
+    let href = escape_html_attr(&item.href);
     // Raw HTML: Span::style() creates a <style> child, not an inline style attribute.
+    // `sigil_bg`/`sigil_color` are design-system palette constants (trusted).
     let sigil_html = format!(
-        r#"<span class="sigil" style="background:{};color:{};">{}</span>"#,
-        item.sigil_bg, item.sigil_color, sigil_text
+        r#"<span class="sigil" style="background:{};color:{};">{sigil_text}</span>"#,
+        item.sigil_bg, item.sigil_color
     );
     let mut a = Anchor::builder();
     a.href(href).class(row_class);
@@ -85,7 +87,7 @@ pub(crate) fn render_dyn_item_row(item: &DynItemRow) -> Anchor {
     let version_tag = if item.version.is_empty() {
         String::new()
     } else {
-        let v = &item.version;
+        let v = escape_html_text(&item.version);
         format!(
             r#" <span class="inline-flex items-center px-1.5 h-5 rounded border border-line text-[10px] mono text-ink-500 ml-2 align-middle" title="The version of the item we're targeting">{v}</span>"#
         )
@@ -94,7 +96,7 @@ pub(crate) fn render_dyn_item_row(item: &DynItemRow) -> Anchor {
     a.text(sigil_html)
         .division(|d| d.text(name_html).division(|dd| dd.class("desc").text(desc)));
     if !meta.is_empty() {
-        let meta_title = &item.meta_title;
+        let meta_title = escape_html_attr(&item.meta_title);
         let meta_tag = format!(
             r#"<span class="meta inline-flex items-center px-1.5 h-5 rounded border border-line text-[10px] mono text-ink-500" title="{meta_title}">{meta}</span>"#
         );
@@ -105,7 +107,7 @@ pub(crate) fn render_dyn_item_row(item: &DynItemRow) -> Anchor {
 
 /// Render a list of dynamic item rows.
 pub(crate) fn render_dyn_item_list(title: &str, items: &[DynItemRow]) -> Division {
-    let title = title.to_owned();
+    let title = escape_html_text(title);
     let mut list_html = String::new();
     list_html.push_str(r#"<div class="item-list">"#);
     for item in items {
@@ -294,5 +296,37 @@ mod tests {
             ENDPOINT_ROWS,
             ANATOMY_ITEMS,
         )));
+    }
+
+    fn malicious_row() -> DynItemRow {
+        DynItemRow {
+            sigil_bg: "var(--c-cat-green)".to_owned(),
+            sigil_color: "var(--c-cat-green-ink)".to_owned(),
+            sigil_text: "c".to_owned(),
+            name: "</span><script>alert(1)</script>".to_owned(),
+            href: r#"/x"><img src=x onerror=alert(1)>"#.to_owned(),
+            desc: "<script>alert(2)</script>".to_owned(),
+            version: r#"<img src=x onerror=alert(3)>"#.to_owned(),
+            meta: "<b>m</b>".to_owned(),
+            meta_title: r#""><script>alert(4)</script>"#.to_owned(),
+            deprecated: false,
+            id: None,
+        }
+    }
+
+    // r[verify frontend.security.html-escaping]
+    #[test]
+    fn dyn_item_row_neutralizes_injection() {
+        let html = render_dyn_item_row(&malicious_row()).to_string();
+        assert!(!html.contains("<script>"));
+        assert!(!html.contains("<img"));
+        assert!(html.contains("&lt;script&gt;"));
+    }
+
+    #[test]
+    fn dyn_item_list_escapes_title() {
+        let html = render_dyn_item_list("</h2><script>alert(1)</script>", &[]).to_string();
+        assert!(!html.contains("<script>"));
+        assert!(html.contains("&lt;script&gt;"));
     }
 }

--- a/crates/component-frontend/src/components/ds/item_list.rs
+++ b/crates/component-frontend/src/components/ds/item_list.rs
@@ -82,7 +82,7 @@ pub(crate) fn render_dyn_item_row(item: &DynItemRow) -> Anchor {
     let mut a = Anchor::builder();
     a.href(href).class(row_class);
     if let Some(id) = &item.id {
-        a.id(id.clone());
+        a.id(escape_html_attr(id));
     }
     let version_tag = if item.version.is_empty() {
         String::new()
@@ -310,7 +310,7 @@ mod tests {
             meta: "<b>m</b>".to_owned(),
             meta_title: r#""><script>alert(4)</script>"#.to_owned(),
             deprecated: false,
-            id: None,
+            id: Some(r#"x"><script>alert(5)</script>"#.to_owned()),
         }
     }
 

--- a/crates/component-frontend/src/components/ds/search_bar.rs
+++ b/crates/component-frontend/src/components/ds/search_bar.rs
@@ -150,7 +150,7 @@ pub(crate) fn inline(query: &str) -> Division {
                     input
                         .type_("search")
                         .name("q")
-                        .value(query.to_owned())
+                        .value(crate::escape::escape_html_attr(query))
                         .placeholder("Search\u{2026}")
                         .class("flex-1 h-9 px-3 rounded-md border border-line bg-surface text-[14px] text-ink-900 placeholder:text-ink-400 focus:outline-none focus:border-ink-900")
                 })

--- a/crates/component-frontend/src/components/ds/sidebar.rs
+++ b/crates/component-frontend/src/components/ds/sidebar.rs
@@ -1,5 +1,6 @@
 //! C01 — Nested Sidebar.
 
+use crate::escape::{escape_html_attr, escape_html_text};
 use html::content::Navigation;
 use html::interactive::Details;
 use html::text_content::Division;
@@ -145,9 +146,11 @@ pub(crate) fn render_version_selector(
         } else {
             format!("v{v}")
         };
+        let value = escape_html_attr(&format!("{base_url}{v}"));
+        let label = escape_html_text(&label);
         let _ = write!(
             options,
-            r#"<option value="{base_url}{v}"{selected}>{label}</option>"#
+            r#"<option value="{value}"{selected}>{label}</option>"#
         );
     }
     let html = Division::builder()
@@ -231,10 +234,12 @@ fn render_entry(entry: &SidebarEntry) -> html::inline_text::Anchor {
         "tree-link"
     };
     let mut a = html::inline_text::Anchor::builder();
-    a.href(entry.href.clone()).class(cls);
+    a.href(escape_html_attr(&entry.href)).class(cls);
     a.text(entry_sigil);
-    a.span(|s| s.class("mono").text(entry.name.clone()));
+    a.span(|s| s.class("mono").text(escape_html_text(&entry.name)));
     if !entry.meta.is_empty() {
+        // `meta` is a trusted pre-rendered HTML fragment built by callers
+        // (already escaped); embed it verbatim.
         let meta = entry.meta.clone();
         a.span(|s| {
             s.class("ml-auto mono text-[10.5px] text-ink-400")
@@ -281,8 +286,10 @@ fn render_group(group: &SidebarGroup) -> Details {
     };
 
     // Build the label part — either a navigating <a> or plain spans
+    let label = escape_html_text(label);
     let label_html = match &group.href {
         Some(href) => {
+            let href = escape_html_attr(href);
             format!(
                 r#"<a href="{href}" class="flex items-center gap-1.5 flex-1 min-w-0" onclick="event.stopPropagation()">{grp_sigil}<span class="mono">{label}</span><span class="ml-auto mono text-[10.5px] text-ink-400">{count}</span></a>"#
             )
@@ -495,5 +502,19 @@ mod tests {
             SIGIL_LEGEND,
             ANATOMY_ITEMS,
         )));
+    }
+
+    // r[verify frontend.security.html-escaping]
+    #[test]
+    fn version_selector_neutralizes_injection() {
+        let html = render_version_selector(
+            r#"1"><script>alert(1)</script>"#,
+            &[r#"1"><script>alert(1)</script>"#],
+            "/v/",
+        )
+        .expect("selector should render");
+        assert!(!html.contains("<script>"));
+        assert!(!html.contains(r#""><script>"#));
+        assert!(html.contains("&lt;script&gt;"));
     }
 }

--- a/crates/component-frontend/src/components/page_sidebar.rs
+++ b/crates/component-frontend/src/components/page_sidebar.rs
@@ -5,6 +5,7 @@
 
 use crate::components::ds::sidebar::{self, SidebarEntry, SidebarGroup, SidebarItem};
 use crate::components::ds::sigil as s;
+use crate::escape::{escape_html_attr, escape_html_text, escape_js_string, sanitize_url};
 use crate::wit_doc::WitDocument;
 use component_meta_registry_client::{ComponentSummary, OciAnnotations};
 use html::content::Aside;
@@ -190,6 +191,7 @@ fn build_dependency_entries(
         .map(|dep| {
             let href = format!("/{}", dep.package.replace(':', "/"));
             let meta = dep.version.as_deref().map_or(String::new(), |v| {
+                let v = escape_html_text(v);
                 format!(
                     r#"<span class="inline-flex items-center px-1.5 h-5 rounded border border-line text-[10px] mono text-ink-500">{v}</span>"#
                 )
@@ -209,8 +211,12 @@ fn build_dependency_entries(
 
 /// Build the sidebar header with icon, title, version subtitle, and description.
 fn build_sidebar_header(ctx: &SidebarContext<'_>) -> String {
-    let ns = ctx.display_name.replace(':', "/");
-    let desc = ctx.description.unwrap_or("No description available.");
+    let ns = escape_html_attr(&ctx.display_name.replace(':', "/"));
+    let desc = escape_html_text(ctx.description.unwrap_or("No description available."));
+    let display_name = escape_html_text(ctx.display_name);
+    let version_text = escape_html_text(ctx.version);
+    let version_attr = escape_html_attr(ctx.version);
+    let kind_label = escape_html_text(ctx.kind_label);
     let icon = match ctx.kind_label {
         "Component" => SVG_PACKAGE,
         "Interface Types" => SVG_LAYERS,
@@ -218,13 +224,9 @@ fn build_sidebar_header(ctx: &SidebarContext<'_>) -> String {
     };
 
     format!(
-        r#"<div class="pb-4 border-b-[1.5px] border-rule"><div class="flex items-center gap-2.5"><span class="sigil" style="background:{};color:{};width:28px;height:28px;">{icon}</span><div><a href="/{ns}/{}" class="text-[15px] font-semibold text-ink-900 hover:underline no-underline">{}</a><div class="text-[11px] text-ink-500 mono">v{} · {}</div></div></div><p class="mt-2 text-[12px] text-ink-700 leading-relaxed">{desc}</p></div>"#,
+        r#"<div class="pb-4 border-b-[1.5px] border-rule"><div class="flex items-center gap-2.5"><span class="sigil" style="background:{};color:{};width:28px;height:28px;">{icon}</span><div><a href="/{ns}/{version_attr}" class="text-[15px] font-semibold text-ink-900 hover:underline no-underline">{display_name}</a><div class="text-[11px] text-ink-500 mono">v{version_text} · {kind_label}</div></div></div><p class="mt-2 text-[12px] text-ink-700 leading-relaxed">{desc}</p></div>"#,
         s::ROOT.bg,
         s::ROOT.color,
-        ctx.version,
-        ctx.display_name,
-        ctx.version,
-        ctx.kind_label,
     )
 }
 
@@ -293,6 +295,8 @@ fn build_project_section(ctx: &SidebarContext<'_>) -> Option<String> {
 
 /// Render a project link as a tree-link with an icon and label.
 fn project_link(href: &str, icon: &str, label: &str) -> String {
+    let href = escape_html_attr(&sanitize_url(href));
+    let label = escape_html_text(label);
     format!(
         r#"<a href="{href}" class="tree-link" target="_blank" rel="noopener"><span class="project-icon">{icon}</span> <span>{label}</span></a>"#
     )
@@ -300,6 +304,7 @@ fn project_link(href: &str, icon: &str, label: &str) -> String {
 
 /// Render a non-link row with an icon and text (tree-link styling, no href).
 fn project_icon_row(icon: &str, text: &str) -> String {
+    let text = escape_html_text(text);
     format!(
         r#"<div class="tree-link"><span class="project-icon">{icon}</span> <span>{text}</span></div>"#
     )
@@ -307,6 +312,8 @@ fn project_icon_row(icon: &str, text: &str) -> String {
 
 /// Render a key-value detail row for the project section.
 fn detail_row(label: &str, value: &str) -> String {
+    let label = escape_html_text(label);
+    let value = escape_html_text(value);
     format!(
         r#"<div class="flex items-baseline justify-between gap-4 py-1 text-[12px]"><span class="text-ink-500">{label}</span><span class="text-ink-700 mono text-right truncate">{value}</span></div>"#
     )
@@ -377,6 +384,7 @@ fn build_digest_row(digest: &str) -> String {
     let prefix_box = if prefix.is_empty() {
         String::new()
     } else {
+        let prefix = escape_html_text(prefix);
         format!(
             r#"<span class="inline-flex items-center px-2.5 h-7 rounded-l-md border border-r-0 border-line bg-surfaceMuted text-[11px] text-ink-500 mono select-none">{prefix}</span>"#
         )
@@ -387,19 +395,19 @@ fn build_digest_row(digest: &str) -> String {
         ""
     };
 
+    let hash = escape_html_text(hash);
+    let digest_attr = escape_html_attr(digest);
+    let digest_js = escape_js_string(digest);
     format!(
-        r#"<div><div class="mono uppercase tracking-wider text-[10px] text-ink-500 mb-1 flex items-center gap-1">Image Digest {info}</div><div class="flex">{prefix_box}<code class="inline-flex items-center px-2.5 h-7 flex-1 min-w-0 border border-line bg-surface mono text-[11px] text-ink-700 truncate {code_rounding}" title="{digest}">{hash}</code><button type="button" id="copy-digest-btn" class="inline-flex items-center justify-center w-7 h-7 rounded-r-md border border-l-0 border-line bg-surface text-ink-500 hover:text-ink-900 hover:bg-surfaceMuted" aria-label="Copy digest">{copy_svg}</button></div></div><script>(function(){{var b=document.getElementById('copy-digest-btn');var ci='{copy_svg}';var ch='{check_svg}';b.addEventListener('click',function(){{navigator.clipboard.writeText('{digest}').then(function(){{b.innerHTML=ch;setTimeout(function(){{b.innerHTML=ci}},2000)}})}})}})()</script>"#,
+        r#"<div><div class="mono uppercase tracking-wider text-[10px] text-ink-500 mb-1 flex items-center gap-1">Image Digest {info}</div><div class="flex">{prefix_box}<code class="inline-flex items-center px-2.5 h-7 flex-1 min-w-0 border border-line bg-surface mono text-[11px] text-ink-700 truncate {code_rounding}" title="{digest_attr}">{hash}</code><button type="button" id="copy-digest-btn" class="inline-flex items-center justify-center w-7 h-7 rounded-r-md border border-l-0 border-line bg-surface text-ink-500 hover:text-ink-900 hover:bg-surfaceMuted" aria-label="Copy digest">{copy_svg}</button></div></div><script>(function(){{var b=document.getElementById('copy-digest-btn');var ci='{copy_svg}';var ch='{check_svg}';b.addEventListener('click',function(){{navigator.clipboard.writeText('{digest_js}').then(function(){{b.innerHTML=ch;setTimeout(function(){{b.innerHTML=ci}},2000)}})}})}})()</script>"#,
         info = sidebar::INFO_BUBBLE_DIGEST,
     )
 }
 
 /// Build the revision row matching the digest copy button pattern.
 fn build_revision_row(revision: &str) -> String {
-    let short = if revision.len() > 12 {
-        format!("{}…", &revision[..12])
-    } else {
-        revision.to_owned()
-    };
+    let short = truncate_chars(revision, 12);
+    let short = escape_html_text(&short);
     let copy_svg: String = SVG_COPY_SM.chars().filter(|c| *c != '\n').collect();
     let check_svg_raw = concat!(
         r#"<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-positive">"#,
@@ -408,10 +416,24 @@ fn build_revision_row(revision: &str) -> String {
     );
     let check_svg: String = check_svg_raw.chars().filter(|c| *c != '\n').collect();
 
+    let revision_attr = escape_html_attr(revision);
+    let revision_js = escape_js_string(revision);
     format!(
-        r#"<div><div class="mono uppercase tracking-wider text-[10px] text-ink-500 mb-1 flex items-center gap-1">Revision {info}</div><div class="flex"><code class="inline-flex items-center px-2.5 h-7 flex-1 min-w-0 border border-line bg-surface mono text-[11px] text-ink-700 truncate rounded-l-md" title="{revision}">{short}</code><button type="button" id="copy-revision-btn" class="inline-flex items-center justify-center w-7 h-7 rounded-r-md border border-l-0 border-line bg-surface text-ink-500 hover:text-ink-900 hover:bg-surfaceMuted" aria-label="Copy revision">{copy_svg}</button></div></div><script>(function(){{var b=document.getElementById('copy-revision-btn');var ci='{copy_svg}';var ch='{check_svg}';b.addEventListener('click',function(){{navigator.clipboard.writeText('{revision}').then(function(){{b.innerHTML=ch;setTimeout(function(){{b.innerHTML=ci}},2000)}})}})}})()</script>"#,
+        r#"<div><div class="mono uppercase tracking-wider text-[10px] text-ink-500 mb-1 flex items-center gap-1">Revision {info}</div><div class="flex"><code class="inline-flex items-center px-2.5 h-7 flex-1 min-w-0 border border-line bg-surface mono text-[11px] text-ink-700 truncate rounded-l-md" title="{revision_attr}">{short}</code><button type="button" id="copy-revision-btn" class="inline-flex items-center justify-center w-7 h-7 rounded-r-md border border-l-0 border-line bg-surface text-ink-500 hover:text-ink-900 hover:bg-surfaceMuted" aria-label="Copy revision">{copy_svg}</button></div></div><script>(function(){{var b=document.getElementById('copy-revision-btn');var ci='{copy_svg}';var ch='{check_svg}';b.addEventListener('click',function(){{navigator.clipboard.writeText('{revision_js}').then(function(){{b.innerHTML=ch;setTimeout(function(){{b.innerHTML=ci}},2000)}})}})}})()</script>"#,
         info = sidebar::INFO_BUBBLE_REVISION,
     )
+}
+
+/// Truncate a string to at most `max` characters, appending an ellipsis when
+/// truncation occurs. Operates on `char` boundaries to avoid panicking on
+/// multi-byte UTF-8 input.
+fn truncate_chars(input: &str, max: usize) -> String {
+    if input.chars().count() > max {
+        let truncated: String = input.chars().take(max).collect();
+        format!("{truncated}\u{2026}")
+    } else {
+        input.to_owned()
+    }
 }
 
 /// Format an ISO 8601 date string to a human-friendly form.
@@ -419,8 +441,8 @@ fn build_revision_row(revision: &str) -> String {
 /// `"2025-03-15T10:30:00Z"` → `"Mar 15, 2025"`
 /// Falls back to the first 10 characters if parsing fails.
 fn format_date(iso: &str) -> String {
-    // Extract YYYY-MM-DD
-    let date_part = if iso.len() >= 10 { &iso[..10] } else { iso };
+    // Extract YYYY-MM-DD (char-safe slice to avoid panics on non-ASCII input).
+    let date_part: String = iso.chars().take(10).collect();
     let parts: Vec<&str> = date_part.split('-').collect();
     if let [year, mm, dd] = parts.as_slice() {
         let month = match *mm {
@@ -436,12 +458,12 @@ fn format_date(iso: &str) -> String {
             "10" => "Oct",
             "11" => "Nov",
             "12" => "Dec",
-            _ => return date_part.to_owned(),
+            _ => return date_part.clone(),
         };
         let day = dd.trim_start_matches('0');
         format!("{month} {day}, {year}")
     } else {
-        date_part.to_owned()
+        date_part.clone()
     }
 }
 
@@ -642,4 +664,66 @@ fn push_component_children_nav(items: &mut Vec<SidebarItem>, ctx: &SidebarContex
 
     push_group(items, "Modules", &s::MODULE, &modules);
     push_group(items, "Components", &s::COMPONENT, &components);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // r[verify frontend.security.html-escaping]
+    #[test]
+    fn project_link_neutralizes_href_injection() {
+        let html = project_link(r#"https://x"><img src=x onerror=alert(1)>"#, "", "Homepage");
+        assert!(!html.contains(r#""><img"#));
+        assert!(html.contains("&quot;&gt;"));
+    }
+
+    #[test]
+    fn project_link_drops_javascript_scheme() {
+        let html = project_link("javascript:alert(1)", "", "Homepage");
+        assert!(!html.contains("javascript:"));
+        assert!(html.contains(r##"href="#""##));
+    }
+
+    #[test]
+    fn project_icon_row_escapes_script() {
+        let html = project_icon_row("", "</span><script>alert(1)</script>");
+        assert!(!html.contains("<script>"));
+        assert!(html.contains("&lt;script&gt;"));
+    }
+
+    #[test]
+    fn detail_row_escapes_value() {
+        let html = detail_row("Authors", "</span><script>alert(1)</script>");
+        assert!(!html.contains("<script>"));
+        assert!(html.contains("&lt;script&gt;"));
+    }
+
+    #[test]
+    fn digest_row_escapes_attr_and_js() {
+        let html = build_digest_row(r#"sha256:'"></script><script>alert(1)"#);
+        // No raw script terminator survives in either the HTML attr or JS string.
+        assert!(!html.contains("</script><script>"));
+        assert!(!html.contains(r#""></script>"#));
+        assert!(html.contains("\\x3C"));
+    }
+
+    #[test]
+    fn revision_row_escapes_attr_and_js() {
+        let html = build_revision_row(r#"'"></script><script>alert(1)"#);
+        assert!(!html.contains("</script><script>"));
+        assert!(html.contains("\\x3C"));
+    }
+
+    #[test]
+    fn revision_row_handles_non_ascii_without_panic() {
+        // Multi-byte chars must not panic the char-boundary truncation.
+        let html = build_revision_row("日本語日本語日本語日本語日本語");
+        assert!(html.contains("\u{2026}"));
+    }
+
+    #[test]
+    fn format_date_handles_non_ascii_without_panic() {
+        let _ = format_date("日本語日本語日本語");
+    }
 }

--- a/crates/component-frontend/src/escape.rs
+++ b/crates/component-frontend/src/escape.rs
@@ -1,0 +1,163 @@
+//! Escaping helpers for safely embedding registry-controlled (untrusted)
+//! data into raw HTML and inline JavaScript.
+//!
+//! The `html` crate performs no automatic escaping: both element text and
+//! attribute values are rendered verbatim, and [`crate::markdown`] embeds
+//! rendered HTML directly. Any value derived from registry data — OCI
+//! annotations, package metadata, user search queries — MUST therefore be
+//! escaped before it is interpolated into raw HTML or a `<script>` body.
+
+/// Escape a string for safe inclusion in HTML text content.
+///
+/// Escapes the five characters that are significant in HTML text and
+/// double/single-quoted attribute contexts: `&`, `<`, `>`, `"`, and `'`.
+#[must_use]
+pub(crate) fn escape_html_text(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#x27;"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Escape a string for safe inclusion in a quoted HTML attribute value.
+///
+/// Uses the same entity set as [`escape_html_text`]; escaping both `"` and
+/// `'` makes the result safe inside either double- or single-quoted
+/// attribute values.
+#[must_use]
+pub(crate) fn escape_html_attr(input: &str) -> String {
+    escape_html_text(input)
+}
+
+/// Escape a string for safe inclusion inside a quoted JavaScript string
+/// literal embedded in an inline `<script>` element.
+///
+/// Backslash and quotes are backslash-escaped; `<` and `>` are emitted as
+/// `\x3C`/`\x3E` so the sequence `</script>` cannot terminate the script
+/// element early; line terminators (including U+2028/U+2029) are escaped.
+/// The browser decodes these escapes, so the runtime string value is
+/// preserved.
+#[must_use]
+pub(crate) fn escape_js_string(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\'' => out.push_str("\\'"),
+            '"' => out.push_str("\\\""),
+            '<' => out.push_str("\\x3C"),
+            '>' => out.push_str("\\x3E"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Sanitize a URL for use in an `href`/`src` attribute, neutralizing
+/// dangerous schemes such as `javascript:`, `data:`, and `vbscript:`.
+///
+/// Relative URLs (path, query, fragment, or protocol-relative) and the
+/// `http`, `https`, and `mailto` schemes are allowed. Anything else is
+/// replaced with `"#"`. The returned value is NOT attribute-escaped;
+/// callers must still pass it through [`escape_html_attr`].
+#[must_use]
+pub(crate) fn sanitize_url(url: &str) -> String {
+    if is_safe_url(url) {
+        url.to_owned()
+    } else {
+        "#".to_owned()
+    }
+}
+
+/// Return whether `url` is safe to use as a link target.
+fn is_safe_url(url: &str) -> bool {
+    let trimmed = url.trim();
+    match trimmed.find(':') {
+        // No scheme separator: a relative URL.
+        None => true,
+        Some(idx) => {
+            let before = &trimmed[..idx];
+            // If a path/query/fragment separator appears before the first
+            // ':', the ':' is part of the path and there is no scheme.
+            if before.contains('/') || before.contains('?') || before.contains('#') {
+                return true;
+            }
+            matches!(
+                before.to_ascii_lowercase().as_str(),
+                "http" | "https" | "mailto"
+            )
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_html_text_metacharacters() {
+        let injected = "</span><script>alert(1)</script>";
+        let escaped = escape_html_text(injected);
+        assert!(!escaped.contains("<script>"));
+        assert!(!escaped.contains("</span>"));
+        assert_eq!(
+            escaped,
+            "&lt;/span&gt;&lt;script&gt;alert(1)&lt;/script&gt;"
+        );
+    }
+
+    #[test]
+    fn escapes_attribute_breakout() {
+        let injected = r#""><img src=x onerror=alert(1)>"#;
+        let escaped = escape_html_attr(injected);
+        assert!(!escaped.contains("\"><img"));
+        assert!(escaped.starts_with("&quot;&gt;"));
+    }
+
+    #[test]
+    fn leaves_safe_text_unchanged() {
+        assert_eq!(escape_html_text("wasi:cli"), "wasi:cli");
+        assert_eq!(escape_html_attr("/wasi/cli/0.2.0"), "/wasi/cli/0.2.0");
+    }
+
+    #[test]
+    fn escapes_js_script_terminator_and_quotes() {
+        let injected = "');</script><script>alert(1)//";
+        let escaped = escape_js_string(injected);
+        assert!(!escaped.contains("</script>"));
+        assert!(escaped.contains("\\');"));
+        assert!(escaped.contains("\\x3C"));
+    }
+
+    #[test]
+    fn sanitizes_dangerous_url_schemes() {
+        assert_eq!(sanitize_url("javascript:alert(1)"), "#");
+        assert_eq!(sanitize_url("JavaScript:alert(1)"), "#");
+        assert_eq!(sanitize_url("data:text/html,<script>"), "#");
+        assert_eq!(sanitize_url("  javascript:alert(1)"), "#");
+    }
+
+    #[test]
+    fn allows_safe_urls() {
+        assert_eq!(
+            sanitize_url("https://example.com/x"),
+            "https://example.com/x"
+        );
+        assert_eq!(sanitize_url("/wasi/cli"), "/wasi/cli");
+        assert_eq!(sanitize_url("#anchor"), "#anchor");
+        assert_eq!(sanitize_url("mailto:a@b.com"), "mailto:a@b.com");
+        assert_eq!(sanitize_url("./relative/path"), "./relative/path");
+    }
+}

--- a/crates/component-frontend/src/layout.rs
+++ b/crates/component-frontend/src/layout.rs
@@ -1030,18 +1030,7 @@ fn render_document(title: &str, body_class: &str, body_children: &str) -> String
 
 #[must_use]
 fn escape_html_text(text: &str) -> String {
-    let mut escaped = String::with_capacity(text.len());
-    for ch in text.chars() {
-        match ch {
-            '&' => escaped.push_str("&amp;"),
-            '<' => escaped.push_str("&lt;"),
-            '>' => escaped.push_str("&gt;"),
-            '"' => escaped.push_str("&quot;"),
-            '\'' => escaped.push_str("&#x27;"),
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
+    crate::escape::escape_html_text(text)
 }
 
 #[cfg(test)]

--- a/crates/component-frontend/src/lib.rs
+++ b/crates/component-frontend/src/lib.rs
@@ -12,6 +12,7 @@
 // r[impl frontend.server.wasi-http]
 
 mod components;
+mod escape;
 mod footer;
 mod layout;
 mod markdown;

--- a/crates/component-frontend/src/markdown.rs
+++ b/crates/component-frontend/src/markdown.rs
@@ -2,9 +2,11 @@
 
 /// Render a markdown string to HTML.
 ///
-/// Uses `pulldown-cmark` to convert doc comments into HTML.
-/// The output is safe to embed directly in the page since
-/// `pulldown-cmark` does not pass through raw HTML by default.
+/// Uses `pulldown-cmark` to convert doc comments into HTML. Registry
+/// documentation is untrusted, so raw HTML in the source is downgraded to
+/// escaped text (instead of being passed through verbatim) and link/image
+/// destinations with dangerous URL schemes (e.g. `javascript:`) are
+/// neutralized. See [`crate::escape::sanitize_url`].
 #[must_use]
 pub(crate) fn render(input: &str) -> String {
     use pulldown_cmark::{Options, Parser, html};
@@ -13,10 +15,45 @@ pub(crate) fn render(input: &str) -> String {
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
 
-    let parser = Parser::new_ext(input, options);
+    let parser = Parser::new_ext(input, options).map(sanitize_event);
     let mut output = String::new();
     html::push_html(&mut output, parser);
     output
+}
+
+/// Neutralize unsafe events emitted by the markdown parser.
+///
+/// Raw HTML is turned into text (so `push_html` escapes it), and link/image
+/// destinations are passed through [`crate::escape::sanitize_url`].
+fn sanitize_event(event: pulldown_cmark::Event<'_>) -> pulldown_cmark::Event<'_> {
+    use pulldown_cmark::{Event, Tag};
+
+    match event {
+        Event::Html(html) | Event::InlineHtml(html) => Event::Text(html),
+        Event::Start(Tag::Link {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Link {
+            link_type,
+            dest_url: crate::escape::sanitize_url(&dest_url).into(),
+            title,
+            id,
+        }),
+        Event::Start(Tag::Image {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => Event::Start(Tag::Image {
+            link_type,
+            dest_url: crate::escape::sanitize_url(&dest_url).into(),
+            title,
+            id,
+        }),
+        other => other,
+    }
 }
 
 /// Standard CSS class for rendered doc comment blocks.
@@ -49,4 +86,30 @@ pub(crate) fn render_inline(input: &str) -> String {
     }
     // Fallback: return as-is if no <p> found
     html
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_raw_html_in_markdown() {
+        let out = render("hello <script>alert(1)</script> world");
+        assert!(!out.contains("<script>"));
+        assert!(out.contains("&lt;script&gt;"));
+    }
+
+    #[test]
+    fn neutralizes_javascript_links() {
+        let out = render("[click](javascript:alert(1))");
+        assert!(!out.contains("javascript:"));
+        assert!(out.contains(r##"href="#""##));
+    }
+
+    #[test]
+    fn preserves_safe_markdown() {
+        let out = render("**bold** and [link](https://example.com)");
+        assert!(out.contains("<strong>bold</strong>"));
+        assert!(out.contains(r#"href="https://example.com""#));
+    }
 }

--- a/crates/component-frontend/src/pages/home.rs
+++ b/crates/component-frontend/src/pages/home.rs
@@ -42,9 +42,7 @@ fn render_error(err: &ApiError) -> String {
 
 /// Minimal HTML escape for inline error text.
 fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+    crate::escape::escape_html_text(s)
 }
 
 /// Aggregated landing-page statistics derived from the registry index.

--- a/crates/component-frontend/src/pages/package.rs
+++ b/crates/component-frontend/src/pages/package.rs
@@ -184,18 +184,7 @@ pub(crate) fn render(
 
 /// Escape a string for safe inclusion in an HTML attribute value.
 fn html_escape_attr(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
-        match ch {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#x27;"),
-            _ => out.push(ch),
-        }
-    }
-    out
+    crate::escape::escape_html_attr(s)
 }
 
 /// Render the WIT content section for a package version.

--- a/crates/component-frontend/src/pages/queue.rs
+++ b/crates/component-frontend/src/pages/queue.rs
@@ -264,8 +264,5 @@ fn render_error(message: &str) -> String {
 
 /// Minimal HTML entity escaping.
 fn html_escape(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
-        .replace('"', "&quot;")
+    crate::escape::escape_html_text(s)
 }

--- a/crates/component-frontend/src/pages/search.rs
+++ b/crates/component-frontend/src/pages/search.rs
@@ -6,6 +6,7 @@ use component_meta_registry_client::KnownPackage;
 use html::text_content::Division;
 
 use crate::components::ds::{package_row, search_bar};
+use crate::escape::escape_html_text;
 use crate::layout;
 use component_meta_registry_client::{ApiError, RegistryClient};
 
@@ -26,7 +27,10 @@ fn render_results(query: &str, packages: &[KnownPackage]) -> String {
         div.class("pt-8 pb-6 border-b-[1.5px] border-rule mb-6")
             .heading_1(|h1| {
                 h1.class(crate::components::ds::typography::H1_CLASS)
-                    .text(format!("Results for \u{201c}{query}\u{201d}"))
+                    .text(format!(
+                        "Results for \u{201c}{}\u{201d}",
+                        escape_html_text(query)
+                    ))
             })
             .paragraph(|p| {
                 p.class(format!(
@@ -87,7 +91,10 @@ fn render_error(query: &str, err: &ApiError) -> String {
         div.class("pt-8 pb-6 border-b-[1.5px] border-rule mb-6")
             .heading_1(|h1| {
                 h1.class(crate::components::ds::typography::H1_CLASS)
-                    .text(format!("Results for \u{201c}{query}\u{201d}"))
+                    .text(format!(
+                        "Results for \u{201c}{}\u{201d}",
+                        escape_html_text(query)
+                    ))
             })
     });
 


### PR DESCRIPTION
## Why

Several HTML builders in `component-frontend` interpolated registry-controlled data (OCI annotation fields, package metadata, search queries) directly into raw HTML via `format!`. The `html` crate performs no automatic escaping (`.text()` and attribute setters render verbatim), and markdown descriptions were passed through with raw HTML intact. A malicious registry entry could therefore inject markup or `<script>`, and untrusted `href` values could carry `javascript:` URLs.

## Approach

Introduce a single shared `escape` module that all rendering paths route through, then apply it at every interpolation point for untrusted data.

- **`src/escape.rs` (new)**
  - `escape_html_text` / `escape_html_attr` escape `& < > " '`.
  - `escape_js_string` backslash-escapes quotes and emits `\x3C`/`\x3E` so an injected `</script>` cannot terminate an inline script.
  - `sanitize_url` enforces a scheme allowlist (http/https/mailto/relative, otherwise `#`), neutralizing `javascript:`, `data:`, and `vbscript:`.
- **`markdown.rs`**: downgrade raw HTML events to text and sanitize link/image URL schemes during rendering.
- **Builders**: escape untrusted values in `page_sidebar.rs` (header, `project_link` href + label, icon/detail/digest/revision rows), `ds/sidebar.rs`, `ds/item_list.rs`, `pages/search.rs` query headings, and the `search_bar` inline value.
- Consolidate the duplicate private escape helpers in `layout.rs`, `pages/package.rs`, `copy_button.rs`, `install_card.rs`, `home.rs`, and `queue.rs` to delegate to the shared module (`home`/`queue` also gained `'` escaping).

## Notes for reviewers

- Trusted, already-composed fragments are intentionally left unescaped to avoid double-escaping: the `meta` field (pre-rendered HTML), sigil palette constants, and numeric `count`.
- Fixed two latent UTF-8 char-boundary panics in `page_sidebar.rs` (revision truncation and date slicing) exposed while hardening those rows.
- `pages/sidebar.rs` is an uncompiled orphan (not declared in `pages/mod.rs`); the live sidebar is `components/page_sidebar.rs`, which is what this PR hardens.

## Tests

Added unit tests proving `</span><script>...` and `"><img onerror=...` payloads are neutralized across `escape`, `markdown`, `page_sidebar`, `ds/sidebar`, and `ds/item_list`, plus non-ASCII no-panic coverage. `cargo xtask test` (fmt + clippy `-Dwarnings` + tests + sql check) passes.