### PR TITLE
feat: WASI 0.3-rc HTTP support for library component runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,9 +133,17 @@ insta = "1.44.3"
 serde_json = { version = "1.0.145", features = ["alloc"] }
 termcolor = "1.4.1"
 wasm-metadata = "0.251.0"
-wasmtime = "45.0.0"
+bytes = "1"
+http = "1"
+http-body = "1"
+http-body-util = "0.1"
+rustls = { version = "0.23", features = ["ring"] }
+rustls-native-certs = "0.8"
+tokio-rustls = { version = "0.26", features = ["ring", "tls12"] }
+webpki-roots = "0.26"
+wasmtime = { version = "45.0.0", features = ["component-model-async"] }
 wasmtime-wasi = "45.0.0"
-wasmtime-wasi-http = "45.0.0"
+wasmtime-wasi-http = { version = "45.0.0", features = ["p3"] }
 hyper = { version = "1", features = ["http1", "server"] }
 
 # store dependencies

--- a/crates/component-cli-internal-run/Cargo.toml
+++ b/crates/component-cli-internal-run/Cargo.toml
@@ -17,6 +17,17 @@ wasmparser = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
+bytes = { workspace = true }
+http = { workspace = true }
+http-body = { workspace = true }
+http-body-util = { workspace = true }
+rustls = { workspace = true }
+rustls-native-certs = { workspace = true }
+tokio-rustls = { workspace = true }
+webpki-roots = { workspace = true }
+hyper = { workspace = true }
+tokio = { workspace = true, features = ["net", "time"] }
+tracing = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/component-cli-internal-run/src/http_hooks/mod.rs
+++ b/crates/component-cli-internal-run/src/http_hooks/mod.rs
@@ -1,0 +1,67 @@
+//! Custom `WasiHttpHooks` that augment TLS root certificates with native system CAs.
+//!
+//! The default [`wasmtime_wasi_http`] implementation only trusts the [`webpki_roots`] bundle,
+//! which breaks in environments that use a TLS inspection proxy with a private CA (e.g.
+//! corporate proxies or cloud sandbox environments). This module provides drop-in
+//! replacements — one for WASI HTTP P3 ([`NativeCertHooks`]) and one for WASI HTTP P2
+//! ([`NativeCertHooksP2`]) — that each load the OS certificate store via
+//! [`rustls_native_certs`] in addition to the standard webpki roots.
+//!
+//! The two hook implementations live in their own modules ([`p3`] and [`p2`]); the shared
+//! TLS root store / [`rustls::ClientConfig`] construction lives here so it is built only
+//! once and reused across requests.
+//!
+//! # Alternative approach
+//!
+//! The same behaviour can be achieved without any extra code by patching
+//! `wasmtime-wasi-http` directly: replace the two lines in `src/p3/request.rs` that
+//! construct the `RootCertStore` with code that also calls
+//! `rustls_native_certs::load_native_certs()`, and add `rustls-native-certs` to
+//! `default-send-request` in `Cargo.toml`. This requires vendoring the upstream crate
+//! (adding a `[patch.crates-io]` entry and a `vendor/wasmtime-wasi-http/` directory).
+//! The hooks approach avoids that maintenance burden at the cost of duplicating ~100 lines
+//! of connection logic from `default_send_request`.
+
+mod p2;
+mod p3;
+
+pub(crate) use p2::NativeCertHooksP2;
+pub(crate) use p3::NativeCertHooks;
+
+use std::sync::{Arc, OnceLock};
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tracing::warn;
+
+/// Async I/O stream abstraction covering both plain TCP and TLS connections.
+pub(super) trait RwStream: AsyncRead + AsyncWrite + Send + Unpin + 'static {}
+impl<T: AsyncRead + AsyncWrite + Send + Unpin + 'static> RwStream for T {}
+
+/// Shared [`rustls::ClientConfig`] trusting both the [`webpki_roots`] bundle and the OS
+/// native CA certificates.
+///
+/// Loading the native cert store and rebuilding the config is relatively expensive, so it
+/// is constructed once on first use and cached for the lifetime of the process. The config
+/// carries no per-request state (SNI is supplied per connection), so a single shared
+/// instance is safe to reuse for every outbound request.
+pub(super) fn native_root_tls_config() -> Arc<rustls::ClientConfig> {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    let config = CONFIG.get_or_init(|| {
+        let mut roots = rustls::RootCertStore {
+            roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+        };
+        let native = rustls_native_certs::load_native_certs();
+        for err in &native.errors {
+            warn!("native cert load error: {err:?}");
+        }
+        for cert in native.certs {
+            let _ = roots.add(cert);
+        }
+        Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth(),
+        )
+    });
+    Arc::clone(config)
+}

