### PR TITLE
Redesign homepage hero, principles, and search card

### DIFF
--- a/crates/component-frontend/src/components/ds/hero.rs
+++ b/crates/component-frontend/src/components/ds/hero.rs
@@ -19,7 +19,6 @@ pub(crate) enum HeroCtaStyle {
     /// Outlined, secondary action.
     Secondary,
     /// Plain text-link with a leading icon.
-    #[allow(dead_code)]
     Ghost,
 }
 

--- a/crates/component-frontend/src/components/ds/hero.rs
+++ b/crates/component-frontend/src/components/ds/hero.rs
@@ -19,6 +19,7 @@ pub(crate) enum HeroCtaStyle {
     /// Outlined, secondary action.
     Secondary,
     /// Plain text-link with a leading icon.
+    #[allow(dead_code)]
     Ghost,
 }
 
@@ -46,8 +47,10 @@ pub(crate) fn render(hero: &Hero<'_>) -> String {
     let title = hero.title.to_owned();
     let lede = hero.lede.to_owned();
     let right = hero.right.to_owned();
+    let has_kicker = !hero.kicker.is_empty();
     let kicker = render_kicker(hero.kicker);
 
+    let has_ctas = !hero.ctas.is_empty();
     let mut ctas_div = Division::builder();
     ctas_div.class("mt-7 flex flex-wrap items-center gap-3");
     for cta in hero.ctas {
@@ -58,18 +61,26 @@ pub(crate) fn render(hero: &Hero<'_>) -> String {
     Section::builder()
         .class("mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8 pt-12 md:pt-20 pb-10 md:pb-14")
         .division(|grid| {
-            grid.class("grid md:grid-cols-[1fr_440px] gap-10 md:gap-16 items-end")
+            grid.class("grid md:grid-cols-[1fr_600px] gap-10 md:gap-16 items-start")
                 .division(|left| {
-                    left.push(kicker)
-                        .heading_1(|h| {
-                            h.class("mt-4 text-[40px] md:text-[52px] lg:text-[64px] leading-[1.05] font-semibold tracking-tight text-balance max-w-[14ch] md:max-w-[18ch] lg:max-w-[20ch]")
-                                .text(title)
-                        })
+                    if has_kicker {
+                        left.push(kicker);
+                    }
+                    let heading_class = if has_kicker {
+                        "mt-4 text-[40px] md:text-[52px] lg:text-[64px] leading-[1.05] font-semibold tracking-tight text-balance max-w-[14ch] md:max-w-[18ch] lg:max-w-[20ch]"
+                    } else {
+                        "text-[40px] md:text-[52px] lg:text-[64px] leading-[1.05] font-semibold tracking-tight text-balance max-w-[14ch] md:max-w-[18ch] lg:max-w-[20ch]"
+                    };
+                    let left = left
+                        .heading_1(|h| h.class(heading_class).text(title))
                         .paragraph(|p| {
                             p.class("mt-5 max-w-2xl text-[16px] md:text-[17px] text-ink-700 leading-relaxed")
                                 .text(lede)
-                        })
-                        .push(ctas)
+                        });
+                    if has_ctas {
+                        left.push(ctas);
+                    }
+                    left
                 })
                 .text(right)
         })

--- a/crates/component-frontend/src/components/ds/install_card.rs
+++ b/crates/component-frontend/src/components/ds/install_card.rs
@@ -108,7 +108,10 @@ pub(crate) fn prompt(rest: &str) -> String {
 }
 
 /// Convenience helper for a muted-info line in the install card snippet.
-#[allow(dead_code)]
+///
+/// Only used from snapshot tests today, so it is compiled in test builds only
+/// to avoid carrying an unused API in production.
+#[cfg(test)]
 #[must_use]
 pub(crate) fn muted(text: &str) -> String {
     format!(r#"<span class="text-ink-500">{text}</span>"#)

--- a/crates/component-frontend/src/components/ds/install_card.rs
+++ b/crates/component-frontend/src/components/ds/install_card.rs
@@ -108,6 +108,7 @@ pub(crate) fn prompt(rest: &str) -> String {
 }
 
 /// Convenience helper for a muted-info line in the install card snippet.
+#[allow(dead_code)]
 #[must_use]
 pub(crate) fn muted(text: &str) -> String {
     format!(r#"<span class="text-ink-500">{text}</span>"#)

--- a/crates/component-frontend/src/components/ds/principles_grid.rs
+++ b/crates/component-frontend/src/components/ds/principles_grid.rs
@@ -18,6 +18,7 @@ pub(crate) struct Principle<'a> {
 /// Render the principles grid section.
 #[must_use]
 pub(crate) fn render(kicker: &str, title: &str, lede: &str, items: &[Principle<'_>]) -> String {
+    let has_kicker = !kicker.is_empty();
     let kicker = kicker.to_owned();
     let title = title.to_owned();
     let lede = lede.to_owned();
@@ -36,18 +37,22 @@ pub(crate) fn render(kicker: &str, title: &str, lede: &str, items: &[Principle<'
         .division(|grid| {
             grid.class("grid md:grid-cols-[200px_1fr] gap-6 md:gap-12")
                 .division(|left| {
-                    left.division(|d| {
-                        d.class("text-[12px] mono uppercase tracking-wider text-ink-500")
-                            .text(kicker)
-                    })
-                    .heading_2(|h| {
-                        h.class("mt-2 text-[24px] font-semibold tracking-tight")
-                            .text(title)
-                    })
-                    .paragraph(|p| {
-                        p.class("mt-2 text-[13px] text-ink-500 leading-relaxed")
-                            .text(lede)
-                    })
+                    if has_kicker {
+                        left.division(|d| {
+                            d.class("text-[12px] mono uppercase tracking-wider text-ink-500")
+                                .text(kicker)
+                        });
+                    }
+                    let heading_class = if has_kicker {
+                        "mt-2 text-[24px] font-semibold tracking-tight"
+                    } else {
+                        "text-[24px] font-semibold tracking-tight"
+                    };
+                    left.heading_2(|h| h.class(heading_class).text(title))
+                        .paragraph(|p| {
+                            p.class("mt-2 text-[13px] text-ink-500 leading-relaxed")
+                                .text(lede)
+                        })
                 })
                 .push(tiles)
         })
@@ -64,7 +69,7 @@ fn push_tile(parent: &mut html::text_content::builders::DivisionBuilder, p: &Pri
         p.bg_class, p.fg_class
     );
     parent.division(|tile| {
-        tile.class("bg-canvas p-6")
+        tile.class("bg-surface p-6")
             .division(|d| d.class(sigil_class.clone()).text(icon))
             .division(|d| {
                 d.class("mt-3 text-[15px] font-semibold tracking-tight")

--- a/crates/component-frontend/src/components/ds/search_bar.rs
+++ b/crates/component-frontend/src/components/ds/search_bar.rs
@@ -11,32 +11,138 @@ const SEARCH_ICON: &str = concat!(
     "</svg>"
 );
 
-/// Render the landing-page "explore" search input — full-width, with a
-/// leading magnifying-glass icon and a trailing `⌘K` keyboard hint.
+const ARROW_RIGHT: &str = r#"<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>"#;
+
+/// Pre-formatted registry counts shown on the landing search card.
+pub(crate) struct LandingStats<'a> {
+    /// Total indexed packages (already thousands-formatted).
+    pub packages: &'a str,
+    /// Distinct namespaces (already thousands-formatted).
+    pub namespaces: &'a str,
+    /// Total release versions (already thousands-formatted).
+    pub versions: &'a str,
+}
+
+/// Render the landing-page hero search card — a bordered "find a component"
+/// panel that anchors the right column of the hero (callout left, search
+/// right). The card carries a headline, a federated meta-registry subline, a
+/// search input joined to a dark submit button, a stat-bearing "browse all"
+/// link, and a short list of example queries. Each entry in `examples` is a
+/// `(query, description)` pair rendered as a clickable row that runs the
+/// search.
 ///
-/// Submitting the form navigates to `/search?q=...`. The placeholder is
-/// formatted with the supplied package count.
-pub(crate) fn landing(placeholder_count: &str) -> Division {
-    let placeholder = format!("Search {placeholder_count} packages\u{2026}");
-    Division::builder()
-        .form(|form| {
-            form.action("/search")
-                .method("get")
-                .class("mt-6 relative")
-                .text(SEARCH_ICON)
-                .input(|input| {
-                    input
-                        .type_("search")
-                        .name("q")
-                        .placeholder(placeholder)
-                        .aria_label("Search packages")
-                        .class("block w-full h-10 pl-10 pr-24 rounded-lg border border-line bg-canvas text-[14px] placeholder:text-ink-400 focus:outline-none focus:border-ink-900")
-                })
-                .text(
-                    r#"<kbd class="absolute right-3 top-1/2 -translate-y-1/2 inline-flex items-center gap-1 h-6 px-2 rounded border border-lineSoft bg-surfaceMuted text-[11px] mono text-ink-500"><span>⌘</span><span>K</span></kbd>"#,
-                )
-        })
-        .build()
+/// Submitting the form navigates to `/search?q=...`. The placeholder and the
+/// browse link are formatted from the supplied [`LandingStats`].
+pub(crate) fn landing_card(stats: &LandingStats<'_>, examples: &[(&str, &str)]) -> Division {
+    let placeholder = format!("Search {} packages\u{2026}", stats.packages);
+    let browse_label = format!(
+        "Browse {} packages \u{00b7} {} namespaces \u{00b7} {} versions",
+        stats.packages, stats.namespaces, stats.versions
+    );
+    let examples: Vec<(String, String)> = examples
+        .iter()
+        .map(|(q, d)| ((*q).to_owned(), (*d).to_owned()))
+        .collect();
+
+    let mut wrapper = Division::builder();
+    wrapper.division(|card| {
+        card.class("rounded-lg border border-line bg-surface shadow-card p-5 md:p-6")
+            .heading_2(|h| {
+                h.class("text-[22px] md:text-[24px] font-semibold tracking-tight")
+                    .text("Search the registry.".to_owned())
+            })
+            .paragraph(|p| {
+                p.class("mt-1.5 text-[13px] text-ink-500 leading-relaxed")
+                    .text(
+                        "Search for Wasm Components published to any OCI registry."
+                            .to_owned(),
+                    )
+            })
+            .form(|form| {
+                let placeholder = placeholder.clone();
+                form.action("/search")
+                    .method("get")
+                    .class("mt-5 flex")
+                    .division(|field| {
+                        field
+                            .class("relative flex-1")
+                            .text(SEARCH_ICON)
+                            .input(|input| {
+                                input
+                                    .type_("search")
+                                    .name("q")
+                                    .placeholder(placeholder)
+                                    .aria_label("Search packages")
+                                    .class("block w-full h-11 pl-10 pr-3 rounded-l-lg border border-r-0 border-line bg-canvas text-[14px] text-ink-900 placeholder:text-ink-400 focus:outline-none focus:border-ink-900")
+                            })
+                    })
+                    .button(|btn| {
+                        btn.type_("submit")
+                            .class("h-11 px-5 rounded-r-lg bg-ink-900 text-canvas text-[13px] font-medium inline-flex items-center gap-2 hover:opacity-90")
+                            .text("Search".to_owned())
+                            .text(format!(" {ARROW_RIGHT}"))
+                    })
+            })
+            .division(|secondary| {
+                secondary
+                    .class("mt-5 pt-4 border-t border-dashed border-lineSoft text-[13px]")
+                    .anchor(|a| {
+                        a.href("/all")
+                            .class("text-ink-700 inline-flex items-center gap-1.5 no-underline hover:text-ink-900 hover:underline")
+                            .text(browse_label.clone())
+                            .text(format!(" {ARROW_RIGHT}"))
+                    })
+            })
+    });
+
+    if !examples.is_empty() {
+        push_example_queries(&mut wrapper, &examples);
+    }
+
+    wrapper.build()
+}
+
+fn push_example_queries(
+    wrapper: &mut html::text_content::builders::DivisionBuilder,
+    examples: &[(String, String)],
+) {
+    wrapper.division(|list| {
+        let mut list = list.class("mt-5 space-y-2.5");
+        for (i, (query, description)) in examples.iter().enumerate() {
+            let num = format!("{:02}", i + 1);
+            let href = format!("/search?q={}", encode_query(query));
+            let description = description.clone();
+            list = list.anchor(|row| {
+                row.href(href)
+                    .class("flex gap-3 text-[13px] no-underline group")
+                    .span(|n| n.class("mono tabular-nums text-ink-400").text(num))
+                    .span(|t| {
+                        t.class("text-ink-700 group-hover:text-ink-900")
+                            .span(|e| e.class("text-ink-400").text("Example: ".to_owned()))
+                            .span(|d| d.class("group-hover:underline").text(description))
+                    })
+            });
+        }
+        list
+    });
+}
+
+/// Minimal percent-encoding for an example query placed in a `q=` parameter.
+fn encode_query(q: &str) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(q.len());
+    for b in q.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            b' ' => out.push('+'),
+            _ => {
+                let _ = write!(out, "%{b:02X}");
+            }
+        }
+    }
+    out
 }
 
 /// Configuration for the search bar.
@@ -161,4 +267,41 @@ pub(crate) fn inline(query: &str) -> Division {
                 })
         })
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn landing_card_renders_search_form_and_notes() {
+        let html = landing_card(
+            &LandingStats {
+                packages: "1 248",
+                namespaces: "73",
+                versions: "4 902",
+            },
+            &[
+                ("wasi:http", "Find components that handle HTTP requests"),
+                ("wasi", "Browse the standard WASI interfaces"),
+            ],
+        )
+        .to_string();
+        // Submits a `q` query to the search endpoint.
+        assert!(html.contains(r#"action="/search""#));
+        assert!(html.contains(r#"method="get""#));
+        assert!(html.contains(r#"name="q""#));
+        // Carries the formatted placeholder and the stat-bearing browse link.
+        assert!(html.contains("Search 1 248 packages"));
+        assert!(html.contains(r#"href="/all""#));
+        assert!(
+            html.contains("Browse 1 248 packages \u{00b7} 73 namespaces \u{00b7} 4 902 versions")
+        );
+        // Example queries are numbered, link to search, and show their copy.
+        assert!(html.contains(">01<"));
+        assert!(html.contains(">02<"));
+        assert!(html.contains(r#"href="/search?q=wasi%3Ahttp""#));
+        assert!(html.contains("Find components that handle HTTP requests"));
+        assert!(html.contains("Browse the standard WASI interfaces"));
+    }
 }

--- a/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__hero__tests__snapshot.snap
+++ b/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__hero__tests__snapshot.snap
@@ -3,7 +3,7 @@ source: crates/component-frontend/src/components/ds/hero.rs
 expression: "crate::components::ds::pretty_html(&html)"
 ---
 <section class="mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8 pt-12 md:pt-20 pb-10 md:pb-14">
-  <div class="grid md:grid-cols-[1fr_440px] gap-10 md:gap-16 items-end">
+  <div class="grid md:grid-cols-[1fr_600px] gap-10 md:gap-16 items-start">
     <div>
       <div class="flex items-center gap-2 text-[12px] text-ink-500 mono uppercase tracking-wider">
         <span>

--- a/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__principles_grid__tests__snapshot.snap
+++ b/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__principles_grid__tests__snapshot.snap
@@ -16,7 +16,7 @@ expression: "crate::components::ds::pretty_html(&html)"
       </p>
     </div>
     <div class="grid sm:grid-cols-2 gap-px bg-lineSoft border border-lineSoft rounded-lg overflow-hidden">
-      <div class="bg-canvas p-6">
+      <div class="bg-surface p-6">
         <div class="h-8 w-8 grid place-items-center rounded-md bg-cat-blue text-cat-blueInk">
           <svg width="16" height="16">
           </svg>
@@ -28,7 +28,7 @@ expression: "crate::components::ds::pretty_html(&html)"
           Interfaces are the contract; implementations follow.
         </p>
       </div>
-      <div class="bg-canvas p-6">
+      <div class="bg-surface p-6">
         <div class="h-8 w-8 grid place-items-center rounded-md bg-cat-green text-cat-greenInk">
           <svg width="16" height="16">
           </svg>

--- a/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__typography__tests__snapshot.snap
+++ b/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__typography__tests__snapshot.snap
@@ -257,8 +257,8 @@ expression: "crate::components::ds::pretty_html(&render(\"typography\", \"02\", 
               </li>
             </ol>
             <blockquote class="border-l-2 border-ink-900 pl-4 text-ink-700 italic">
-              Registries are append-only. A version, once published, cannot be
-                  overwritten &mdash; only yanked.
+              Every dependency is locked by content hash, so a build today
+                  resolves byte-for-byte tomorrow.
             </blockquote>
             <pre class="id-code text-[13px] leading-relaxed">
               <span class="h">

--- a/crates/component-frontend/src/components/ds/typography.rs
+++ b/crates/component-frontend/src/components/ds/typography.rs
@@ -196,8 +196,8 @@ pub(crate) fn render(
                   </li>
                 </ol>
                 <blockquote class="border-l-2 border-ink-900 pl-4 text-ink-700 italic">
-                  Registries are append-only. A version, once published, cannot be
-                  overwritten &mdash; only yanked.
+                  Every dependency is locked by content hash, so a build today
+                  resolves byte-for-byte tomorrow.
                 </blockquote>
                 <pre class="id-code text-[13px] leading-relaxed"><span class="h">[package]</span>
 <span class="k">name</span>    <span class="p">=</span> <span class="s">"example.com/hello-world"</span>

--- a/crates/component-frontend/src/layout.rs
+++ b/crates/component-frontend/src/layout.rs
@@ -74,10 +74,6 @@ pub(crate) fn document_landing(title: &str, body_content: &str) -> String {
             label: "Docs",
             href: "/docs",
         },
-        NavLink {
-            label: "Spec",
-            href: "/docs",
-        },
     ];
     let nav = navbar::render_bar_grid(&[], LINKS);
     document_inner(title, body_content, &nav, MAIN_CLASS_FULL, true)

--- a/crates/component-frontend/src/pages/design_system.rs
+++ b/crates/component-frontend/src/pages/design_system.rs
@@ -399,6 +399,11 @@ fn render_landing_components() -> String {
                 href: "#",
                 style: HeroCtaStyle::Secondary,
             },
+            HeroCta {
+                label: "View on GitHub",
+                href: "#",
+                style: HeroCtaStyle::Ghost,
+            },
         ],
         right: r#"<div class="rounded-lg border border-line bg-surface shadow-card h-40 grid place-items-center text-[12px] text-ink-500 mono">install card slot</div>"#,
     });

--- a/crates/component-frontend/src/pages/home.rs
+++ b/crates/component-frontend/src/pages/home.rs
@@ -6,10 +6,7 @@ use component_meta_registry_client::{ApiError, KnownPackage, RegistryClient};
 
 use crate::components::ds::{
     cta_strip::{self, CtaStrip},
-    hero::{self, Hero, HeroCta, HeroCtaStyle},
-    install_card::{self, InstallCard},
-    link_list::{self, LeftStyle, LinkRow, RightStyle},
-    metrics_strip::{self, Metric},
+    hero::{self, Hero},
     principles_grid::{self, Principle},
     search_bar,
 };
@@ -33,7 +30,7 @@ fn render_packages(packages: &[KnownPackage]) -> String {
 /// surface a small notice so visitors know the live data is unavailable.
 fn render_error(err: &ApiError) -> String {
     let notice = format!(
-        r#"<div class="mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8 pt-4"><div role="status" class="flex items-start gap-2 rounded-md border border-line bg-surfaceMuted px-3 py-2 text-[12px] text-ink-700"><span class="mono uppercase tracking-wider text-ink-500">Registry offline</span><span>Live package data is temporarily unavailable. Install the CLI below to get started — the registry is not required to use <code class="px-1 py-0.5 rounded-sm bg-surface text-ink-900 mono text-[0.875em]">component</code> locally. ({err})</span></div></div>"#,
+        r#"<div class="mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8 pt-4"><div role="status" class="flex items-start gap-2 rounded-md border border-line bg-surfaceMuted px-3 py-2 text-[12px] text-ink-700"><span class="mono uppercase tracking-wider text-ink-500">Registry offline</span><span>Live package data is temporarily unavailable, so search may return nothing right now. The <code class="px-1 py-0.5 rounded-sm bg-surface text-ink-900 mono text-[0.875em]">component</code> CLI still works locally without the registry — see the <a href="/docs" class="text-ink-900 hover:underline">docs</a> to get started. ({err})</span></div></div>"#,
         err = html_escape(&err.to_string()),
     );
     let body = compose_body(&Stats::default(), Some(&notice));
@@ -49,34 +46,23 @@ fn html_escape(s: &str) -> String {
 #[derive(Default)]
 struct Stats {
     /// Total number of indexed packages.
-    package_count: usize,
+    packages: usize,
     /// Number of distinct WIT namespaces (or repository owners as fallback).
-    author_count: usize,
+    namespaces: usize,
     /// Sum of release tag counts across all packages.
-    version_count: usize,
-    /// Top featured packages by version count, with a short description.
-    featured: Vec<NamedRow>,
-    /// Top namespaces by package count.
-    namespaces: Vec<NamedRow>,
-}
-
-/// An owned row used to feed [`link_list::render`] from dynamic data.
-struct NamedRow {
-    left: String,
-    right: String,
-    href: String,
+    versions: usize,
 }
 
 impl Stats {
     fn from_packages(packages: &[KnownPackage]) -> Self {
-        use std::collections::BTreeMap;
+        use std::collections::BTreeSet;
 
         let package_count = packages.len();
         let version_count: usize = packages.iter().map(|p| p.tags.len()).sum();
 
-        // Group by WIT namespace (preferred) or fall back to the first
+        // Count distinct WIT namespaces (preferred) or fall back to the first
         // segment of the repository path.
-        let mut by_ns: BTreeMap<String, Vec<&KnownPackage>> = BTreeMap::new();
+        let mut ns_set: BTreeSet<String> = BTreeSet::new();
         for pkg in packages {
             let ns = pkg
                 .wit_namespace
@@ -86,72 +72,13 @@ impl Stats {
             if ns.is_empty() {
                 continue;
             }
-            by_ns.entry(ns).or_default().push(pkg);
+            ns_set.insert(ns);
         }
-        let author_count = by_ns.len();
-
-        // Top namespaces by package count.
-        let mut ns_rows: Vec<(String, usize)> = by_ns
-            .iter()
-            .map(|(ns, pkgs)| (ns.clone(), pkgs.len()))
-            .collect();
-        ns_rows.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
-        let namespaces: Vec<NamedRow> = ns_rows
-            .into_iter()
-            .take(5)
-            .map(|(ns, count)| NamedRow {
-                left: ns.clone(),
-                right: format_count(count),
-                href: format!("/{ns}"),
-            })
-            .collect();
-
-        // Top featured packages: most release tags first, alphabetical tiebreak.
-        let mut featured_pool: Vec<&KnownPackage> = packages.iter().collect();
-        featured_pool.sort_by(|a, b| {
-            b.tags
-                .len()
-                .cmp(&a.tags.len())
-                .then_with(|| a.repository.cmp(&b.repository))
-        });
-        let featured: Vec<NamedRow> = featured_pool
-            .into_iter()
-            .take(5)
-            .map(|p| {
-                let label = match (&p.wit_namespace, &p.wit_name) {
-                    (Some(ns), Some(name)) => format!("{ns}:{name}"),
-                    _ => p.repository.clone(),
-                };
-                let href = match (&p.wit_namespace, &p.wit_name) {
-                    (Some(ns), Some(name)) => format!("/{ns}/{name}"),
-                    _ => format!("/{}", p.repository),
-                };
-                let right = p
-                    .description
-                    .clone()
-                    .filter(|d| !d.trim().is_empty())
-                    .unwrap_or_else(|| {
-                        let n = p.tags.len();
-                        if n == 1 {
-                            "1 release".to_owned()
-                        } else {
-                            format!("{n} releases")
-                        }
-                    });
-                NamedRow {
-                    left: label,
-                    right,
-                    href,
-                }
-            })
-            .collect();
 
         Self {
-            package_count,
-            author_count,
-            version_count,
-            featured,
-            namespaces,
+            packages: package_count,
+            namespaces: ns_set.len(),
+            versions: version_count,
         }
     }
 }
@@ -159,77 +86,45 @@ impl Stats {
 /// Compose the full landing page body. `notice_html` is rendered above
 /// the hero when present (for example, a registry-offline banner).
 fn compose_body(stats: &Stats, notice_html: Option<&str>) -> String {
-    let install = install_card::render(&InstallCard {
-        platforms: &["macOS", "Linux", "Windows"],
-        filename: "install.sh",
-        snippet_html: &install_snippet(),
-        sha: "9e4a…c0f1",
-        copy_command: "curl -sSf https://component.dev/install.sh | sh",
-    });
+    let pkg_count = format_count(stats.packages);
+    let ns_count = format_count(stats.namespaces);
+    let version_count = format_count(stats.versions);
+
+    let examples = [
+        (
+            "wasi:http",
+            "Find components that can handle incoming HTTP requests",
+        ),
+        ("wasi", "Browse the reusable standard WASI interfaces"),
+        (
+            "wasi:keyvalue",
+            "Discover key-value storage backends to plug into",
+        ),
+    ];
+    let search_card = search_bar::landing_card(
+        &search_bar::LandingStats {
+            packages: &pkg_count,
+            namespaces: &ns_count,
+            versions: &version_count,
+        },
+        &examples,
+    )
+    .to_string();
 
     let hero_html = hero::render(&Hero {
-        kicker: &["v0.4.0", "Stable · WASI 0.2"],
-        title: "The package manager for components.",
+        kicker: &[],
+        title: "The package manager for wasm components.",
         lede: "Resolve, vendor, and compose WebAssembly components from any registry. \
-               Reproducible builds, semantic versioning, and an append-only index — so \
-               the dependency you shipped is the dependency you keep.",
-        ctas: &[
-            HeroCta {
-                label: "Get started",
-                href: "/docs",
-                style: HeroCtaStyle::Primary,
-            },
-            HeroCta {
-                label: "Browse packages",
-                href: "/all",
-                style: HeroCtaStyle::Secondary,
-            },
-            HeroCta {
-                label: "Source on GitHub",
-                href: "https://github.com/yoshuawuyts/component-cli",
-                style: HeroCtaStyle::Ghost,
-            },
-        ],
-        right: &install,
+               Reproducible builds and semantic versioning — so the dependency you \
+               shipped is the dependency you keep.",
+        ctas: &[],
+        right: &search_card,
     });
 
-    let pkg_count = format_count(stats.package_count);
-    let author_count = format_count(stats.author_count);
-    let version_count = format_count(stats.version_count);
-    let metrics_html = metrics_strip::render(&[
-        Metric {
-            label: "Packages",
-            value: &pkg_count,
-            delta: None,
-            verified: false,
-        },
-        Metric {
-            label: "Authors",
-            value: &author_count,
-            delta: None,
-            verified: false,
-        },
-        Metric {
-            label: "Versions published",
-            value: &version_count,
-            delta: None,
-            verified: false,
-        },
-        Metric {
-            label: "Index integrity",
-            value: "100%",
-            delta: Some("verified"),
-            verified: true,
-        },
-    ]);
-
-    let explore_html = render_explore(stats);
-
     let principles_html = principles_grid::render(
-        "Why component",
-        "Built for components.",
-        "A package manager designed around the WebAssembly Component Model — not \
-         retrofitted from an older ecosystem.",
+        "",
+        "Why Wasm Components?",
+        "Wasm Components package core WebAssembly instructions into portable binaries and libraries with fully-typed interfaces.",
         PRINCIPLES,
     );
 
@@ -238,7 +133,7 @@ fn compose_body(stats: &Stats, notice_html: Option<&str>) -> String {
         title: "Publish your component.",
         body_html: "Add your namespace to a registry config and run \
                     <code class=\"px-1 py-0.5 rounded-sm bg-surfaceMuted text-ink-900 mono text-[0.875em]\">component publish</code>. \
-                    The index is append-only and signed end-to-end.",
+                    Every release is signed end-to-end.",
         primary_label: "Open the publishing guide",
         primary_href: "/docs",
         secondary_label: "Read the spec",
@@ -249,77 +144,10 @@ fn compose_body(stats: &Stats, notice_html: Option<&str>) -> String {
     format!(
         r#"{notice_html}
 {hero_html}
-{metrics_html}
-<div class="bg-surface pt-12 md:pt-16 pb-14 md:pb-20">
-{explore_html}
+<div class="pb-16 md:pb-24">
 {principles_html}
 {cta_html}
 </div>"#
-    )
-}
-
-/// Render the "Explore the ecosystem" section: kicker, search input, and
-/// two link lists (Featured / Namespaces).
-fn render_explore(stats: &Stats) -> String {
-    let pkg_count = format_count(stats.package_count);
-    let author_count = format_count(stats.author_count);
-    let ns_count = format_count(stats.namespaces.len());
-    let search_html = search_bar::landing(&pkg_count).to_string();
-
-    let featured_rows: Vec<LinkRow<'_>> = stats
-        .featured
-        .iter()
-        .map(|r| LinkRow {
-            left: &r.left,
-            right: &r.right,
-            href: &r.href,
-        })
-        .collect();
-    let namespace_rows: Vec<LinkRow<'_>> = stats
-        .namespaces
-        .iter()
-        .map(|r| LinkRow {
-            left: &r.left,
-            right: &r.right,
-            href: &r.href,
-        })
-        .collect();
-    let featured = link_list::render(
-        "Featured",
-        &featured_rows,
-        &LeftStyle::Mono,
-        &RightStyle::Description,
-    );
-    let namespaces = link_list::render(
-        "Namespaces",
-        &namespace_rows,
-        &LeftStyle::Mono,
-        &RightStyle::Count,
-    );
-
-    format!(
-        r#"<section class="mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8">
-  <div class="max-w-2xl">
-    <div class="text-[12px] mono uppercase tracking-wider text-ink-500">Explore</div>
-    <h2 class="mt-2 text-[28px] md:text-[32px] font-semibold tracking-tight">The ecosystem.</h2>
-    <p class="mt-3 text-[14px] text-ink-700 leading-relaxed">
-      <span class="mono tabular-nums text-ink-900">{pkg_count}</span> packages from
-      <span class="mono tabular-nums text-ink-900">{author_count}</span> authors across
-      <span class="mono tabular-nums text-ink-900">{ns_count}</span> namespaces.
-    </p>
-  </div>
-
-  {search_html}
-
-  <div class="mt-10 grid md:grid-cols-2 gap-x-12 gap-y-10">
-    {featured}
-    {namespaces}
-  </div>
-
-  <div class="mt-6 text-right text-[13px]">
-    <a href="/all" class="text-ink-900 hover:underline no-underline">Browse all packages →</a>
-  </div>
-</section>"#
     )
 }
 
@@ -337,46 +165,6 @@ fn format_count(n: usize) -> String {
     out.chars().rev().collect()
 }
 
-/// Build the install card shell snippet using the helper spans.
-fn install_snippet() -> String {
-    let mut s = String::new();
-    s.push_str(&install_card::prompt(
-        "curl -sSf https://component.dev/install.sh | sh",
-    ));
-    s.push_str("\n\n");
-    s.push_str(&install_card::prompt(
-        "component <span class=\"font-semibold\">init</span> hello-world",
-    ));
-    s.push('\n');
-    s.push_str(&install_card::muted("  Created hello-world/wasm.toml"));
-    s.push_str("\n\n");
-    s.push_str(&install_card::prompt(
-        "component <span class=\"font-semibold\">add</span> wasi:http@0.2",
-    ));
-    s.push('\n');
-    s.push_str(&install_card::muted("  Resolved 4 packages in 312 ms"));
-    s.push('\n');
-    s.push_str(&install_card::positive("  ✓ Locked"));
-    s.push_str(" wasi:http ");
-    s.push_str(&install_card::muted("0.2.3"));
-    s.push('\n');
-    s.push_str(&install_card::positive("  ✓ Locked"));
-    s.push_str(" wasi:io   ");
-    s.push_str(&install_card::muted("0.2.3"));
-    s.push_str("\n\n");
-    s.push_str(&install_card::prompt(
-        "component <span class=\"font-semibold\">build</span>",
-    ));
-    s.push('\n');
-    s.push_str(&install_card::positive("  ✓ Compiled"));
-    s.push_str(" hello-world ");
-    s.push_str(&install_card::muted("v0.1.0"));
-    s.push(' ');
-    s.push_str("<span class=\"text-ink-400\">(2.18s)</span>");
-    s
-}
-
-const SHIELD_SVG: &str = r#"<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>"#;
 const STACK_SVG: &str = concat!(
     r#"<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">"#,
     include_str!("../../../../vendor/lucide/layers.svg"),
@@ -384,39 +172,43 @@ const STACK_SVG: &str = concat!(
 );
 const GLOBE_SVG: &str = r#"<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18z"/></svg>"#;
 const GRID_SVG: &str = r#"<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>"#;
+const CODE_SVG: &str = r#"<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round"><path d="m16 18 6-6-6-6"/><path d="m8 6-6 6 6 6"/></svg>"#;
 
 const PRINCIPLES: &[Principle<'static>] = &[
     Principle {
         bg_class: "bg-cat-blue",
         fg_class: "text-cat-blueInk",
-        icon_svg: SHIELD_SVG,
-        title: "Reproducible by default",
-        body: "Every dependency is locked by content hash. The build you ship today \
-               is the build you can ship in five years.",
+        icon_svg: STACK_SVG,
+        title: "Compose sandboxes together",
+        body: "Components can be linked together thanks to the strongly typed \
+        WIT interfaces. Each component is always individually sandboxed, so a \
+        problem in one component doesn't become a problem for all other \
+        components.",
     },
     Principle {
         bg_class: "bg-cat-green",
         fg_class: "text-cat-greenInk",
-        icon_svg: STACK_SVG,
-        title: "Federated registries",
-        body: "Pull from any OCI-compatible registry — host your own, mirror upstream, \
-               or compose private and public packages in one manifest.",
+        icon_svg: GRID_SVG,
+        title: "Works with (almost) any language",
+        body: "Choose the best language for the job — Rust, Go, JS, Python, C. \
+               The interface is the contract, so if you ever need to switch languages, you can.",
     },
     Principle {
         bg_class: "bg-cat-peach",
         fg_class: "text-cat-peachInk",
         icon_svg: GLOBE_SVG,
-        title: "Semantic versioning",
-        body: "Versions are strict semver — breaking changes require a major bump, \
-               and once published, a version cannot be overwritten, only yanked.",
+        title: "Truly portable binaries",
+        body: "Ship the same binary to your server, editor, or browser. As long as the host \
+               provides the right imports, components will run anywhere.",
     },
     Principle {
         bg_class: "bg-cat-lilac",
         fg_class: "text-cat-lilacInk",
-        icon_svg: GRID_SVG,
-        title: "Compose, don't link",
-        body: "Components are wired together at the WIT interface boundary — \
-               no shared globals, no symbol clashes, no surprise side effects.",
+        icon_svg: CODE_SVG,
+        title: "SDKs for free",
+        body: "Define your interface once in WIT and every language gets a typed \
+               binding — Rust, Go, JS, Python, C. No hand-written client library \
+               to write and maintain per language.",
     },
 ];
 
@@ -430,13 +222,6 @@ mod tests {
         assert_eq!(format_count(73), "73");
         assert_eq!(format_count(1248), "1\u{2009}248");
         assert_eq!(format_count(1_234_567), "1\u{2009}234\u{2009}567");
-    }
-
-    #[test]
-    fn install_snippet_contains_expected_commands() {
-        let snippet = install_snippet();
-        assert!(snippet.contains("install.sh"));
-        assert!(snippet.contains("wasi:http"));
     }
 
     fn pkg(ns: &str, name: &str, tags: &[&str], description: Option<&str>) -> KnownPackage {
@@ -464,40 +249,8 @@ mod tests {
             pkg("ba", "sqlite", &["0.1.0", "0.2.0"], Some("SQLite")),
         ];
         let stats = Stats::from_packages(&packages);
-        assert_eq!(stats.package_count, 3);
-        assert_eq!(stats.author_count, 2);
-        assert_eq!(stats.version_count, 6);
-    }
-
-    #[test]
-    fn stats_featured_sorted_by_version_count() {
-        let packages = vec![
-            pkg("wasi", "io", &["0.2.0"], None),
-            pkg("wasi", "http", &["0.1.0", "0.2.0", "0.2.1"], Some("HTTP")),
-            pkg("ba", "sqlite", &["0.1.0", "0.2.0"], Some("SQLite")),
-        ];
-        let stats = Stats::from_packages(&packages);
-        assert_eq!(stats.featured[0].left, "wasi:http");
-        assert_eq!(stats.featured[0].right, "HTTP");
-        assert_eq!(stats.featured[0].href, "/wasi/http");
-        assert_eq!(stats.featured[1].left, "ba:sqlite");
-        // Falls back to release count when description is missing.
-        assert_eq!(stats.featured[2].right, "1 release");
-    }
-
-    #[test]
-    fn stats_top_namespaces_sorted_by_package_count() {
-        let packages = vec![
-            pkg("wasi", "http", &["0.1.0"], None),
-            pkg("wasi", "io", &["0.1.0"], None),
-            pkg("wasi", "cli", &["0.1.0"], None),
-            pkg("ba", "sqlite", &["0.1.0"], None),
-        ];
-        let stats = Stats::from_packages(&packages);
-        assert_eq!(stats.namespaces[0].left, "wasi");
-        assert_eq!(stats.namespaces[0].right, "3");
-        assert_eq!(stats.namespaces[0].href, "/wasi");
-        assert_eq!(stats.namespaces[1].left, "ba");
-        assert_eq!(stats.namespaces[1].right, "1");
+        assert_eq!(stats.packages, 3);
+        assert_eq!(stats.namespaces, 2);
+        assert_eq!(stats.versions, 6);
     }
 }


### PR DESCRIPTION
## Why

The old landing page led with a generic hero, repeated append-only claims, and a search card whose footnotes carried stats rather than helping people actually search. This reworks the homepage into a clearer callout-left, search-right layout and sharpens the copy to explain what wasm components are and why the registry is useful.

## What changed

**Hero**
- Removed the version eyebrow kicker and the CTA buttons; the kicker and CTA rows are now optional so the layout collapses cleanly when empty.
- Widened the search column and narrowed the title block.
- Retitled to "the package manager for wasm components."

**Search card**
- Added a subline clarifying the search scope ("Search for Wasm Components published to any OCI registry.").
- Replaced the numbered stat footnotes with a numbered list of clickable `Example:` search queries that run a real search (e.g. components that handle HTTP, the standard WASI interfaces).
- Turned the footer into a single stat-bearing `Browse N packages, M namespaces, K versions` link, with counts pulled from the registry index.

**Principles**
- Kept the 2x2 boxed grid, fixing the tile background to `bg-surface` so the cards read against the canvas.
- Rewrote the four pillars to describe the value of wasm components themselves: composable sandboxes, language choice, truly portable binaries, and "SDKs for free" (define the interface once in WIT, get typed bindings in every language).
- The section header is now "Why Wasm Components?" with a lede that defines the format.

**Misc**
- Removed the "Spec" link from the landing nav.
- De-emphasized append-only / immutable-index claims in the hero lede, search copy, and the typography demo blockquote.

## Notes for reviewers

This is a frontend-only change in `component-frontend` (server-side `html` builder + Tailwind classes). Component snapshots (`hero`, `principles_grid`, `typography`) were updated to match the new markup. `cargo xtask test` passes (fmt, clippy `-D warnings`, tests, sql check).