### PR TITLE
Run the project's local component with bare `component run`

### DIFF
--- a/crates/component-cli/src/run/errors.rs
+++ b/crates/component-cli/src/run/errors.rs
@@ -81,6 +81,39 @@ pub(crate) enum RunError {
         /// The manifest key that was looked up.
         name: String,
     },
+
+    /// `component run` was invoked with no input but the project has no
+    /// runnable `[package]` (missing `wasm.toml` or missing `[package]`).
+    #[diagnostic(
+        code(component::run::no_local_package),
+        help(
+            "add a `[package]` with `kind = \"component\"` to `wasm.toml`, or pass an explicit \
+             file path / OCI reference / dependency key to run"
+        )
+    )]
+    NoLocalPackage,
+
+    /// The local `[package]` describes an interface, which cannot be run.
+    #[diagnostic(
+        code(component::run::local_package_not_component),
+        help("`component run` can only run components; '{name}' has `kind = \"interface\"`")
+    )]
+    LocalPackageNotComponent {
+        /// The `[package].name` that was resolved.
+        name: String,
+    },
+
+    /// The local `[package]` artifact has not been built yet.
+    #[diagnostic(
+        code(component::run::local_artifact_missing),
+        help("'{path}' not found; build '{name}' with your language toolchain first")
+    )]
+    LocalArtifactMissing {
+        /// The expected artifact path.
+        path: String,
+        /// The `[package].name` that was resolved.
+        name: String,
+    },
 }
 
 impl std::fmt::Display for RunError {
@@ -109,6 +142,15 @@ impl std::fmt::Display for RunError {
             }
             RunError::NotInGlobalCache { name } => {
                 write!(f, "component '{name}' is not present in the global cache")
+            }
+            RunError::NoLocalPackage => {
+                write!(f, "no local `[package]` to run")
+            }
+            RunError::LocalPackageNotComponent { name } => {
+                write!(f, "local package '{name}' is an interface, not a component")
+            }
+            RunError::LocalArtifactMissing { path, name } => {
+                write!(f, "artifact '{path}' not found for local package '{name}'")
             }
         }
     }
