### PR TITLE
fix(wit2cli): skip unsupported functions, support option/list records, wasmparser fallback

### DIFF
--- a/crates/component-cli/src/run/mod.rs
+++ b/crates/component-cli/src/run/mod.rs
@@ -567,6 +567,16 @@ async fn run_library_component(
                 "component exports the resource `{name}`, which is not supported by `component run`"
             ));
         }
+        // r[impl run.library-resources-rejected]
+        // Every export was skipped because it uses an unsupported type
+        // (resources, streams, futures, …), so there is nothing to invoke.
+        Err(LibraryExtractError::NoInvocableFunctions { reasons }) => {
+            return Err(miette::miette!(
+                help = "library-style invocation does not support these types; \
+                        use a CLI or HTTP component instead",
+                "no invocable functions: every export uses an unsupported type ({reasons})"
+            ));
+        }
         Err(e) => return Err(miette::miette!("{e}")),
     };
 

--- a/crates/wit2cli/Cargo.toml
+++ b/crates/wit2cli/Cargo.toml
@@ -16,6 +16,7 @@ clap = { workspace = true }
 miette = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+wasmparser = { workspace = true }
 wasmtime = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }

--- a/crates/wit2cli/src/cli.rs
+++ b/crates/wit2cli/src/cli.rs
@@ -63,6 +63,16 @@ pub enum CliError {
     },
 }
 
+impl CliError {
+    /// Whether this error means a single export should be skipped (it uses a
+    /// type we cannot express as a CLI argument) rather than aborting the
+    /// entire CLI build. Genuine build errors such as flag collisions are not
+    /// skippable and must propagate.
+    fn is_skippable(&self) -> bool {
+        matches!(self, CliError::UnsupportedArg { .. })
+    }
+}
+
 /// Build a top-level `clap::Command` representing every export of
 /// `surface` as a sub-command tree.
 // r[impl run.library-help]
@@ -75,9 +85,13 @@ pub fn build_clap(surface: &LibrarySurface, program_name: &str) -> Result<Comman
 
     for item in &surface.items {
         match item {
-            LibraryItem::Func(f) => {
-                root = root.subcommand(build_func_command(f)?);
-            }
+            LibraryItem::Func(f) => match build_func_command(f) {
+                Ok(cmd) => root = root.subcommand(cmd),
+                // Skip exports that use unsupported argument types; propagate
+                // real build errors (e.g. flag collisions).
+                Err(e) if e.is_skippable() => {}
+                Err(e) => return Err(e),
+            },
             LibraryItem::Interface {
                 name, doc, funcs, ..
             } => {
@@ -87,10 +101,20 @@ pub fn build_clap(surface: &LibrarySurface, program_name: &str) -> Result<Comman
                 if let Some(doc) = doc {
                     iface_cmd = iface_cmd.about(doc.trim().to_string());
                 }
+                let mut added = 0usize;
                 for f in funcs {
-                    iface_cmd = iface_cmd.subcommand(build_func_command(f)?);
+                    match build_func_command(f) {
+                        Ok(cmd) => {
+                            iface_cmd = iface_cmd.subcommand(cmd);
+                            added += 1;
+                        }
+                        Err(e) if e.is_skippable() => {}
+                        Err(e) => return Err(e),
+                    }
                 }
-                root = root.subcommand(iface_cmd);
+                if added > 0 {
+                    root = root.subcommand(iface_cmd);
+                }
             }
         }
     }
@@ -154,6 +178,29 @@ fn add_param_args(
                 };
                 let arg = positional_for_primitive(&inner_param);
                 cmd = cmd.arg(arg.required(false));