--- a/crates/component-cli-internal-run/src/http_hooks/p2.rs
+++ b/crates/component-cli-internal-run/src/http_hooks/p2.rs
@@ -1,0 +1,171 @@
+//! WASI HTTP P2 native-cert hooks.
+//!
+//! Mirrors [`super::p3`] for the WASI P2 `wasi:http/outgoing-handler` interface used by
+//! TinyGo-compiled components.
+
+use tokio::net::TcpStream;
+use tracing::warn;
+use wasmtime_wasi_http::p2::bindings::http::types::{
+    DnsErrorPayload as P2DnsErrorPayload, ErrorCode as P2ErrorCode,
+};
+use wasmtime_wasi_http::p2::{
+    self as p2, WasiHttpHooks as WasiHttpHooksP2,
+    body::{HyperIncomingBody, HyperOutgoingBody},
+    types::{HostFutureIncomingResponse, IncomingResponse, OutgoingRequestConfig},
+};
+
+use super::{RwStream, native_root_tls_config};
+
+fn p2_dns_error(rcode: &str) -> P2ErrorCode {
+    P2ErrorCode::DnsError(P2DnsErrorPayload {
+        rcode: Some(rcode.to_string()),
+        info_code: Some(0),
+    })
+}
+
+/// WASI HTTP P2 [`WasiHttpHooksP2`] implementation that trusts native OS CA
+/// certificates in addition to the built-in [`webpki_roots`] bundle.
+///
+/// Mirrors [`super::NativeCertHooks`] for the WASI P3 path but targets the P2
+/// `wasi:http/outgoing-handler` interface used by TinyGo-compiled components.
+pub(crate) struct NativeCertHooksP2;
+
+impl WasiHttpHooksP2 for NativeCertHooksP2 {
+    fn send_request(
+        &mut self,
+        request: hyper::Request<HyperOutgoingBody>,
+        config: OutgoingRequestConfig,
+    ) -> p2::HttpResult<HostFutureIncomingResponse> {
+        let handle =
+            wasmtime_wasi::runtime::spawn(
+                async move { Ok(p2_native_cert_send(request, config).await) },
+            );
+        Ok(HostFutureIncomingResponse::pending(handle))
+    }
+}
+
+/// Async inner implementation of the P2 native-cert request sender.
+/// Mirrors `wasmtime_wasi_http::p2::default_send_request_handler` but builds
+/// the TLS root store from both `webpki_roots` and the OS native cert store.
+async fn p2_native_cert_send(
+    mut request: hyper::Request<HyperOutgoingBody>,
+    OutgoingRequestConfig {
+        use_tls,
+        connect_timeout,
+        first_byte_timeout,
+        between_bytes_timeout,
+    }: OutgoingRequestConfig,
+) -> Result<IncomingResponse, P2ErrorCode> {
+    use http_body_util::BodyExt as _;
+    use tokio::time::timeout;
+    use wasmtime_wasi_http::io::TokioIo;
+    use wasmtime_wasi_http::p2::hyper_request_error;
+
+    let uri_authority = request
+        .uri()
+        .authority()
+        .ok_or(P2ErrorCode::HttpRequestUriInvalid)?
+        .clone();
+    // Host without the port, used for TLS SNI. Using `Authority::host()` keeps IPv6
+    // literals like `[::1]` intact instead of truncating at the first colon.
+    let host = uri_authority.host().to_string();
+    let authority = if uri_authority.port().is_some() {
+        uri_authority.to_string()
+    } else {
+        let port = if use_tls { 443 } else { 80 };
+        format!("{uri_authority}:{port}")
+    };
+
+    let tcp_stream = timeout(connect_timeout, TcpStream::connect(&authority))
+        .await
+        .map_err(|_| P2ErrorCode::ConnectionTimeout)?
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::AddrNotAvailable => p2_dns_error("address not available"),
+            _ => {
+                if e.to_string()
+                    .starts_with("failed to lookup address information")
+                {
+                    p2_dns_error("address not available")
+                } else {
+                    P2ErrorCode::ConnectionRefused
+                }
+            }
+        })?;
+
+    // Build a common stream abstraction so both branches produce the same sender type.
+    #[allow(clippy::items_after_statements)]
+    type Sender = hyper::client::conn::http1::SendRequest<HyperOutgoingBody>;
+
+    let (mut sender, worker): (Sender, _) = if use_tls {
+        use rustls::pki_types::ServerName;
+
+        let connector = tokio_rustls::TlsConnector::from(native_root_tls_config());
+        let domain = ServerName::try_from(host.as_str())
+            .map_err(|e| {
+                warn!("invalid DNS name (p2): {e:?}");
+                p2_dns_error("invalid dns name")
+            })?
+            .to_owned();
+        let tls_stream = connector.connect(domain, tcp_stream).await.map_err(|e| {
+            warn!("TLS protocol error (p2): {e:?}");
+            P2ErrorCode::TlsProtocolError
+        })?;
+
+        // Erase the concrete TLS stream type behind a boxed trait object so
+        // both branches produce the same `(Sender, worker)` tuple type.
+        let boxed: Box<dyn RwStream> = Box::new(tls_stream);
+        let (sender, conn) = timeout(
+            connect_timeout,
+            hyper::client::conn::http1::handshake(TokioIo::new(boxed)),
+        )
+        .await
+        .map_err(|_| P2ErrorCode::ConnectionTimeout)?
+        .map_err(hyper_request_error)?;
+        let worker = wasmtime_wasi::runtime::spawn(async move {
+            match conn.await {
+                Ok(()) => {}
+                Err(e) => warn!("p2 tls connection error: {e}"),
+            }
+        });
+        (sender, worker)
+    } else {
+        let boxed: Box<dyn RwStream> = Box::new(tcp_stream);
+        let (sender, conn) = timeout(
+            connect_timeout,
+            hyper::client::conn::http1::handshake(TokioIo::new(boxed)),
+        )
+        .await
+        .map_err(|_| P2ErrorCode::ConnectionTimeout)?
+        .map_err(hyper_request_error)?;
+        let worker = wasmtime_wasi::runtime::spawn(async move {
+            match conn.await {
+                Ok(()) => {}
+                Err(e) => warn!("p2 plain connection error: {e}"),
+            }
+        });
+        (sender, worker)
+    };
+
+    // Strip scheme + authority — HTTP/1.1 request-line must not include them.
+    *request.uri_mut() = http::Uri::builder()
+        .path_and_query(
+            request
+                .uri()
+                .path_and_query()
+                .map_or("/", http::uri::PathAndQuery::as_str),
+        )
+        .build()
+        .expect("comes from valid request");
+
+    let resp = timeout(first_byte_timeout, sender.send_request(request))
+        .await
+        .map_err(|_| P2ErrorCode::ConnectionReadTimeout)?
+        .map_err(hyper_request_error)?
+        .map(|body| -> HyperIncomingBody { body.map_err(hyper_request_error).boxed_unsync() });
+
+    Ok(IncomingResponse {
+        resp,
+        worker: Some(worker),
+        between_bytes_timeout,
+    })
+}

