### PR TITLE
Map SemVer build metadata onto valid OCI tags

### DIFF
--- a/crates/component-package-manager/src/manager/install/mod.rs
+++ b/crates/component-package-manager/src/manager/install/mod.rs
@@ -83,7 +83,10 @@ pub async fn resolve_wit_name(input: &str, manager: &Manager) -> anyhow::Result<
 ///
 /// Both the compact string format (`"ghcr.io/webassembly/wasi-logging:1.0.0"`) and
 /// the explicit table format (`registry`/`namespace`/`package`:`version`) are
-/// supported. Returns an error if the resulting reference string cannot be parsed
+/// supported. The explicit form's `version` is mapped through
+/// [`crate::publish::oci_tag`] so SemVer build metadata (e.g. `0.1.0+2026-01-14`)
+/// becomes a valid OCI tag (`0.1.0_2026-01-14`), matching how `publish` tags the
+/// artifact. Returns an error if the resulting reference string cannot be parsed
 /// as a valid OCI reference.
 pub fn reference_from_dependency(
     dep: &component_manifest::Dependency,
@@ -96,7 +99,10 @@ pub fn reference_from_dependency(
             package,
             version,
             ..
-        } => format!("{registry}/{namespace}/{package}:{version}"),
+        } => format!(
+            "{registry}/{namespace}/{package}:{}",
+            crate::publish::oci_tag(version)
+        ),
     };
     crate::parse_reference(&s).map_err(|e| InstallError::InvalidReference { reason: e }.into())
 }
@@ -372,5 +378,25 @@ mod tests {
     #[test]
     fn looks_like_wit_name_rejects_multiple_at() {
         assert!(!looks_like_wit_name("wasi:http@0.2@extra"));
+    }
+
+    #[test]
+    fn reference_from_explicit_dependency_maps_build_metadata() {
+        // The manifest's explicit table form carries a SemVer `version`; build
+        // metadata (`+`) is illegal in an OCI tag, so it must be mapped to `_`
+        // — the inverse of what `publish` does — so the dependency resolves to
+        // the tag the registry actually stores.
+        let dep = component_manifest::Dependency::Explicit {
+            registry: "ghcr.io".into(),
+            namespace: "yoshuawuyts".into(),
+            package: "fetch".into(),
+            version: "0.1.0+2026-01-14".into(),
+            permissions: None,
+        };
+        let r =
+            reference_from_dependency(&dep).expect("build metadata should yield a valid reference");
+        assert_eq!(r.registry(), "ghcr.io");
+        assert_eq!(r.repository(), "yoshuawuyts/fetch");
+        assert_eq!(r.tag(), Some("0.1.0_2026-01-14"));
     }
 }

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -13,6 +13,7 @@ mod models;
 use crate::config::Config;
 use crate::oci::{Client, ImageEntry, InsertResult};
 use crate::progress::ProgressEvent;
+use crate::publish::oci_tag;
 use crate::storage::{FetchTaskKind, KnownPackage, KnownPackageParams, StateInfo, Store};
 use crate::types::WitPackage;
 use component_meta_registry_types::PackageKind;
@@ -587,7 +588,10 @@ impl Manager {
             .await?
         {
             let tag = self.resolve_tag_for_dep(dep, &registry, &repository).await;
-            let ref_str = format!("{registry}/{repository}:{tag}");
+            // Map SemVer build metadata (`0.1.0+meta`) onto a valid OCI tag
+            // (`0.1.0_meta`) — the inverse of what `publish` does — so a `+`
+            // dependency resolves to the tag the registry actually stores.
+            let ref_str = format!("{registry}/{repository}:{}", oci_tag(&tag));
             return Ok(Some(ref_str.parse()?));
         }
 
@@ -611,7 +615,8 @@ impl Manager {
                     "latest".to_string()
                 }
             };
-            let ref_str = format!("{}/{}:{}", known.registry, known.repository, tag);
+            // Same `+`→`_` tag mapping as the exact-lookup path above.
+            let ref_str = format!("{}/{}:{}", known.registry, known.repository, oci_tag(&tag));
             return Ok(Some(ref_str.parse()?));
         }
 

--- a/crates/component-package-manager/src/publish/mod.rs
+++ b/crates/component-package-manager/src/publish/mod.rs
@@ -160,17 +160,31 @@ pub fn build_annotations(pkg: &Package, created: DateTime<Utc>) -> BTreeMap<Stri
     a
 }
 
+/// Map a `[package].version` (SemVer) onto a valid OCI tag.
+///
+/// OCI tags must match `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`, so the `+` that introduces
+/// SemVer build metadata (e.g. `0.1.0+2026-01-14`) is illegal in a tag. Following Helm's
+/// convention for pushing charts to OCI registries, we replace `+` with `_`
+/// (`0.1.0+2026-01-14` → `0.1.0_2026-01-14`). The unmodified SemVer — build metadata and
+/// all — is still recorded in the `org.opencontainers.image.version` annotation, so no
+/// information is lost.
+#[must_use]
+pub fn oci_tag(version: &str) -> String {
+    version.replace('+', "_")
+}
+
 /// Resolve the OCI reference for a given `[package]` section.
 ///
 /// The reference is built from `[package].registry` and