+                Ok(cmd)
+            }
+            // option<record>: expand each inner field as an optional
+            // --param-field flag. If none are provided the whole option
+            // collapses to None at collection time.
+            WitTy::Record(fields) => {
+                for (fname, fty) in fields {
+                    let flag = format!("{}-{}", param.name, fname);
+                    if !seen.insert(flag.clone()) {
+                        return Err(CliError::FlagCollision { flag });
+                    }
+                    // Unwrap one layer of option<T> for the field itself.
+                    let effective = match fty {
+                        WitTy::Option(inner_inner) => inner_inner.as_ref(),
+                        other => other,
+                    };
+                    let arg = Arg::new(flag.clone())
+                        .long(flag)
+                        .required(false)
+                        .num_args(1)
+                        .help(format!("field `{fname}` of optional `{}`", param.name));
+                    cmd = cmd.arg(attach_value_parser(arg, effective));
+                }
                 Ok(cmd)
             }
             other => Err(CliError::UnsupportedArg {
@@ -460,8 +507,36 @@ fn collect_one(
 ) -> Result<Val, CliError> {
     match &param.ty {
         WitTy::Option(inner) => {
-            // Try to read a positional value; if absent, return None.
             let id = param.name.as_str();
+            // option<record>: flags are --{param}-{field}; collapse to None
+            // if none of them were supplied.
+            if let WitTy::Record(fields) = inner.as_ref() {
+                let any = fields
+                    .iter()
+                    .any(|(fname, _)| matches.contains_id(&format!("{id}-{fname}")));
+                if !any {
+                    return Ok(Val::Option(None));
+                }
+                let mut pairs = Vec::with_capacity(fields.len());
+                for (fname, fty) in fields {
+                    let flag = format!("{id}-{fname}");
+                    let v = match fty {
+                        WitTy::Option(inner_ty) => {
+                            if matches.contains_id(&flag) {
+                                Val::Option(Some(Box::new(collect_typed(
+                                    matches, &flag, inner_ty,
+                                )?)))
+                            } else {
+                                Val::Option(None)
+                            }
+                        }
+                        other => collect_typed(matches, &flag, other)?,
+                    };
+                    pairs.push((fname.clone(), v));
+                }
+                return Ok(Val::Option(Some(Box::new(Val::Record(pairs)))));
+            }
+            // Primitives and other option<T>: read a single positional value.
             if matches.contains_id(id) {
                 let inner_param = ParamDecl {
                     name: param.name.clone(),
@@ -683,7 +758,30 @@ fn collect_typed_many(matches: &ArgMatches, id: &str, ty: &WitTy) -> Result<Vec<
             }
             out
         }
+        // list<record>: each flag value is a JSON object string.
+        WitTy::Record(fields) => {
+            let raws: Vec<String> = matches
+                .get_many::<String>(id)
+                .map(|it| it.cloned().collect())
+                .unwrap_or_default();
+            let mut out = Vec::with_capacity(raws.len());
+            for raw in &raws {
+                let json: serde_json::Value =
+                    serde_json::from_str(raw).map_err(|e| CliError::InvalidValue {
+                        param: id.to_string(),
+                        reason: format!("expected JSON object for record element: {e}"),
+                    })?;
+                out.push(json_to_val(id, fields, &json)?);
+            }
+            out
+        }
         other => {
+            // If the user provided no values for this flag, return an empty
+            // list rather than failing — list<record> fields are optional and
+            // the component's default behaviour applies when omitted.
+            if matches.get_many::<String>(id).is_none() {
+                return Ok(vec![]);
+            }
             return Err(CliError::UnsupportedArg {
                 param: id.to_string(),
                 reason: format!(
@@ -692,6 +790,83 @@ fn collect_typed_many(matches: &ArgMatches, id: &str, ty: &WitTy) -> Result<Vec<
                 ),
             });
         }
+    })
+}
+
+/// Convert a JSON value to a [`Val`] using a WIT record's field schema.
+/// Used by `collect_typed_many` for `list<record>` parameters.
+fn json_to_val(
+    param: &str,
+    fields: &[(String, WitTy)],
+    json: &serde_json::Value,
+) -> Result<Val, CliError> {
+    let obj = json.as_object().ok_or_else(|| CliError::InvalidValue {
+        param: param.to_string(),
+        reason: "expected a JSON object".to_string(),
+    })?;
+    let mut pairs = Vec::with_capacity(fields.len());
+    for (fname, fty) in fields {
+        let jval = obj.get(fname).unwrap_or(&serde_json::Value::Null);
+        let v = json_scalar_to_val(param, fname, fty, jval)?;
+        pairs.push((fname.clone(), v));
+    }
+    Ok(Val::Record(pairs))
+}
+
+/// Convert a single JSON scalar to a [`Val`] for the given WIT type.
+fn json_scalar_to_val(
+    param: &str,
+    fname: &str,
+    ty: &WitTy,
+    json: &serde_json::Value,
+) -> Result<Val, CliError> {
+    let err = || CliError::InvalidValue {
+        param: format!("{param}.{fname}"),
+        reason: format!("cannot convert JSON `{json}` to {}", debug_kind(ty)),
+    };
+    Ok(match (ty, json) {
+        (WitTy::String, serde_json::Value::String(s)) => Val::String(s.clone()),
+        (WitTy::Bool, serde_json::Value::Bool(b)) => Val::Bool(*b),
+        (WitTy::U8, serde_json::Value::Number(n)) => {
+            Val::U8(u8::try_from(n.as_u64().ok_or_else(err)?).map_err(|_| err())?)
+        }
+        (WitTy::U16, serde_json::Value::Number(n)) => {
+            Val::U16(u16::try_from(n.as_u64().ok_or_else(err)?).map_err(|_| err())?)
+        }
+        (WitTy::U32, serde_json::Value::Number(n)) => {
+            Val::U32(u32::try_from(n.as_u64().ok_or_else(err)?).map_err(|_| err())?)
+        }
+        (WitTy::U64, serde_json::Value::Number(n)) => Val::U64(n.as_u64().ok_or_else(err)?),
+        (WitTy::S8, serde_json::Value::Number(n)) => {
+            Val::S8(i8::try_from(n.as_i64().ok_or_else(err)?).map_err(|_| err())?)
+        }
+        (WitTy::S16, serde_json::Value::Number(n)) => {
+            Val::S16(i16::try_from(n.as_i64().ok_or_else(err)?).map_err(|_| err())?)
+        }
+        (WitTy::S32, serde_json::Value::Number(n)) => {
+            Val::S32(i32::try_from(n.as_i64().ok_or_else(err)?).map_err(|_| err())?)
+        }
+        (WitTy::S64, serde_json::Value::Number(n)) => Val::S64(n.as_i64().ok_or_else(err)?),
+        (WitTy::F32, serde_json::Value::Number(n)) => {
+            #[allow(clippy::cast_possible_truncation)]
+            let v = n.as_f64().ok_or_else(err)? as f32;
+            Val::Float32(v)
+        }
+        (WitTy::Option(_), serde_json::Value::Null) => Val::Option(None),
+        (WitTy::Option(inner), v) => {
+            Val::Option(Some(Box::new(json_scalar_to_val(param, fname, inner, v)?)))
+        }
+        (WitTy::Record(inner_fields), serde_json::Value::Object(_)) => {
+            json_to_val(param, inner_fields, json)?
+        }
+        (WitTy::List(inner), serde_json::Value::Array(arr)) => {
+            let mut items = Vec::with_capacity(arr.len());
+            for item in arr {
+                items.push(json_scalar_to_val(param, fname, inner, item)?);
+            }
+            Val::List(items)
+        }
+        _ => return Err(err()),
     })
 }
 

--- a/crates/wit2cli/src/cli.rs
+++ b/crates/wit2cli/src/cli.rs
@@ -197,9 +197,16 @@ fn add_param_args(
                     let arg = Arg::new(flag.clone())
                         .long(flag)
                         .required(false)
-                        .num_args(1)
                         .help(format!("field `{fname}` of optional `{}`", param.name));
-                    cmd = cmd.arg(attach_value_parser(arg, effective));
+                    // list<T> fields are repeatable flags: --flag v1 --flag v2,
+                    // matching how non-optional record list fields are collected.
+                    if let WitTy::List(inner) = effective {
+                        let arg = arg.action(ArgAction::Append).num_args(1);
+                        cmd = cmd.arg(attach_value_parser(arg, inner));
+                    } else {
+                        let arg = arg.num_args(1);
+                        cmd = cmd.arg(attach_value_parser(arg, effective));
+                    }
                 }
                 Ok(cmd)
             }
@@ -1225,5 +1232,166 @@ mod tests {
         ))]);
         let err = build_clap(&s, "test").expect_err("must detect collision");
         assert!(matches!(err, CliError::FlagCollision { ref flag } if flag == "a-b-c"));
