### PR TITLE
fix(wit2cli): use ComponentExternName.name field for wasmparser 0.251

### DIFF
--- a/crates/wit2cli/src/wit.rs
+++ b/crates/wit2cli/src/wit.rs
@@ -326,9 +326,9 @@ fn fallback_library_surface(bytes: &[u8]) -> Option<LibrarySurface> {
                         None => Vec::new(),
                     };
                     func_map.insert(
-                        export.name.0.to_string(),
+                        export.name.name.to_string(),
                         FuncDecl {
-                            name: export.name.0.to_string(),
+                            name: export.name.name.to_string(),
                             doc: None,
                             params: param_decls,
                             results: result_decls,
@@ -339,7 +339,7 @@ fn fallback_library_surface(bytes: &[u8]) -> Option<LibrarySurface> {
             Payload::ComponentExportSection(reader) if depth == 1 => {
                 for export in reader.into_iter().flatten() {
                     if export.kind == ComponentExternalKind::Instance {
-                        let full_name = export.name.0.to_string();
+                        let full_name = export.name.name.to_string();
                         let short_name = iface_short_name(&full_name);
                         instance_exports.push((full_name, short_name));
                     }


### PR DESCRIPTION
## Summary

`main` currently fails to compile `wit2cli` under `cargo {doc,test} --workspace`, which blocks every open PR's CI (Build and test, Checking docs, Coverage).

### Root cause
This is a merge-skew breakage between two already-merged PRs:
- **#402** introduced `export.name.0` (tuple access on `ComponentExternName`). Its CI passed because it ran against the then-current base where wasmparser was **0.248** (tuple form).
- **#400** (dependabot) subsequently bumped wasmparser to **0.251**, where `ComponentExternName` became a struct with named fields (`name`, `implements`).

The combination on `main` HEAD leaves `export.name.0` referencing a field that no longer exists, so wit2cli no longer compiles. A clean `origin/main` checkout reproduces `error[E0609]: no field `0` on type `ComponentExternName<'_>`` × 3.

### Fix
Update the three accessors from `export.name.0` to `export.name.name` to match wasmparser 0.251's struct shape. Verified with `cargo doc --no-deps --workspace` (clean compile).

Split out as a focused fix so unrelated feature PRs (e.g. #401) don't have to carry it.