--- a/crates/component-cli-internal-run/src/http_hooks/p3.rs
+++ b/crates/component-cli-internal-run/src/http_hooks/p3.rs
@@ -1,0 +1,237 @@
+//! WASI HTTP P3 native-cert hooks.
+
+use bytes::Bytes;
+use core::pin::Pin;
+use core::task::{Context, Poll, ready};
+use core::time::Duration;
+use http::uri::Scheme;
+use http_body_util::combinators::UnsyncBoxBody;
+use std::future::Future;
+use tokio::net::TcpStream;
+use tracing::warn;
+use wasmtime_wasi::TrappableError;
+use wasmtime_wasi_http::{
+    io::TokioIo,
+    p3::{
+        RequestOptions, WasiHttpHooks,
+        bindings::http::types::{DnsErrorPayload, ErrorCode},
+    },
+};
+
+use super::{RwStream, native_root_tls_config};
+
+/// [`WasiHttpHooks`] implementation that trusts native OS CA certificates in addition to
+/// the built-in [`webpki_roots`] bundle.
+pub(crate) struct NativeCertHooks;
+
+impl WasiHttpHooks for NativeCertHooks {
+    fn send_request(
+        &mut self,
+        request: http::Request<UnsyncBoxBody<Bytes, ErrorCode>>,
+        options: Option<RequestOptions>,
+        _fut: Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
+    ) -> Box<
+        dyn Future<
+                Output = Result<
+                    (
+                        http::Response<UnsyncBoxBody<Bytes, ErrorCode>>,
+                        Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
+                    ),
+                    TrappableError<ErrorCode>,
+                >,
+            > + Send,
+    > {
+        Box::new(async move {
+            let (res, io) = send(request, options).await.map_err(TrappableError::from)?;
+            Ok((
+                res.map(http_body_util::BodyExt::boxed_unsync),
+                Box::new(io) as Box<dyn Future<Output = Result<(), ErrorCode>> + Send>,
+            ))
+        })
+    }
+}
+
+async fn send(
+    mut req: http::Request<UnsyncBoxBody<Bytes, ErrorCode>>,
+    options: Option<RequestOptions>,
+) -> Result<
+    (
+        http::Response<ResponseBody>,
+        impl Future<Output = Result<(), ErrorCode>> + Send,
+    ),
+    ErrorCode,
+> {
+    use core::future::poll_fn;
+    use core::pin::pin;
+
+    let uri = req.uri();
+    let authority = uri
+        .authority()
+        .ok_or(ErrorCode::HttpRequestUriInvalid)?
+        .clone();
+    let use_tls = uri.scheme() == Some(&Scheme::HTTPS);
+    let addr = if authority.port().is_some() {
+        authority.to_string()
+    } else {
+        format!("{}:{}", authority, if use_tls { 443 } else { 80 })
+    };
+
+    let connect_timeout = options
+        .and_then(|o| o.connect_timeout)
+        .unwrap_or(Duration::from_mins(10));
+    let first_byte_timeout = options
+        .and_then(|o| o.first_byte_timeout)
+        .unwrap_or(Duration::from_mins(10));
+    let between_bytes_timeout = options
+        .and_then(|o| o.between_bytes_timeout)
+        .unwrap_or(Duration::from_mins(10));
+
+    let tcp = match tokio::time::timeout(connect_timeout, TcpStream::connect(&addr)).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) if e.kind() == std::io::ErrorKind::AddrNotAvailable => {
+            return Err(ErrorCode::DnsError(DnsErrorPayload {
+                rcode: Some("address not available".to_string()),
+                info_code: Some(0),
+            }));
+        }
+        Ok(Err(e))
+            if e.to_string()
+                .starts_with("failed to lookup address information") =>
+        {
+            return Err(ErrorCode::DnsError(DnsErrorPayload {
+                rcode: Some("address not available".to_string()),
+                info_code: Some(0),
+            }));
+        }
+        Ok(Err(_)) => return Err(ErrorCode::ConnectionRefused),
+        Err(_) => return Err(ErrorCode::ConnectionTimeout),
+    };
+
+    let stream: Box<dyn RwStream> = if use_tls {
+        use rustls::pki_types::ServerName;
+
+        let connector = tokio_rustls::TlsConnector::from(native_root_tls_config());
+        let domain = ServerName::try_from(authority.host())
+            .map_err(|e| {
+                warn!("invalid DNS name: {e:?}");
+                ErrorCode::DnsError(DnsErrorPayload {
+                    rcode: Some("invalid dns name".to_string()),
+                    info_code: Some(0),
+                })
+            })?
+            .to_owned();
+        let tls = connector.connect(domain, tcp).await.map_err(|e| {
+            warn!("TLS protocol error: {e:?}");
+            ErrorCode::TlsProtocolError
+        })?;
+        Box::new(tls)
+    } else {
+        Box::new(tcp)
+    };
+
+    let (mut sender, conn) = tokio::time::timeout(
+        connect_timeout,
+        hyper::client::conn::http1::Builder::new().handshake(TokioIo::new(stream)),
+    )
+    .await
+    .map_err(|_| ErrorCode::ConnectionTimeout)?
+    .map_err(ErrorCode::from_hyper_request_error)?;
+
+    // HTTP/1.1 must not include scheme or authority in the request URI.
+    *req.uri_mut() = http::Uri::builder()
+        .path_and_query(
+            req.uri()
+                .path_and_query()
+                .map_or("/", http::uri::PathAndQuery::as_str),
+        )
+        .build()
+        .expect("comes from valid request");
+
+    let send_fut = async move {
+        let res = tokio::time::timeout(first_byte_timeout, sender.send_request(req))
+            .await
+            .map_err(|_| ErrorCode::ConnectionReadTimeout)?
+            .map_err(ErrorCode::from_hyper_request_error)?;
+        let mut timeout = tokio::time::interval(between_bytes_timeout);
+        timeout.reset();
+        Ok(res.map(|incoming| ResponseBody { incoming, timeout }))
+    };
+
+    let mut send_fut = pin!(send_fut);
+    let mut conn = Some(conn);
+
+    // Drive connection I/O alongside the send future.
+    let res = poll_fn(|cx| match send_fut.as_mut().poll(cx) {
+        Poll::Ready(v) => Poll::Ready(v),
+        Poll::Pending => {
+            let Some(ref mut c) = conn else {
+                return Poll::Pending;
+            };
+            match ready!(Pin::new(c).poll(cx)) {
+                Ok(()) => {
+                    conn = None;
+                    send_fut.as_mut().poll(cx)
+                }
+                Err(err) => Poll::Ready(Err(ErrorCode::from_hyper_request_error(err))),
+            }
+        }
+    })
+    .await?;
+
+    // Wait for connection close after the response body is consumed.
+    let io_fut = async move {
+        let Some(c) = conn else {
+            return Ok(());
+        };
+        c.await.map_err(|err| {
+            if err.is_timeout() {
+                ErrorCode::HttpResponseTimeout
+            } else {
+                ErrorCode::HttpProtocolError
+            }
+        })
+    };
+
+    Ok((res, io_fut))
+}
+
+/// Response body that enforces the between-bytes read timeout.
+struct ResponseBody {
+    incoming: hyper::body::Incoming,
+    timeout: tokio::time::Interval,
+}
+
+impl http_body::Body for ResponseBody {
+    type Data = Bytes;
+    type Error = ErrorCode;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        match Pin::new(&mut self.as_mut().incoming).poll_frame(cx) {
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(if err.is_timeout() {
+                ErrorCode::HttpResponseTimeout
+            } else {
+                ErrorCode::HttpProtocolError
+            }))),
+            Poll::Ready(Some(Ok(frame))) => {
+                self.timeout.reset();
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Pending => {
+                ready!(self.timeout.poll_tick(cx));
+                Poll::Ready(Some(Err(ErrorCode::ConnectionReadTimeout)))
+            }
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.incoming.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.incoming.size_hint()
+    }
+}

