### PR TITLE
Fix frontend API_BASE_URL baked into published image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,8 +203,14 @@ jobs:
           # fails to push to a freshly created GHCR package with
           # "denied: permission_denied: write_package".
           provenance: false
+          # API_BASE_URL is baked into the Wasm at build time via
+          # option_env!("API_BASE_URL"). In Azure Container Apps the backend is
+          # reached by its app name on the ingress port (80), which forwards to
+          # the container's targetPort (8081). Using http://backend:8081 here
+          # does NOT route in ACA and makes the frontend panic (connection
+          # reset) on every backend-backed request, so use http://backend.
           build-args: |
-            API_BASE_URL=http://backend:8081
+            API_BASE_URL=http://backend
           tags: |
             ${{ env.IMAGE_BASE }}/frontend:${{ needs.resolve-version.outputs.version }}
             ${{ env.IMAGE_BASE }}/frontend:latest

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,7 +1,14 @@
 # ───── Stage 1: Build component-frontend as a wasm32-wasip2 component ─────
 FROM rust:1-slim-bookworm AS builder
 
-ARG API_BASE_URL=http://backend:8081
+# Compile-time backend URL, baked into the Wasm via option_env!("API_BASE_URL").
+# Defaults to the Azure Container Apps form: the backend app is reached by name
+# on its ingress port (80), which forwards to the container's targetPort (8081).
+# Do NOT use http://backend:8081 here — that does not route in ACA and makes the
+# frontend panic on every backend-backed request. docker-compose overrides this
+# to http://backend:8081 for local dev, where services talk directly on their
+# container ports.
+ARG API_BASE_URL=http://backend
 
 WORKDIR /build
 


### PR DESCRIPTION
## Problem

The live frontend Container App panics (`connection reset`) on every backend-backed request. Root cause: `API_BASE_URL` is a **compile-time** value baked into the frontend Wasm via `option_env!("API_BASE_URL")` (`component-meta-registry-client/src/client.rs`), and the published image had it set to `http://backend:8081`.

In **Azure Container Apps**, an internal app is reached by its app name on the **ingress port (80)**, which forwards to the container's `targetPort` (8081). `http://backend:8081` does **not** route in ACA and causes a TCP reset — so every backend call in the frontend fails.

The wrong value was baked in by **CI**: the `publish-images` job in `release.yml` explicitly passed `API_BASE_URL=http://backend:8081`. The `Dockerfile.frontend` default was the same trap. (Fixing only the Dockerfile wouldn't help, since CI overrides it.)

## Fix

- **`.github/workflows/release.yml`** — CI build-arg → `API_BASE_URL=http://backend` (the load-bearing fix; makes the next published image work).
- **`Dockerfile.frontend`** — default `ARG API_BASE_URL=http://backend`, so a plain build isn't a trap.

Both now carry a comment explaining ACA routing.

`docker-compose.yml` is intentionally left as-is: it overrides `API_BASE_URL=http://backend:8081` for local dev, where services talk directly on their container ports.

## Notes

- **Frontend error handling is already robust** — every HTTP call in `client.rs` maps errors to `ApiError` and pages render an offline state (e.g. home's "Registry offline" banner). The live panic came from the older `0.7.0` image, not current `main`.
- The live frontend will remain broken until CI republishes a corrected image with this change.

## Known issue found while investigating (not fixed here)

The backend logs a Postgres `syntax error at or near "AND"` at startup. Cause: SQLite-only `GLOB` operators in `enqueue_reindex_all` and `seed_completed_from_tags` (`component-package-manager/src/storage/store.rs`), dispatched to both backends verbatim via `Statement::from_string(get_database_backend(), sql)`. `GLOB` doesn't exist in Postgres. `cargo xtask sql check` doesn't catch it (it only applies migrations). Suggested fix: per-backend SQL dispatch or filter hex tags in Rust. Happy to do this as a follow-up.

Validated with `cargo xtask test` (fmt, clippy, test, sql check, readme) — all green.