+    }
+
+    // r[verify run.library-args]
+    #[test]
+    fn option_record_collapses_to_none() {
+        // option<record> with none of its --param-field flags supplied
+        // collapses to `none`.
+        let rec_ty = WitTy::Record(vec![
+            ("name".to_string(), WitTy::String),
+            ("age".to_string(), WitTy::U32),
+        ]);
+        let s = surface(vec![LibraryItem::Func(func(
+            "set",
+            vec![("who", WitTy::Option(Box::new(rec_ty)))],
+        ))]);
+        let inv = parse(&s, &["set"]).unwrap();
+        assert!(matches!(&inv.args[0], Val::Option(None)));
+    }
+
+    // r[verify run.library-args]
+    #[test]
+    fn option_record_with_values() {
+        // Supplying any field flag materializes the whole record inside `some`.
+        let rec_ty = WitTy::Record(vec![
+            ("name".to_string(), WitTy::String),
+            ("age".to_string(), WitTy::Option(Box::new(WitTy::U32))),
+        ]);
+        let s = surface(vec![LibraryItem::Func(func(
+            "set",
+            vec![("who", WitTy::Option(Box::new(rec_ty)))],
+        ))]);
+        let inv = parse(&s, &["set", "--who-name", "ada"]).unwrap();
+        let Val::Option(Some(boxed)) = &inv.args[0] else {
+            panic!("expected some(record)");
+        };
+        let Val::Record(pairs) = boxed.as_ref() else {
+            panic!("expected record");
+        };
+        assert!(matches!(&pairs[0].1, Val::String(s) if s == "ada"));
+        // The unsupplied optional field is `none`.
+        assert!(matches!(&pairs[1].1, Val::Option(None)));
+    }
+
+    // r[verify run.library-args]
+    #[test]
+    fn option_record_with_repeatable_list_field() {
+        // A list field inside option<record> must accept multiple
+        // --param-field occurrences, like non-optional record list fields.
+        let rec_ty = WitTy::Record(vec![
+            ("name".to_string(), WitTy::String),
+            ("tags".to_string(), WitTy::List(Box::new(WitTy::String))),
+        ]);
+        let s = surface(vec![LibraryItem::Func(func(
+            "set",
+            vec![("who", WitTy::Option(Box::new(rec_ty)))],
+        ))]);
+        let inv = parse(
+            &s,
+            &[
+                "set",
+                "--who-name",
+                "ada",
+                "--who-tags",
+                "a",
+                "--who-tags",
+                "b",
+            ],
+        )
+        .unwrap();
+        let Val::Option(Some(boxed)) = &inv.args[0] else {
+            panic!("expected some(record)");
+        };
+        let Val::Record(pairs) = boxed.as_ref() else {
+            panic!("expected record");
+        };
+        assert_eq!(pairs[1].0, "tags");
+        let Val::List(elems) = &pairs[1].1 else {
+            panic!("expected list");
+        };
+        assert_eq!(elems.len(), 2);
+        assert!(matches!(&elems[0], Val::String(s) if s == "a"));
+        assert!(matches!(&elems[1], Val::String(s) if s == "b"));
+    }
+
+    // r[verify run.library-args]
+    #[test]
+    fn list_record_json_input() {
+        // list<record> elements are supplied as JSON object strings, one per
+        // repeated flag occurrence, and may contain nested options/lists.
+        let rec_ty = WitTy::Record(vec![
+            ("name".to_string(), WitTy::String),
+            ("age".to_string(), WitTy::Option(Box::new(WitTy::U32))),
+            ("tags".to_string(), WitTy::List(Box::new(WitTy::String))),
+        ]);
+        let s = surface(vec![LibraryItem::Func(func(
+            "add",
+            vec![("people", WitTy::List(Box::new(rec_ty)))],
+        ))]);
+        let inv = parse(
+            &s,
+            &[
+                "add",
+                r#"{"name":"ada","age":36,"tags":["x","y"]}"#,
+                r#"{"name":"bob","tags":[]}"#,
+            ],
+        )
+        .unwrap();
+        let Val::List(elems) = &inv.args[0] else {
+            panic!("expected list");
+        };
+        assert_eq!(elems.len(), 2);
+        let Val::Record(first) = &elems[0] else {
+            panic!("expected record");
+        };
+        assert!(matches!(&first[0].1, Val::String(s) if s == "ada"));
+        assert!(matches!(&first[1].1, Val::Option(Some(b)) if matches!(b.as_ref(), Val::U32(36))));
+        let Val::List(tags) = &first[2].1 else {
+            panic!("expected list");
+        };
+        assert_eq!(tags.len(), 2);
+        // Second element: omitted optional `age` becomes `none`.
+        let Val::Record(second) = &elems[1] else {
+            panic!("expected record");
+        };
+        assert!(matches!(&second[1].1, Val::Option(None)));
+    }
+
+    // r[verify run.library-args]
+    #[test]
+    fn list_record_missing_required_field_errors() {
+        // A required (non-option) field absent from the JSON object is an error.
+        let rec_ty = WitTy::Record(vec![
+            ("name".to_string(), WitTy::String),
+            ("age".to_string(), WitTy::U32),
+        ]);
+        let s = surface(vec![LibraryItem::Func(func(
+            "add",
+            vec![("people", WitTy::List(Box::new(rec_ty)))],
+        ))]);
+        let err = parse(&s, &["add", r#"{"name":"ada"}"#])
+            .expect_err("missing required field must error");
+        assert!(
+            err.contains("age"),
+            "expected error to mention `age`: {err}"
+        );
+    }
+
+    // r[verify run.library-args]
+    #[test]
+    fn list_record_invalid_json_errors() {
+        // A malformed JSON object string is rejected.
+        let rec_ty = WitTy::Record(vec![("name".to_string(), WitTy::String)]);
+        let s = surface(vec![LibraryItem::Func(func(
+            "add",
+            vec![("people", WitTy::List(Box::new(rec_ty)))],
+        ))]);
+        let err = parse(&s, &["add", "not-json"]).expect_err("invalid JSON must error");
+        assert!(
+            err.to_lowercase().contains("json"),
+            "expected error to mention JSON: {err}"
+        );
     }
 }

--- a/crates/wit2cli/src/wit.rs
+++ b/crates/wit2cli/src/wit.rs
@@ -181,6 +181,19 @@ pub enum LibraryExtractError {
     },
 }
 