--- a/crates/component-cli-internal-run/src/lib.rs
+++ b/crates/component-cli-internal-run/src/lib.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::print_stderr)]
-
 //! Internal crate for executing WebAssembly components via Wasmtime.
 //!
 //! This crate is **not** intended for third-party consumption — it is an
@@ -14,9 +13,10 @@
 //!   `wasi:cli/run@0.2.0#run`.
 //! - [`execute_library_function`] — invokes an arbitrary exported
 //!   function on a "library-style" component using wasmtime's untyped
-//!   `Func::call` API.
+//!   `Func::call_async` API.
 
 mod errors;
+mod http_hooks;
 
 use miette::Context;
 use wasmparser::{Encoding, Parser, Payload};
@@ -26,6 +26,9 @@ use wasmtime_wasi::p2::bindings::sync::Command;
 use wasmtime_wasi::{DirPerms, FilePerms, ResourceTable, WasiCtxBuilder, WasiCtxView, WasiView};
 use wasmtime_wasi_http::WasiHttpCtx;
 use wasmtime_wasi_http::p2::{WasiHttpCtxView, WasiHttpView};
+use wasmtime_wasi_http::p3::{
+    WasiHttpCtxView as WasiHttpCtxViewP3, WasiHttpView as WasiHttpViewP3,
+};
 
 pub use errors::RunError;
 