-/// `[package].version` as `<registry>:<version>` — `registry` is the full
-/// OCI location (host + path, no tag), e.g. `ghcr.io/yoshuawuyts/fetch`.
+/// `[package].version` as `<registry>:<tag>` — `registry` is the full
+/// OCI location (host + path, no tag), e.g. `ghcr.io/yoshuawuyts/fetch`,
+/// and `tag` is the version mapped to a valid OCI tag by [`oci_tag`].
 ///
 /// # Errors
 ///
 /// Returns an error when the resulting reference cannot be parsed.
 pub fn resolve_reference(pkg: &Package) -> Result<Reference> {
-    let s = format!("{}:{}", pkg.registry, pkg.version);
+    let s = format!("{}:{}", pkg.registry, oci_tag(&pkg.version));
     s.parse::<Reference>()
         .with_context(|| format!("failed to parse OCI reference `{s}`"))
 }
@@ -307,6 +321,27 @@ mod tests {
         let mut pkg = sample_pkg();
         pkg.registry = "not a valid ref".into();
         assert!(resolve_reference(&pkg).is_err());
+    }
+
+    // r[verify publish.reference.build-metadata]
+    #[test]
+    fn build_metadata_version_maps_plus_to_underscore_in_tag() {
+        let mut pkg = sample_pkg();
+        pkg.version = "0.1.0+2026-01-14".into();
+
+        // `+` is illegal in an OCI tag, so it is mapped to `_` (Helm's convention).
+        let r = resolve_reference(&pkg).expect("build metadata should yield a valid reference");
+        assert_eq!(r.repository(), "yoshuawuyts/fetch");
+        assert_eq!(r.tag(), Some("0.1.0_2026-01-14"));
+
+        // The annotation keeps the full, unmodified SemVer — including build metadata.
+        let annot = build_annotations(&pkg, Utc::now());
+        assert_eq!(
+            annot
+                .get("org.opencontainers.image.version")
+                .map(String::as_str),
+            Some("0.1.0+2026-01-14"),
+        );
     }
 
     // r[verify publish.require-package.missing]

--- a/crates/component-package-manager/src/storage/store.rs
+++ b/crates/component-package-manager/src/storage/store.rs
@@ -3713,6 +3713,60 @@ mod smoke_tests {
     }
 
     #[tokio::test]
+    async fn find_oci_reference_matches_build_metadata_version() {
+        // `publish` stores the artifact under an OCI tag with `+` mapped to `_`,
+        // but the WIT package decl keeps the full SemVer (build metadata and all).
+        // The resolver matches a `0.1.0+meta` dependency against the SemVer
+        // recorded in `wit_package`, then maps it to the `_` tag when pulling —
+        // so the lookup here must succeed on the unmodified `+` version.
+        let store = Store::open_in_memory().await.unwrap();
+        let repo_id =
+            upsert_oci_repository_full(&store.db, "ghcr.io", "yoshuawuyts/fetch", None, None, None)
+                .await
+                .unwrap();
+        let digest = "sha256:deadbeef";
+        let (manifest_id, _) = upsert_oci_manifest(
+            &store.db,
+            repo_id,
+            digest,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &HashMap::new(),
+        )
+        .await
+        .unwrap();
+        // The registry stores the build-metadata release under the `_` tag …
+        upsert_oci_tag(&store.db, repo_id, "0.1.0_2026-01-14", digest)
+            .await
+            .unwrap();
+        // … while the WIT package decl retains the full `+` SemVer.
+        upsert_wit_package(
+            &store.db,
+            "yoshuawuyts:fetch",
+            Some("0.1.0+2026-01-14"),
+            None,
+            None,
+            Some(manifest_id),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let found = store
+            .find_oci_reference_by_wit_name("yoshuawuyts:fetch", Some("0.1.0+2026-01-14"))
+            .await
+            .unwrap();
+        assert_eq!(
+            found,
+            Some(("ghcr.io".to_string(), "yoshuawuyts/fetch".to_string())),
+        );
+    }
+
+    #[tokio::test]
     async fn fetch_queue_pull_complete_roundtrip() {
         let store = Store::open_in_memory().await.unwrap();
         store


### PR DESCRIPTION
## Why

OCI tags must match `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`, so the `+` that introduces SemVer build metadata (e.g. `0.1.0+2026-01-14`) is illegal in a tag. `component publish` built the OCI reference as `<registry>:<version>` verbatim, so any package whose `[package].version` carried build metadata failed with `invalid reference format`.

This blocks a real use case: the `openapi-bindgen` generator stamps each component's `wasm.toml` version as `<base>+<schema-version>` (e.g. `0.1.0+1.0.0`) to record which OpenAPI revision the bindings came from.

## Approach

Following Helm's convention for OCI, map `+` to `_` when constructing the tag (`0.1.0+2026-01-14` -> `0.1.0_2026-01-14`), and keep the full, unmodified SemVer in the `org.opencontainers.image.version` annotation so no information is lost. The mapping lives in a small `oci_tag()` helper in `publish`.

Crucially, this is applied in **both directions** so the round-trip is symmetric:

- **Publish (push):** `resolve_reference` tags the artifact through `oci_tag`.
- **Resolve (fetch/install):** `resolve_wit_dependency` and `reference_from_dependency` map a build-metadata dependency version onto the same `_` tag the registry actually stores.

## Non-obvious bit worth a look

The database match is intentionally left untouched: `wit_package.version` retains the full SemVer (`+` and all), so dependency lookups still match on the unmodified version. Only the tag used to *build the OCI reference* is mapped. A store-level test (`find_oci_reference_matches_build_metadata_version`) locks this in by storing the `_` tag alongside the `+` WIT version and asserting the lookup resolves.

Raw OCI references (`component install ghcr.io/u/r:tag`) are deliberately not mapped, since there the tag is literal registry coordinates rather than a SemVer field.

## Tests

Three focused unit tests cover the publish-side mapping, the explicit-dependency resolve mapping, and the store match. `cargo xtask test` passes fully (workspace clippy, fmt check, all tests, SQL migration check, README check).