### PR TITLE
fix(release): bump version pins on intra-workspace path-deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,10 +93,14 @@ jobs:
         env:
           VERSION: ${{ needs.resolve-version.outputs.version }}
         run: |
-          import os, re, pathlib
+          import os, re, tomllib, pathlib
           version = os.environ["VERSION"]
           path = pathlib.Path("Cargo.toml")
           text = path.read_text()
+          data = tomllib.loads(text)
+
+          # 1) Bump [workspace.package].version (every crate inherits via
+          #    `version = { workspace = true }`).
           new_text, count = re.subn(
               r'(\[workspace\.package\][^\[]*?\nversion\s*=\s*")[^"]*(")',
               lambda m: m.group(1) + version + m.group(2),
@@ -106,6 +110,38 @@ jobs:
           )
           if count != 1:
               raise SystemExit("Failed to update [workspace.package] version in Cargo.toml")
+
+          # 2) Bump version= pins on intra-workspace path-deps in
+          #    [workspace.dependencies]. cargo requires these to match
+          #    the bumped crate versions or resolution fails with
+          #    "candidate versions found which didn't match".
+          deps = data.get("workspace", {}).get("dependencies", {})
+          for name, spec in deps.items():
+              if not isinstance(spec, dict):
+                  continue
+              if not isinstance(spec.get("path"), str):
+                  continue
+              if not spec["path"].startswith("crates/"):
+                  continue
+              if "version" not in spec:
+                  continue
+              pattern = (
+                  r'^(' + re.escape(name)
+                  + r'\s*=\s*\{[^}]*?version\s*=\s*")[^"]*(")'
+              )
+              new_text, n2 = re.subn(
+                  pattern,
+                  lambda m: m.group(1) + version + m.group(2),
+                  new_text,
+                  count=1,
+                  flags=re.MULTILINE,
+              )
+              if n2 != 1:
+                  raise SystemExit(
+                      f"Failed to update workspace dep version pin for `{name}`"
+                  )
+              print(f"  pinned {name} -> {version}")
+
           path.write_text(new_text)
           print(f"Set workspace version to {version}")
 


### PR DESCRIPTION
# fix(release): bump version pins on intra-workspace path-deps

The `Set workspace version` step in `release.yml` only updates
`[workspace.package].version`. Workspace member crates inherit that
fine, but the `version=` pins on intra-workspace path-deps in
`[workspace.dependencies]` (e.g. `component-cli-internal-run`) are
left at the old value, so the post-bump workspace ends up inconsistent
and `cargo build` fails with:

```
error: failed to select a version for the requirement
  `component-cli-internal-run = "^0.3.0"`
candidate versions found which didn't match: 0.8.0
```

## Fix

Extends the bump step to find every `workspace.dependencies` entry
whose `path` starts with `crates/` and rewrite its `version=` pin in
lockstep with the workspace version.

The two-step `Release Bump` flow already handled this correctly via
`cargo set-version --workspace`; this brings the standalone `Release`
(`workflow_dispatch`) path to parity.

## Scope

- `.github/workflows/release.yml` only: +37 / −1.
- No code changes, no test changes.