@@ -34,6 +37,8 @@ struct WasiState {
     ctx: wasmtime_wasi::WasiCtx,
     http: WasiHttpCtx,
     table: ResourceTable,
+    p2_hooks: http_hooks::NativeCertHooksP2,
+    p3_hooks: http_hooks::NativeCertHooks,
 }
 
 impl WasiView for WasiState {
@@ -50,7 +55,17 @@ impl WasiHttpView for WasiState {
         WasiHttpCtxView {
             ctx: &mut self.http,
             table: &mut self.table,
-            hooks: Default::default(),
+            hooks: &mut self.p2_hooks,
+        }
+    }
+}
+
+impl WasiHttpViewP3 for WasiState {
+    fn http(&mut self) -> WasiHttpCtxViewP3<'_> {
+        WasiHttpCtxViewP3 {
+            ctx: &mut self.http,
+            table: &mut self.table,
+            hooks: &mut self.p3_hooks,
         }
     }
 }
@@ -131,6 +146,8 @@ fn build_wasi_state(
         ctx: wasi_ctx,
         http: WasiHttpCtx::new(),
         table: ResourceTable::new(),
+        p2_hooks: http_hooks::NativeCertHooksP2,
+        p3_hooks: http_hooks::NativeCertHooks,
     })
 }
 