@@ -141,6 +183,14 @@ mod tests {
             Box::new(RunError::HttpAcceptFailed {
                 reason: "test".to_string(),
             }),
+            Box::new(RunError::NoLocalPackage),
+            Box::new(RunError::LocalPackageNotComponent {
+                name: "test".to_string(),
+            }),
+            Box::new(RunError::LocalArtifactMissing {
+                path: "test".to_string(),
+                name: "test".to_string(),
+            }),
         ];
 
         let expected_codes = [
@@ -150,6 +200,9 @@ mod tests {
             "component::run::vendored_file_missing",
             "component::run::http_bind_failed",
             "component::run::http_accept_failed",
+            "component::run::no_local_package",
+            "component::run::local_package_not_component",
+            "component::run::local_artifact_missing",
         ];
 
         for (variant, expected_code) in variants.iter().zip(expected_codes.iter()) {

--- a/crates/component-cli/src/run/mod.rs
+++ b/crates/component-cli/src/run/mod.rs
@@ -33,8 +33,13 @@ use wit2cli::{
 pub(crate) struct Opts {
     /// Local file path, OCI reference, or manifest key (scope:component)
     /// for a Wasm Component.
+    ///
+    /// Optional: when omitted, `component run` executes the project's own
+    /// component as described by the `[package]` section of `wasm.toml`
+    /// (like `cargo run` runs the current crate). Passing the manifest's
+    /// own `[package].name` resolves to that same local artifact.
     #[arg(value_name = "INPUT")]
-    input: String,
+    input: Option<String>,
 
     /// Pass an environment variable to the guest (repeatable).
     #[arg(long = "env", value_name = "KEY=VAL", num_args = 1)]
@@ -87,71 +92,36 @@ pub(crate) struct Opts {
 impl Opts {
     /// Execute the `run` command.
     pub(crate) async fn run(self, offline: bool) -> miette::Result<()> {
-        let input = self.input.as_str();
+        // 1. Resolve input. An explicit, existing local file path wins
+        //    first; then the project's own `[package]` (local run); then
+        //    manifest keys / global cache / OCI references.
+        let input = self.input.as_deref();
+        let local_path = input.map(PathBuf::from);
+        let is_local = local_path.as_ref().is_some_and(|p| p.exists());
 
-        // 1. Resolve input — local files take priority, then manifest keys,
-        //    then OCI references.
-        let local_path = PathBuf::from(input);
-        let is_local = local_path.exists();
-
-        // Manifest keys use `scope:component` syntax; an optional `@version`
-        // suffix (e.g. `yoshuawuyts:wordmark@2.0.6`) is part of the input
-        // grammar but is not part of the key stored in `wasm.toml`. Strip the
-        // version when consulting the manifest/lockfile, but pass the original
-        // input — which still carries the version — to install/global-cache
-        // resolution so the requested version is honored.
-        let manifest_key = strip_at_version(input);
-
-        // Try manifest key lookup (scope:component syntax).
-        let mut manifest_path = if is_local {
-            None
-        } else {
-            resolve_manifest_key(manifest_key)?
-        };
-
-        // For inputs that look like manifest keys (`scope:component`) but are
-        // not yet installed in the local project, auto-install into a local
-        // manifest + lockfile by default. The `--global` flag bypasses local
-        // installation and runs from the global cache instead.
-        let global_bytes =
-            if !is_local && manifest_path.is_none() && looks_like_manifest_key(manifest_key) {
-                if self.global {
-                    Some(load_from_global_cache(input, offline).await?)
-                } else {
-                    auto_install(input, offline).await?;
-                    // Re-resolve the manifest key now that the install has
-                    // populated `wasm.toml`, `wasm.lock.toml`, and the
-                    // vendored Wasm file.
-                    manifest_path = resolve_manifest_key(manifest_key)?;
-                    None
-                }
-            } else {
-                None
-            };
-
-        // Only try OCI when the input is not a local file and not a manifest key.
-        let reference = if is_local || manifest_path.is_some() || global_bytes.is_some() {
-            None
-        } else {
-            crate::util::parse_reference(input).ok()
-        };
-
-        // 2. Get Wasm bytes.
-        let bytes = if let Some(bytes) = global_bytes {
-            bytes
-        } else if let Some(ref vendored) = manifest_path {
-            tokio::fs::read(vendored)
+        // 2. Get Wasm bytes (and an OCI reference, when one applies, for
+        //    per-component permission resolution).
+        let (bytes, reference) = if is_local {
+            let path = local_path.expect("is_local implies an input path");
+            let bytes = tokio::fs::read(&path)
                 .await
                 .into_diagnostic()
-                .wrap_err_with(|| format!("failed to read {}", vendored.display()))?
+                .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+            (bytes, None)
+        } else if let Some(path) = resolve_local_package(input)? {
+            // Bare `component run`, or `component run <own-package-name>`:
+            // run the artifact built from this project's `[package]`.
+            // r[impl run.local-package]
+            let bytes = tokio::fs::read(&path)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read {}", path.display()))?;
+            (bytes, None)
         } else {
-            match reference {
-                Some(ref oci_ref) => fetch_oci_bytes(oci_ref, offline).await?,
-                None => tokio::fs::read(&local_path)
-                    .await
-                    .into_diagnostic()
-                    .wrap_err_with(|| format!("failed to read {}", local_path.display()))?,
-            }
+            // `resolve_local_package(None)` errors when there is no local
+            // package, so reaching this arm always implies an explicit input.
+            let input = input.expect("remote resolution requires an explicit input");
+            self.resolve_remote_bytes(input, offline).await?
         };
 
         // 3. Validate — must be a Wasm Component.
@@ -195,6 +165,79 @@ impl Opts {
         Ok(())
     }
 
+    /// Resolve Wasm bytes for an explicit `input` via the remote paths:
+    /// vendored manifest key, `--global` cache, auto-install, or OCI.
+    ///
+    /// Returns the component bytes together with the OCI [`Reference`] when
+    /// one applies — the reference is consumed by per-component permission
+    /// resolution. Local files and local-package runs are handled by the
+    /// caller before this method is reached.
+    ///
+    /// [`Reference`]: component_package_manager::Reference
+    async fn resolve_remote_bytes(
+        &self,
+        input: &str,
+        offline: bool,
+    ) -> miette::Result<(Vec<u8>, Option<component_package_manager::Reference>)> {
+        // Manifest keys use `scope:component` syntax; an optional `@version`
+        // suffix (e.g. `yoshuawuyts:wordmark@2.0.6`) is part of the input
+        // grammar but is not part of the key stored in `wasm.toml`. Strip the
+        // version when consulting the manifest/lockfile, but pass the original
+        // input — which still carries the version — to install/global-cache
+        // resolution so the requested version is honored.
+        let manifest_key = strip_at_version(input);
+
+        // Try manifest key lookup (scope:component syntax).
+        let mut manifest_path = resolve_manifest_key(manifest_key)?;
+
+        // For inputs that look like manifest keys (`scope:component`) but are
+        // not yet installed in the local project, auto-install into a local
+        // manifest + lockfile by default. The `--global` flag bypasses local
+        // installation and runs from the global cache instead.
+        let global_bytes = if manifest_path.is_none() && looks_like_manifest_key(manifest_key) {
+            if self.global {
+                Some(load_from_global_cache(input, offline).await?)
+            } else {
+                auto_install(input, offline).await?;
+                // Re-resolve the manifest key now that the install has
+                // populated `wasm.toml`, `wasm.lock.toml`, and the
+                // vendored Wasm file.
+                manifest_path = resolve_manifest_key(manifest_key)?;
+                None
+            }
+        } else {
+            None
+        };
+
+        // Only try OCI when the input is not a manifest key.
+        let reference = if manifest_path.is_some() || global_bytes.is_some() {
+            None
+        } else {
+            crate::util::parse_reference(input).ok()
+        };
+
+        let bytes = if let Some(bytes) = global_bytes {
+            bytes
+        } else if let Some(ref vendored) = manifest_path {
+            tokio::fs::read(vendored)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read {}", vendored.display()))?
+        } else if let Some(ref oci_ref) = reference {
+            fetch_oci_bytes(oci_ref, offline).await?
+        } else {
+            // Not a local file, manifest key, or OCI reference: fall back to a
+            // read so the user gets a clear "failed to read" error.
+            let path = PathBuf::from(input);
+            tokio::fs::read(&path)
+                .await
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read {}", path.display()))?
+        };
+
+        Ok((bytes, reference))
+    }
+
     /// Build a [`RunPermissions`] from CLI flags (only the explicitly
     /// provided flags are `Some`).
     fn cli_permissions(&self) -> RunPermissions {
@@ -231,6 +274,102 @@ impl Opts {
     ) -> component_manifest::ResolvedPermissions {
         let cli = self.cli_permissions();
         component_package_manager::permissions::resolve_permissions(reference, cli)
+    }
+}
+
+/// Resolve the project's own component artifact for a "local run".
+///
+/// `cargo run` runs the current crate; `component run` mirrors this by
+/// running the component described by the `[package]` section of the
+/// project's `wasm.toml`. This triggers when:
+///
+/// * `input` is `None` — the bare `component run` form, or
+/// * `input` equals the manifest's `[package].name` (an optional matching
+///   `@version` suffix is allowed) — `component run <own-package-name>`.
+///
+/// Reads `wasm.toml` from the current directory and, on a trigger, returns
+/// the path to the built artifact ([`Package::artifact_path`], default
+/// `build/<name>.wasm`).
+///
+/// # Errors
+///
+/// * [`RunError::NoLocalPackage`] — bare `component run` with no `wasm.toml`
+///   or no `[package]` section.
+/// * [`RunError::LocalPackageNotComponent`] — the `[package]` is an interface.
+/// * [`RunError::LocalArtifactMissing`] — the artifact has not been built yet.
+///
+/// Returns `Ok(None)` when an explicit `input` does not name the local
+/// package, so resolution falls through to the remote paths.
+// r[impl run.local-package]
+fn resolve_local_package(input: Option<&str>) -> miette::Result<Option<PathBuf>> {
+    let manifest_str = match std::fs::read_to_string("wasm.toml") {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return no_local_package(input),
+        // For a bare run, surface other read errors; an explicit input falls
+        // through to remote resolution (mirroring `resolve_manifest_key`).
+        Err(e) => {
+            return match input {
+                None => Err(e)
+                    .into_diagnostic()
+                    .wrap_err("failed to read wasm.toml"),
+                Some(_) => Ok(None),
+            };
+        }
+    };
+
+    let manifest = match toml::from_str::<component_manifest::Manifest>(&manifest_str) {
+        Ok(manifest) => manifest,
+        Err(e) => {
+            return match input {
+                None => Err(e)
+                    .into_diagnostic()
+                    .wrap_err("failed to parse wasm.toml"),
+                Some(_) => Ok(None),
+            };
+        }
+    };
+
+    let Some(package) = manifest.package else {
+        return no_local_package(input);
+    };
+
+    // For an explicit input, only resolve locally when it names this package.
+    // A matching `@version` suffix is honored; a non-matching version falls
+    // through to remote resolution so a different published version can run.
+    if let Some(name) = input {
+        if strip_at_version(name) != package.name {
+            return Ok(None);
+        }
+        if let Some((_, version)) = name.split_once('@')
+            && version != package.version
+        {
+            return Ok(None);
+        }
+    }
+
+    if package.kind != component_manifest::PackageKind::Component {
+        return Err(RunError::LocalPackageNotComponent { name: package.name }.into());
+    }
+
+    let artifact = package.artifact_path();
+    if !artifact.exists() {
+        return Err(RunError::LocalArtifactMissing {
+            path: artifact.display().to_string(),
+            name: package.name,
+        }
+        .into());
+    }
+
+    Ok(Some(artifact))
+}
+
+/// Outcome when no local `[package]` is available: a bare `component run`
+/// fails with [`RunError::NoLocalPackage`]; an explicit input falls through
+/// to remote resolution.
+fn no_local_package(input: Option<&str>) -> miette::Result<Option<PathBuf>> {
+    match input {
+        None => Err(RunError::NoLocalPackage.into()),
+        Some(_) => Ok(None),
     }
 }
 

--- a/crates/component-cli/src/run/mod.rs
+++ b/crates/component-cli/src/run/mod.rs
@@ -194,10 +194,10 @@ impl Opts {
         // not yet installed in the local project, auto-install into a local
         // manifest + lockfile by default. The `--global` flag bypasses local
         // installation and runs from the global cache instead.
-        let global_bytes = if manifest_path.is_none() && looks_like_manifest_key(manifest_key) {
-            if self.global {
-                Some(load_from_global_cache(input, offline).await?)
-            } else {
+        let needs_remote_key = manifest_path.is_none() && looks_like_manifest_key(manifest_key);
+        let global_bytes = match (needs_remote_key, self.global) {
+            (true, true) => Some(load_from_global_cache(input, offline).await?),
+            (true, false) => {
                 auto_install(input, offline).await?;
                 // Re-resolve the manifest key now that the install has
                 // populated `wasm.toml`, `wasm.lock.toml`, and the
@@ -205,8 +205,7 @@ impl Opts {
                 manifest_path = resolve_manifest_key(manifest_key)?;
                 None
             }
-        } else {
-            None
+            (false, _) => None,
         };
 
         // Only try OCI when the input is not a manifest key.
@@ -216,23 +215,22 @@ impl Opts {
             crate::util::parse_reference(input).ok()
         };
 
-        let bytes = if let Some(bytes) = global_bytes {
-            bytes
-        } else if let Some(ref vendored) = manifest_path {
-            tokio::fs::read(vendored)
+        let bytes = match (global_bytes, &manifest_path, &reference) {
+            (Some(bytes), _, _) => bytes,
+            (None, Some(vendored), _) => tokio::fs::read(vendored)
                 .await
                 .into_diagnostic()
-                .wrap_err_with(|| format!("failed to read {}", vendored.display()))?
-        } else if let Some(ref oci_ref) = reference {
-            fetch_oci_bytes(oci_ref, offline).await?
-        } else {
-            // Not a local file, manifest key, or OCI reference: fall back to a
-            // read so the user gets a clear "failed to read" error.
-            let path = PathBuf::from(input);
-            tokio::fs::read(&path)
-                .await
-                .into_diagnostic()
-                .wrap_err_with(|| format!("failed to read {}", path.display()))?
+                .wrap_err_with(|| format!("failed to read {}", vendored.display()))?,
+            (None, None, Some(oci_ref)) => fetch_oci_bytes(oci_ref, offline).await?,
+            (None, None, None) => {
+                // Not a local file, manifest key, or OCI reference: fall back to
+                // a read so the user gets a clear "failed to read" error.
+                let path = PathBuf::from(input);
+                tokio::fs::read(&path)
+                    .await
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("failed to read {}", path.display()))?
+            }
         };
 
         Ok((bytes, reference))

--- a/crates/component-cli/tests/snapshots/test__cli_run_help_snapshot.snap
+++ b/crates/component-cli/tests/snapshots/test__cli_run_help_snapshot.snap
@@ -4,11 +4,13 @@ expression: output
 ---
 Execute a Wasm Component
 
-Usage: component run [OPTIONS] <INPUT> [GUEST_ARGS]...
+Usage: component run [OPTIONS] [INPUT] [GUEST_ARGS]...
 
 Arguments:
-  <INPUT>
-          Local file path, OCI reference, or manifest key (scope:component) for a Wasm Component
+  [INPUT]
+          Local file path, OCI reference, or manifest key (scope:component) for a Wasm Component.
+          
+          Optional: when omitted, `component run` executes the project's own component as described by the `[package]` section of `wasm.toml` (like `cargo run` runs the current crate). Passing the manifest's own `[package].name` resolves to that same local artifact.
 
   [GUEST_ARGS]...
           Trailing arguments forwarded to the guest. For `wasi:cli/command` components these become `argv`; for library-style components they are parsed by a dynamically generated sub-CLI built from the component's WIT exports.

--- a/crates/component-cli/tests/test.rs
+++ b/crates/component-cli/tests/test.rs
@@ -915,16 +915,20 @@ fn test_run_local_package_by_name() {
 fn test_run_local_package_bare() {
     let project = local_run_project(LOCAL_COMPONENT_MANIFEST, true);
     let out = run_cli_raw_in(project.path(), &["--offline", "run"]);
-    // With no function selected, the dynamic sub-CLI lists the component's
-    // exports; seeing `to-word` proves the local artifact was loaded.
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
+    // Bare run selects no function, so the dynamic clap CLI exits with its
+    // usage error (code 2) and lists the component's exports on stderr.
+    // Pinning both the exit code and the usage banner ensures the test only
+    // passes when the local artifact was actually loaded and introspected,
+    // not when some unrelated failure happens to mention `to-word`.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "bare local run should exit with clap's usage code 2; stderr: {stderr}"
     );
     assert!(
-        combined.contains("to-word"),
-        "bare local run did not load the local component: {combined}"
+        stderr.contains("Usage: component run") && stderr.contains("to-word"),
+        "bare local run did not print the local component's dynamic usage: {stderr}"
     );
 }
 
@@ -965,9 +969,11 @@ wit = "wit"
 fn test_run_local_package_absent() {
     let project = TempDir::new().expect("tempdir");
     let stderr = run_cli_error(&["--offline", "run"], Some(project.path()));
+    // Assert on the specific `RunError::NoLocalPackage` Display message so the
+    // test fails if a different error is surfaced instead.
     assert!(
-        stderr.contains("no local") || stderr.contains("[package]"),
-        "unexpected error: {stderr}"
+        stderr.contains("no local `[package]` to run"),
+        "expected the NoLocalPackage error message, got: {stderr}"
     );
 }
 

--- a/crates/component-cli/tests/test.rs
+++ b/crates/component-cli/tests/test.rs
@@ -849,6 +849,129 @@ fn test_run_missing_file() {
 }
 
 // =============================================================================
+// Local run tests (`component run` with no input / own package name)
+// =============================================================================
+
+/// A `wasm.toml` whose `[package]` is the wordmark component, built at the
+/// default artifact path `build/wordmark.wasm`.
+const LOCAL_COMPONENT_MANIFEST: &str = r#"[package]
+name = "test:wordmark"
+version = "0.1.0"
+registry = "ghcr.io/test/wordmark"
+kind = "component"
+file = "build/wordmark.wasm"
+"#;
+
+/// Run the CLI inside `dir` and capture the full raw output.
+fn run_cli_raw_in(dir: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_component"))
+        .args(args)
+        .current_dir(dir)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to execute command")
+}
+
+/// Create a temp project whose `wasm.toml` is `manifest`. When
+/// `with_artifact` is set, the wordmark fixture is copied to
+/// `build/wordmark.wasm` so the local `[package]` has a built artifact.
+fn local_run_project(manifest: &str, with_artifact: bool) -> TempDir {
+    let dir = TempDir::new().expect("tempdir");
+    std::fs::write(dir.path().join("wasm.toml"), manifest).expect("write wasm.toml");
+    if with_artifact {
+        let build = dir.path().join("build");
+        std::fs::create_dir_all(&build).expect("create build dir");
+        std::fs::copy(
+            library_fixture("library_wordmark.wasm"),
+            build.join("wordmark.wasm"),
+        )
+        .expect("copy fixture");
+    }
+    dir
+}
+
+/// `component run <own-package-name>` runs the project's built artifact,
+/// offline, forwarding guest args to the component's WIT-derived CLI.
+// r[verify run.local-package.by-name]
+#[test]
+fn test_run_local_package_by_name() {
+    let project = local_run_project(LOCAL_COMPONENT_MANIFEST, true);
+    let out = run_cli_raw_in(
+        project.path(),
+        &["--offline", "run", "test:wordmark", "to-word", "# hi"],
+    );
+    assert!(
+        out.status.success(),
+        "local run by name failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(out.stdout, b"DOCX:# hi");
+}
+
+/// Bare `component run` (no input) resolves and loads the project's own
+/// `[package]` artifact, exposing its WIT exports as a sub-CLI.
+// r[verify run.local-package.bare]
+#[test]
+fn test_run_local_package_bare() {
+    let project = local_run_project(LOCAL_COMPONENT_MANIFEST, true);
+    let out = run_cli_raw_in(project.path(), &["--offline", "run"]);
+    // With no function selected, the dynamic sub-CLI lists the component's
+    // exports; seeing `to-word` proves the local artifact was loaded.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("to-word"),
+        "bare local run did not load the local component: {combined}"
+    );
+}
+
+/// Bare `component run` with no built artifact reports a helpful error.
+// r[verify run.local-package.missing-artifact]
+#[test]
+fn test_run_local_package_missing_artifact() {
+    let project = local_run_project(LOCAL_COMPONENT_MANIFEST, false);
+    let stderr = run_cli_error(&["--offline", "run"], Some(project.path()));
+    assert!(
+        stderr.contains("build/wordmark.wasm") && stderr.contains("test:wordmark"),
+        "unexpected error: {stderr}"
+    );
+}
+
+/// A local `[package]` of `kind = "interface"` cannot be run.
+// r[verify run.local-package.interface]
+#[test]
+fn test_run_local_package_interface_rejected() {
+    let manifest = r#"[package]
+name = "test:iface"
+version = "0.1.0"
+registry = "ghcr.io/test/iface"
+kind = "interface"
+wit = "wit"
+"#;
+    let project = local_run_project(manifest, false);
+    let stderr = run_cli_error(&["--offline", "run"], Some(project.path()));
+    assert!(
+        stderr.contains("interface") && stderr.contains("test:iface"),
+        "unexpected error: {stderr}"
+    );
+}
+
+/// Bare `component run` with no `wasm.toml` / no `[package]` errors helpfully.
+// r[verify run.local-package.none]
+#[test]
+fn test_run_local_package_absent() {
+    let project = TempDir::new().expect("tempdir");
+    let stderr = run_cli_error(&["--offline", "run"], Some(project.path()));
+    assert!(
+        stderr.contains("no local") || stderr.contains("[package]"),
+        "unexpected error: {stderr}"
+    );
+}
+
+// =============================================================================
 // Library-style component tests
 // =============================================================================
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -277,6 +277,39 @@ This operation:
 2. Remove unused packages manually or with future commands
 3. Run `component self clean` to reclaim space
 
+## Running the Local Component
+
+Just as `cargo run` runs the crate in the current directory, `component
+run` with **no `<INPUT>`** runs the component your project builds — the
+one described by the `[package]` section of `wasm.toml`:
+
+```bash
+component run
+```
+
+This reads `wasm.toml`, requires a `[package]` with `kind =
+"component"`, and executes the built artifact at `[package].file`
+(default `build/<name>.wasm`). There is no separate build step:
+compile your source to Wasm with your language toolchain first, then
+`component run` executes the result. If the artifact is missing,
+`component run` tells you to build it; if the `[package]` is an
+interface (`kind = "interface"`), it cannot be run.
+
+You can also name the local package explicitly using its
+`[package].name`; this is the way to **forward guest arguments** to a
+local component, since everything after the name is passed through:
+
+```bash
+# Given [package] name = "acme:wordmark":
+component run acme:wordmark to-word "# hi" > file.docx
+```
+
+Passing the package name resolves to the local artifact (it does *not*
+hit the network), taking precedence over installing a same-named
+package from a registry. Requesting a different version
+(`acme:wordmark@9.9.9`) falls through to the normal registry
+resolution described below.
+
 ## Running Library-style Components
 
 `component run` can execute three kinds of WebAssembly components:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -280,7 +280,7 @@ This operation:
 ## Running the Local Component
 
 Just as `cargo run` runs the crate in the current directory, `component
-run` with **no `<INPUT>`** runs the component your project builds — the
+run` with **no `[INPUT]`** runs the component your project builds — the
 one described by the `[package]` section of `wasm.toml`:
 
 ```bash
@@ -317,7 +317,7 @@ resolution described below.
 - **HTTP components** (export `wasi:http/incoming-handler`) are
   served on a local TCP port — use `--listen` to set the address.
 - **CLI components** (export `wasi:cli/run`) are executed as
-  programs; trailing arguments after `<INPUT>` become the guest's
+  programs; trailing arguments after `[INPUT]` become the guest's
   `argv`.
 - **Library-style components** — anything that exports plain
   functions or interfaces but does not target either of the worlds
@@ -381,7 +381,7 @@ Resources and futures/streams are not supported.
 
 All host-side flags (`--global`, `--env`, `--dir`, `--inherit-env`,
 `--inherit-network`, `--no-stdio`, `--listen`) must come **before**
-the `<INPUT>` argument; everything after `<INPUT>` is forwarded to
+the `[INPUT]` argument; everything after `[INPUT]` is forwarded to
 the guest:
 
 ```bash


### PR DESCRIPTION
`component run` always required an explicit `<INPUT>` (a file path, OCI reference, or dependency key). There was no way to say "run the component this project builds," even though `wasm.toml` already describes it in its `[package]` section. This adds that, mirroring how `cargo run` runs the current crate.

Closes #421

## What changed

- Bare `component run` (no input) runs the project's own `[package]` component.
- `component run <own-package-name>` resolves to that same local artifact and forwards guest args, e.g. `component run acme:wordmark to-word "# hi"`.

Resolution reads `wasm.toml`, requires `kind = "component"`, and runs the built artifact at `Package::artifact_path()` (default `build/<name>.wasm`).

## Notes for reviewers

- There is no build step: compilation is done by language toolchains, so a missing artifact is a helpful error (`LocalArtifactMissing`) rather than an auto-build. An interface-kind package and a missing `[package]` get their own errors too (`LocalPackageNotComponent`, `NoLocalPackage`).
- Local resolution takes precedence over the remote (vendored / global cache / OCI) paths. This also fixes a latent wrinkle where running your own package name would try to install it from a registry. The remote logic itself is unchanged, just factored into a new `resolve_remote_bytes` method.
- Passing the package name is the supported way to forward guest args, since the first positional is still `<INPUT>`. Requesting a different version (`acme:wordmark@9.9.9`) falls through to normal registry resolution.

## Testing

`cargo xtask test` (fmt, clippy, tests, sql check, readme check) passes. Added integration tests covering bare run, run-by-name offline, missing artifact, interface kind, and no `[package]`. Updated the `component run --help` snapshot (`<INPUT>` to `[INPUT]`).