+impl LibraryExtractError {
+    /// Whether this error means a single export should be skipped (it uses a
+    /// type we cannot express as a CLI argument) rather than aborting the
+    /// whole extraction. Decode/invariant failures are *not* skippable — they
+    /// indicate a real problem and must propagate so extraction fails loudly.
+    fn is_skippable(&self) -> bool {
+        matches!(
+            self,
+            LibraryExtractError::Resource { .. } | LibraryExtractError::UnsupportedKind { .. }
+        )
+    }
+}
+
 /// Best-effort extraction for components that lack a `component-type` custom
 /// section (e.g. components built with older `wit-bindgen` toolchains).
 ///
@@ -431,7 +444,9 @@ pub fn extract_library_surface(bytes: &[u8]) -> Result<LibrarySurface, LibraryEx
                 match func_to_decl(&resolve, &func.name, func) {
                     Ok(decl) => items.push(LibraryItem::Func(decl)),
                     // skip functions with unsupported types (streams, futures, resources, etc.)
-                    Err(e) => skipped.push(e.to_string()),
+                    Err(e) if e.is_skippable() => skipped.push(e.to_string()),
+                    // decode/invariant errors are real bugs — fail loudly.
+                    Err(e) => return Err(e),
                 }
             }
             WorldItem::Interface { id, .. } => {
@@ -452,7 +467,9 @@ pub fn extract_library_surface(bytes: &[u8]) -> Result<LibrarySurface, LibraryEx
                     match func_to_decl(&resolve, &func.name, func) {
                         Ok(decl) => funcs.push(decl),
                         // skip functions with unsupported types (streams, futures, resources, etc.)
-                        Err(e) => skipped.push(e.to_string()),
+                        Err(e) if e.is_skippable() => skipped.push(e.to_string()),
+                        // decode/invariant errors are real bugs — fail loudly.
+                        Err(e) => return Err(e),
                     }
                 }
                 if !funcs.is_empty() {

--- a/crates/wit2cli/src/wit.rs
+++ b/crates/wit2cli/src/wit.rs
@@ -169,12 +169,248 @@ pub enum LibraryExtractError {
         /// (`"future"`, `"stream"`, `"map"`, etc.).
         kind: &'static str,
     },
+    // r[impl run.library-resources-rejected]
+    /// Every exported function was skipped because it uses an
+    /// unsupported type (resource, stream, future, …), leaving no
+    /// invocable surface to expose as a CLI.
+    #[error("no invocable functions: all exports use unsupported types ({reasons})")]
+    NoInvocableFunctions {
+        /// Comma-separated reasons describing why each export was
+        /// skipped (e.g. the resource/stream/future detail).
+        reasons: String,
+    },
+}
+
+/// Best-effort extraction for components that lack a `component-type` custom
+/// section (e.g. components built with older `wit-bindgen` toolchains).
+///
+/// Walks the binary with `wasmparser`, resolving exported functions from nested
+/// components and matching them to the top-level instance exports. Only
+/// primitive WIT types (`bool`, `s8`…`u64`, `f32/f64`, `char`, `string`) are
+/// resolved; functions with complex type references are silently skipped.
+///
+/// Returns `Some(LibrarySurface)` if at least one interface with at least one
+/// function was found, `None` otherwise.
+fn fallback_library_surface(bytes: &[u8]) -> Option<LibrarySurface> {
+    use std::collections::HashMap;
+    use wasmparser::{
+        ComponentExternalKind, ComponentType as WpComponentType, ComponentTypeRef,
+        ComponentValType, Encoding, Parser, Payload, PrimitiveValType,
+    };
+    // A nested component function signature: its named params and optional result.
+    type InnerFunc = (Vec<(String, ComponentValType)>, Option<ComponentValType>);
+
+    fn prim_to_wit(p: PrimitiveValType) -> Option<WitTy> {
+        #[allow(clippy::match_wildcard_for_single_variants)]
+        match p {
+            PrimitiveValType::Bool => Some(WitTy::Bool),
+            PrimitiveValType::S8 => Some(WitTy::S8),
+            PrimitiveValType::S16 => Some(WitTy::S16),
+            PrimitiveValType::S32 => Some(WitTy::S32),
+            PrimitiveValType::S64 => Some(WitTy::S64),
+            PrimitiveValType::U8 => Some(WitTy::U8),
+            PrimitiveValType::U16 => Some(WitTy::U16),
+            PrimitiveValType::U32 => Some(WitTy::U32),
+            PrimitiveValType::U64 => Some(WitTy::U64),
+            PrimitiveValType::F32 => Some(WitTy::F32),
+            PrimitiveValType::F64 => Some(WitTy::F64),
+            PrimitiveValType::Char => Some(WitTy::Char),
+            PrimitiveValType::String => Some(WitTy::String),
+            // `error-context` (and any future kinds) cannot be CLI args.
+            _ => None,
+        }
+    }
+
+    fn cval_to_wit(cty: ComponentValType) -> Option<WitTy> {
+        match cty {
+            ComponentValType::Primitive(p) => prim_to_wit(p),
+            ComponentValType::Type(_) => None, // complex type: skip
+        }
+    }
+
+    fn iface_short_name(export_name: &str) -> String {
+        // "local:time-server/time"   → "time"
+        // "wasi:io/streams@0.2.0"   → "streams"
+        let after_slash = export_name.rsplit('/').next().unwrap_or(export_name);
+        after_slash
+            .split('@')
+            .next()
+            .unwrap_or(after_slash)
+            .to_string()
+    }
+
+    let mut depth: u32 = 0;
+    let mut in_inner_component = false;
+    // Maps type index → signature within the current depth-2 component.
+    let mut inner_types: Vec<Option<InnerFunc>> = Vec::new();
+    // Collected function declarations: name → FuncDecl.
+    let mut func_map: HashMap<String, FuncDecl> = HashMap::new();
+    // Top-level instance exports: (full_export_name, short_interface_name).
+    let mut instance_exports: Vec<(String, String)> = Vec::new();
+    // Raw JSON from the `package-docs` custom section, if present.
+    let mut pkg_docs_json: Option<String> = None;
+
+    for payload in Parser::new(0).parse_all(bytes) {
+        let Ok(payload) = payload else { continue };
+        match payload {
+            Payload::Version { encoding, .. } => {
+                depth += 1;
+                if depth == 2 {
+                    in_inner_component = encoding == Encoding::Component;
+                    inner_types.clear();
+                }
+            }
+            Payload::End(_) => {
+                if depth == 2 {
+                    in_inner_component = false;
+                }
+                depth = depth.saturating_sub(1);
+            }
+            Payload::ComponentTypeSection(reader) if depth == 2 && in_inner_component => {
+                for ty in reader.into_iter().flatten() {
+                    match ty {
+                        WpComponentType::Func(ft) => {
+                            let params: Vec<(String, ComponentValType)> =
+                                ft.params.iter().map(|(n, t)| (n.to_string(), *t)).collect();
+                            inner_types.push(Some((params, ft.result)));
+                        }
+                        _ => inner_types.push(None),
+                    }
+                }
+            }
+            Payload::ComponentExportSection(reader) if depth == 2 && in_inner_component => {
+                for export in reader.into_iter().flatten() {
+                    if export.kind != ComponentExternalKind::Func {
+                        continue;
+                    }
+                    let type_idx = match export.ty {
+                        Some(ComponentTypeRef::Func(idx)) => idx as usize,
+                        _ => continue,
+                    };
+                    let Some(Some((params, result))) = inner_types.get(type_idx) else {
+                        continue;
+                    };
+                    let mut param_decls = Vec::new();
+                    let mut params_ok = true;
+                    for (pname, pty) in params {
+                        let Some(wty) = cval_to_wit(*pty) else {
+                            params_ok = false;
+                            break;
+                        };
+                        param_decls.push(ParamDecl {
+                            name: pname.clone(),
+                            ty: wty,
+                        });
+                    }
+                    if !params_ok {
+                        continue;
+                    }
+                    let result_decls = match result {
+                        Some(r) => match cval_to_wit(*r) {
+                            Some(wty) => vec![ResultDecl { ty: wty }],
+                            None => continue,
+                        },
+                        None => Vec::new(),
+                    };
+                    func_map.insert(
+                        export.name.0.to_string(),
+                        FuncDecl {
+                            name: export.name.0.to_string(),
+                            doc: None,
+                            params: param_decls,
+                            results: result_decls,
+                        },
+                    );
+                }
+            }
+            Payload::ComponentExportSection(reader) if depth == 1 => {
+                for export in reader.into_iter().flatten() {
+                    if export.kind == ComponentExternalKind::Instance {
+                        let full_name = export.name.0.to_string();
+                        let short_name = iface_short_name(&full_name);
+                        instance_exports.push((full_name, short_name));
+                    }
+                }
+            }
+            Payload::CustomSection(cs) if depth == 1 && cs.name() == "package-docs" => {
+                pkg_docs_json = std::str::from_utf8(cs.data()).ok().map(ToString::to_string);
+            }
+            _ => {}
+        }
+    }
+
+    if func_map.is_empty() || instance_exports.is_empty() {
+        return None;
+    }
+
+    // Parse `package-docs` JSON to get interface→(func→doc) mapping.
+    // Format: {"interfaces":{"time":{"funcs":{"get-current-time":{"docs":"..."}}}}}
+    let iface_funcs: Option<HashMap<String, HashMap<String, Option<String>>>> =
+        pkg_docs_json.as_deref().and_then(|json| {
+            let val: serde_json::Value = serde_json::from_str(json).ok()?;
+            let ifaces = val.get("interfaces")?.as_object()?;
+            let mut result: HashMap<String, HashMap<String, Option<String>>> = HashMap::new();
+            for (iname, ival) in ifaces {
+                let mut fmap: HashMap<String, Option<String>> = HashMap::new();
+                if let Some(funcs) = ival.get("funcs").and_then(|v| v.as_object()) {
+                    for (fname, fval) in funcs {
+                        let doc = fval
+                            .get("docs")
+                            .and_then(|v| v.as_str())
+                            .map(ToString::to_string);
+                        fmap.insert(fname.clone(), doc);
+                    }
+                }
+                result.insert(iname.clone(), fmap);
+            }
+            Some(result)
+        });
+
+    let mut items = Vec::new();
+    for (export_name, short_name) in &instance_exports {
+        let funcs: Vec<FuncDecl> = match iface_funcs.as_ref().and_then(|m| m.get(short_name)) {
+            Some(func_docs) => func_docs
+                .iter()
+                .filter_map(|(fname, doc)| {
+                    let mut decl = func_map.get(fname)?.clone();
+                    decl.doc.clone_from(doc);
+                    Some(decl)
+                })
+                .collect(),
+            None => func_map.values().cloned().collect(),
+        };
+        if !funcs.is_empty() {
+            items.push(LibraryItem::Interface {
+                name: short_name.clone(),
+                export_name: export_name.clone(),
+                doc: None,
+                funcs,
+            });
+        }
+    }
+
+    if items.is_empty() {
+        None
+    } else {
+        Some(LibrarySurface { items })
+    }
 }
 
 /// Decode `bytes` and walk the world's exports into a
 /// [`LibrarySurface`].
 pub fn extract_library_surface(bytes: &[u8]) -> Result<LibrarySurface, LibraryExtractError> {
-    let decoded = decode(bytes).map_err(|e| LibraryExtractError::Decode(e.to_string()))?;
+    let decoded = match decode(bytes) {
+        Ok(d) => d,
+        Err(e) => {
+            // `wit_parser::decode` requires a `component-type` custom section that
+            // older bindgen toolchains (e.g. wit-bindgen-c 0.37) do not emit.
+            // Try a direct wasmparser walk as a last resort.
+            if let Some(surface) = fallback_library_surface(bytes) {
+                return Ok(surface);
+            }
+            return Err(LibraryExtractError::Decode(e.to_string()));
+        }
+    };
     let (resolve, world_id) = match decoded {
         DecodedWasm::Component(r, w) => (r, w),
         DecodedWasm::WitPackage(_, _) => return Err(LibraryExtractError::NotAComponent),
@@ -186,28 +422,47 @@ pub fn extract_library_surface(bytes: &[u8]) -> Result<LibrarySurface, LibraryEx
         .ok_or_else(|| LibraryExtractError::Decode("world id not in resolve".to_string()))?;
 
     let mut items = Vec::new();
+    // Reasons why individual exports were skipped (unsupported types). Used to
+    // build a helpful error if *every* export ends up skipped.
+    let mut skipped: Vec<String> = Vec::new();
     for (key, item) in &world.exports {
         match item {
             WorldItem::Function(func) => {
-                let decl = func_to_decl(&resolve, &func.name, func)?;
-                items.push(LibraryItem::Func(decl));
+                match func_to_decl(&resolve, &func.name, func) {
+                    Ok(decl) => items.push(LibraryItem::Func(decl)),
+                    // skip functions with unsupported types (streams, futures, resources, etc.)
+                    Err(e) => skipped.push(e.to_string()),
+                }
             }
             WorldItem::Interface { id, .. } => {
                 let iface = resolve.interfaces.get(*id).ok_or_else(|| {
                     LibraryExtractError::Decode("interface id not in resolve".to_string())
                 })?;
                 let iface_name = world_key_label(&resolve, key, iface.name.as_deref());
+                // Skip "exports" — this is a componentize-py/componentize-js internal
+                // bootstrap interface (not part of the user-facing API). Calling its
+                // `init` function causes the Python/JS interpreter to panic because it
+                // is already running.
+                if iface_name == "exports" {
+                    continue;
+                }
                 let export_name = world_key_export_name(&resolve, key, iface);
                 let mut funcs = Vec::with_capacity(iface.functions.len());
                 for func in iface.functions.values() {
-                    funcs.push(func_to_decl(&resolve, &func.name, func)?);
+                    match func_to_decl(&resolve, &func.name, func) {
+                        Ok(decl) => funcs.push(decl),
+                        // skip functions with unsupported types (streams, futures, resources, etc.)
+                        Err(e) => skipped.push(e.to_string()),
+                    }
                 }
-                items.push(LibraryItem::Interface {
-                    name: iface_name,
-                    export_name,
-                    doc: iface.docs.contents.clone(),
-                    funcs,
-                });
+                if !funcs.is_empty() {
+                    items.push(LibraryItem::Interface {
+                        name: iface_name,
+                        export_name,
+                        doc: iface.docs.contents.clone(),
+                        funcs,
+                    });
+                }
             }
             WorldItem::Type { .. } => {
                 // Type aliases at the world level are not invocable.
@@ -215,10 +470,31 @@ pub fn extract_library_surface(bytes: &[u8]) -> Result<LibrarySurface, LibraryEx
         }
     }
 
+    // r[impl run.library-resources-rejected]
+    // If no invocable items survived, every export used an unsupported type.
+    // Surface that as an error (with the underlying reasons) instead of
+    // returning an empty surface, which would otherwise make `component run`
+    // print help and exit 0.
+    if items.is_empty() {
+        let reasons = if skipped.is_empty() {
+            "no exported functions".to_string()
+        } else {
+            dedup_preserving_order(skipped).join(", ")
+        };
+        return Err(LibraryExtractError::NoInvocableFunctions { reasons });
+    }
+
     Ok(LibrarySurface { items })
 }
 
-/// Convert a `wit_parser::Function` into a [`FuncDecl`].
+/// Remove duplicate strings while preserving first-seen order.
+fn dedup_preserving_order(items: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    items
+        .into_iter()
+        .filter(|item| seen.insert(item.clone()))
+        .collect()
+}
 fn func_to_decl(
     resolve: &Resolve,
     name: &str,
@@ -456,9 +732,15 @@ mod tests {
     fn extract_resources_fixture_is_rejected() {
         let bytes = read_fixture("library_resources.wasm");
         let err = extract_library_surface(&bytes).expect_err("must reject resource");
-        assert!(
-            matches!(err, LibraryExtractError::Resource { .. }),
-            "expected Resource error, got {err:?}"
-        );
+        // Every export uses a resource type, so all functions are skipped and
+        // the surface ends up empty. We reject with `NoInvocableFunctions`,
+        // whose reasons must name the unsupported `resource` type.
+        match &err {
+            LibraryExtractError::NoInvocableFunctions { reasons } => assert!(
+                reasons.to_lowercase().contains("resource"),
+                "expected reasons to mention resource, got {reasons:?}"
+            ),
+            other => panic!("expected NoInvocableFunctions error, got {other:?}"),
+        }
     }
 }

--- a/crates/wit2cli/tests/snapshots.rs
+++ b/crates/wit2cli/tests/snapshots.rs
@@ -71,15 +71,21 @@ fn needs_import() {
 
 /// Snapshot the rejection diagnostic for a component that exports
 /// a resource type. Resources cannot be expressed as CLI arguments,
-/// so `extract_library_surface` returns
-/// [`LibraryExtractError::Resource`] which propagates through
+/// so every export is skipped and `extract_library_surface` returns
+/// [`LibraryExtractError::NoInvocableFunctions`] (whose reasons name
+/// the offending resource type) which propagates through
 /// [`render_mapping`].
 #[test]
 fn resources_are_rejected() {
     let bytes = fixture_bytes("library_resources.wasm");
     let err = render_mapping(&bytes).expect_err("must reject resource");
-    let RenderMappingError::Extract(LibraryExtractError::Resource { name }) = err else {
-        panic!("expected Resource error, got {err:?}");
+    let RenderMappingError::Extract(LibraryExtractError::NoInvocableFunctions { reasons }) = err
+    else {
+        panic!("expected NoInvocableFunctions error, got {err:?}");
     };
-    insta::assert_snapshot!(format!("rejected: resource `{name}`"));
+    assert!(
+        reasons.to_lowercase().contains("resource"),
+        "expected reasons to mention resource, got {reasons:?}"
+    );
+    insta::assert_snapshot!(format!("rejected: {reasons}"));
 }

--- a/crates/wit2cli/tests/snapshots/snapshots__resources_are_rejected.snap
+++ b/crates/wit2cli/tests/snapshots/snapshots__resources_are_rejected.snap
@@ -1,5 +1,5 @@
 ---
 source: crates/wit2cli/tests/snapshots.rs
-expression: "format!(\"rejected: resource `{name}`\")"
+expression: "format!(\"rejected: {reasons}\")"
 ---
-rejected: resource `<anonymous>`
+rejected: resource type `<anonymous>` is not supported by `component run`


### PR DESCRIPTION
Split out of #362.

This PR brings over **only** the wit2cli changes from the draft PR — no HTTP/WASI, no `component-cli-internal-run`, and no release-tooling/Justfile changes.

## Fixes
- **Skip unsupported functions** at the WIT extraction layer (`wit.rs`) and at the CLI-building layer (`cli.rs`). At the CLI layer, only *unsupported argument types* are skipped — genuine build errors such as flag collisions still propagate (a new `CliError::is_skippable` distinguishes the two).
- **Empty list for unsupported nested list types** when no values are provided.
- **`option<record>` flags and `list<record>` JSON input** support.
- **`list<T>` record fields** in CLI argument collection.
- **wasmparser fallback** for components that lack a `component-type` custom section (older `wit-bindgen` toolchains). Adds the `wasmparser` dependency.
- **Skip the componentize-py/js `exports` bootstrap interface.**

## Empty-surface rejection (preserves `run.library-resources-rejected`)
Skipping unsupported functions introduced a regression: for `library_resources.wasm` every export uses resources, so all functions were skipped and the surface ended up empty — the CLI then printed help and exited 0.

Now, when every export is skipped because it uses an unsupported type, `extract_library_surface` returns a new `LibraryExtractError::NoInvocableFunctions` whose message names the offending types (e.g. `resource`). The `component run` path surfaces this to stderr with a non-zero exit. This keeps `r[verify run.library-resources-rejected]` (`test_library_resources_fixture_is_rejected`) passing with its original assertion unchanged.

## Verification
`cargo xtask test` passes (fmt + clippy + test + sql check). Clippy required fixing several pedantic/restriction lints (`indexing_slicing`, `cast_possible_truncation`, redundant closures, etc.) in the newly-added fallback and JSON-conversion code.