@@ -181,7 +198,7 @@ pub fn execute_cli_component(
 }
 
 /// Invoke an arbitrary exported function on a "library-style"
-/// component using wasmtime's untyped `Func::call` API.
+/// component using wasmtime's untyped `Func::call_async` API.
 ///
 /// `interface` selects an exported interface (e.g. `"math"`); pass
 /// `None` for free world-level exports. `func` is the function name.
@@ -192,7 +209,7 @@ pub fn execute_cli_component(
 /// or invocation failures.
 // r[impl run.library-detection]
 // r[impl run.library-dispatch]
-pub fn execute_library_function(
+pub async fn execute_library_function(
     bytes: &[u8],
     permissions: &component_manifest::ResolvedPermissions,
     interface: Option<&str>,
@@ -208,18 +225,21 @@ pub fn execute_library_function(
     let mut store = Store::new(&engine, state);
 
     let mut linker: Linker<WasiState> = Linker::new(&engine);
-    wasmtime_wasi::p2::add_to_linker_sync(&mut linker).map_err(into_miette)?;
+    wasmtime_wasi::p2::add_to_linker_async(&mut linker).map_err(into_miette)?;
     // Make wasi:http/outgoing-handler available so library functions
     // can opportunistically perform outbound HTTP. Use the
     // http-only variant to avoid colliding with `wasi:io/error` etc.
-    // already provided by `wasmtime_wasi::p2::add_to_linker_sync`.
-    wasmtime_wasi_http::p2::add_only_http_to_linker_sync(&mut linker).map_err(into_miette)?;
+    // already provided by `wasmtime_wasi::p2::add_to_linker_async`.
+    wasmtime_wasi_http::p2::add_only_http_to_linker_async(&mut linker).map_err(into_miette)?;
+    // Also provide WASI HTTP 0.3-rc interfaces for components targeting wasi:http 0.3.
+    wasmtime_wasi_http::p3::add_to_linker(&mut linker).map_err(into_miette)?;
 
-    let instance = linker.instantiate(&mut store, &component).map_err(|e| {
-        RunError::LibraryInstantiationFailed {
+    let instance = linker
+        .instantiate_async(&mut store, &component)
+        .await
+        .map_err(|e| RunError::LibraryInstantiationFailed {
             cause: format!("{e:#}"),
-        }
-    })?;
+        })?;
 
     // Look up the function. Two-phase via `Component::get_export_index`
     // for interface-nested functions; direct `instance.get_func` for
@@ -256,10 +276,10 @@ pub fn execute_library_function(
     let mut results = vec![Val::Bool(false); result_count];
 
     target
-        .call(&mut store, args, &mut results)
+        .call_async(&mut store, args, &mut results)
+        .await
         .map_err(into_miette)
         .wrap_err_with(|| format!("invoking {}", display_path(interface, func)))?;
-    // CRITICAL: do NOT call `Func::post_return` — automatic in wasmtime 43+.
 
     Ok(results)
 }

--- a/crates/component-cli/Cargo.toml
+++ b/crates/component-cli/Cargo.toml
@@ -49,6 +49,7 @@ wasmparser = { workspace = true }
 wac-parser = { workspace = true }
 wac-graph = { workspace = true }
 wac-resolver = { workspace = true }
+rustls = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }

--- a/crates/component-cli/src/main.rs
+++ b/crates/component-cli/src/main.rs
@@ -142,6 +142,12 @@ fn init_tracing(
 
 #[tokio::main]
 async fn main() -> miette::Result<()> {
+    // Install ring as the default rustls crypto provider so that TLS connections
+    // made by WASI 0.3 HTTP components work without a panic.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
     // Load .env file if present; variables already set in the environment
     // take precedence (system environment is not overridden).
     dotenvy::dotenv().ok();

--- a/crates/component-cli/src/run/mod.rs
+++ b/crates/component-cli/src/run/mod.rs
@@ -596,25 +596,19 @@ async fn run_library_component(
     };
     let invocation = parse_invocation(&matches, &surface).map_err(|e| miette::miette!("{e}"))?;
 
-    // 3. Invoke off-thread (sync wasmtime).
-    let bytes_owned = bytes.to_vec();
-    let permissions_owned = permissions.clone();
+    // 3. Invoke asynchronously (component-model-async engine).
     let interface = invocation.path.interface.clone();
     let func = invocation.path.func.clone();
     let func_args = invocation.args;
     let expected_results = invocation.expected_results;
-    let results = tokio::task::spawn_blocking(move || {
-        component_cli_internal_run::execute_library_function(
-            &bytes_owned,
-            &permissions_owned,
-            interface.as_deref(),
-            &func,
-            &func_args,
-        )
-    })
-    .await
-    .into_diagnostic()
-    .wrap_err("runtime task panicked")??;
+    let results = component_cli_internal_run::execute_library_function(
+        bytes,
+        permissions,
+        interface.as_deref(),
+        &func,
+        &func_args,
+    )
+    .await?;
 
     // Sanity-check that wasmtime returned the number of values the
     // WIT signature declared. A mismatch would indicate either a


### PR DESCRIPTION
## Summary

Adds WASI 0.3-rc HTTP support to the library component runner. Split out of #362 (contains none of that PR's wit2cli or release-tooling changes).

## Changes

- **Enable wasmtime `component-model-async`** and the `wasmtime-wasi-http` `p3` feature so components targeting `wasi:http` 0.3 (and `stream`/`future` types) can be compiled and instantiated.
- **Async library execution**: `execute_library_function` now uses `add_to_linker_async`, `instantiate_async`, and `call_async`, and the CLI calls it directly on the async runtime instead of via `spawn_blocking`. WASI 0.3-rc HTTP interfaces are registered via `wasmtime_wasi_http::p3::add_to_linker`.
- **Custom `WasiHttpHooks`** in `crates/component-cli-internal-run/src/http_hooks.rs` that augment the TLS root store with native OS CA certificates (`rustls-native-certs`) for both WASI HTTP P2 and P3. This replaces the vendored `wasmtime-wasi-http` patch that #362 temporarily carried (no `vendor/` files are included here).
- **Engine dedup**: the HTTP/library run paths reuse `build_engine()` from `component-cli-internal-run`.
- **TLS bootstrap**: install the `ring` rustls crypto provider at startup so P2/P3 native TLS connections don't panic.

## Excluded (belong to other PRs)

No `crates/wit2cli/**`, `Justfile`, `.github/workflows/release-fork.yml`, or `vendor/**` changes.

## Verification

`cargo xtask test` passes clean (fmt + clippy + test + sql check).