### PR TITLE
Serve cached component installs locally without network round-trips

### DIFF
--- a/crates/component-cli/src/main.rs
+++ b/crates/component-cli/src/main.rs
@@ -46,7 +46,7 @@ pub(crate) struct Cli {
 impl Cli {
     async fn run(self) -> miette::Result<()> {
         match self.command {
-            Some(Command::Run(opts)) => opts.run(self.offline).await?,
+            Some(Command::Run(opts)) => Box::pin(opts.run(self.offline)).await?,
             Some(Command::Local(opts)) => {
                 opts.run();
             }
@@ -163,7 +163,7 @@ async fn main() -> miette::Result<()> {
     let argv = quarantine_run_trailing_args(std::env::args().collect());
     let cli = Cli::parse_from(argv);
     let _tracing_guard = init_tracing(cli.verbosity.tracing_level_filter())?;
-    cli.run().await?;
+    Box::pin(cli.run()).await?;
     Ok(())
 }
 

--- a/crates/component-meta-registry-client/src/client.rs
+++ b/crates/component-meta-registry-client/src/client.rs
@@ -757,6 +757,29 @@ mod tests {
         format!("http://{addr}")
     }
 
+    /// Build a client with a short connect timeout so a single connection
+    /// attempt to an unreachable address is bounded on every platform.
+    ///
+    /// The default 2s production connect timeout is correct in production but
+    /// makes timing-based tests non-portable: on some platforms (notably
+    /// Windows CI) a connect to a closed loopback port is not refused
+    /// promptly and instead waits out the full connect timeout, so a single
+    /// attempt alone can exceed a sub-second assertion. reqwest enforces the
+    /// connect timeout with its own timer regardless of OS refuse behavior, so
+    /// a short value gives a reliable upper bound on one attempt.
+    #[cfg(not(all(target_os = "wasi", target_env = "p2")))]
+    fn client_with_short_connect_timeout(base_url: impl Into<String>) -> RegistryClient {
+        let base_url = base_url.into();
+        RegistryClient {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client: reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_millis(100))
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .expect("build reqwest client with short connect timeout"),
+        }
+    }
+
     #[cfg(not(all(target_os = "wasi", target_env = "p2")))]
     #[tokio::test]
     async fn fetch_optional_returns_none_on_404() {
@@ -799,19 +822,26 @@ mod tests {
     #[tokio::test]
     async fn fetch_packages_fails_fast_when_registry_unreachable() {
         // Bind then immediately drop the listener to obtain an address that
-        // nothing is listening on, so a connect attempt is refused at once.
+        // nothing is listening on, so the connect attempt fails (refused, or
+        // timed out at the short connect timeout on platforms that don't
+        // refuse loopback connects promptly).
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
         let addr = listener.local_addr().expect("get listener addr");
         drop(listener);
 
-        let client = RegistryClient::new(format!("http://{addr}"));
+        // A short connect timeout bounds a *single* attempt to ~100ms on every
+        // platform, so the assertion below cleanly separates the fail-fast path
+        // (one attempt) from the retry path (three attempts plus backoff).
+        let client = client_with_short_connect_timeout(format!("http://{addr}"));
         let start = std::time::Instant::now();
         let result = client.fetch_packages(None, 10).await;
         let elapsed = start.elapsed();
 
         assert!(result.is_err(), "unreachable registry should error");
-        // Three retries would sleep at least 250ms + 500ms = 750ms. Failing
-        // fast on connection errors must skip those backoff sleeps entirely.
+        // Three retries would sleep at least 250ms + 500ms = 750ms on top of
+        // the connection attempts. Failing fast on connection errors must skip
+        // those backoff sleeps entirely, so a single ~100ms attempt stays well
+        // under this bound while a retrying implementation would blow past it.
         assert!(
             elapsed < std::time::Duration::from_millis(500),
             "fetch should fail fast without retrying, took {elapsed:?}"

--- a/crates/component-meta-registry-client/src/client.rs
+++ b/crates/component-meta-registry-client/src/client.rs
@@ -133,7 +133,17 @@ impl RegistryClient {
             #[cfg(all(target_os = "wasi", target_env = "p2"))]
             client: wstd::http::Client::new(),
             #[cfg(not(all(target_os = "wasi", target_env = "p2")))]
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                // Bound the connect phase so an unreachable meta-registry
+                // fails fast instead of hanging the (blocking) sync step that
+                // runs on the `component install` hot path.
+                .connect_timeout(std::time::Duration::from_secs(2))
+                // Backstop the whole request against a black-holed host.
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                // A builder failure (e.g. TLS backend init) is unexpected;
+                // fall back to the default client rather than panicking.
+                .unwrap_or_else(|_| reqwest::Client::new()),
         }
     }
 
@@ -505,6 +515,20 @@ impl RegistryClient {
 
 // --- ETag-based sync (native only) -------------------------------------------
 
+/// Outcome of a single [`RegistryClient::try_fetch`] attempt, used to decide
+/// whether a retry is worthwhile.
+#[cfg(feature = "client")]
+enum FetchAttemptError {
+    /// The registry could not be reached — a connection error or a
+    /// connect/request timeout. Retrying within a single command is very
+    /// unlikely to help, so the caller fails fast and treats the sync as a
+    /// best-effort miss rather than making the user wait through the backoff.
+    Unreachable(anyhow::Error),
+    /// A transient server-side failure (e.g. a 5xx), an unexpected status, or
+    /// a malformed response. Worth retrying with backoff.
+    Retryable(anyhow::Error),
+}
+
 #[cfg(feature = "client")]
 impl RegistryClient {
     /// Fetch all packages from the meta-registry with ETag support.
@@ -559,7 +583,10 @@ impl RegistryClient {
         for duration in &backoff {
             match self.try_fetch(&url, etag).await {
                 Ok(result) => return Ok(result),
-                Err(e) => {
+                // An unreachable registry won't recover within one command's
+                // backoff window; fail fast so the sync doesn't stall install.
+                Err(FetchAttemptError::Unreachable(e)) => return Err(e),
+                Err(FetchAttemptError::Retryable(e)) => {
                     last_err = Some(e);
                     if let Some(d) = duration {
                         tokio::time::sleep(d).await;
@@ -574,16 +601,27 @@ impl RegistryClient {
     }
 
     /// Single attempt to fetch packages with ETag support.
-    async fn try_fetch(&self, url: &str, etag: Option<&str>) -> anyhow::Result<FetchResult> {
+    async fn try_fetch(
+        &self,
+        url: &str,
+        etag: Option<&str>,
+    ) -> Result<FetchResult, FetchAttemptError> {
         let mut req = self.client.get(url);
         if let Some(etag_val) = etag {
             req = req.header(reqwest::header::IF_NONE_MATCH, etag_val);
         }
 
-        let resp = req
-            .send()
-            .await
-            .map_err(|e| anyhow::anyhow!("could not reach registry at {}: {e}", self.base_url))?;
+        let resp = req.send().await.map_err(|e| {
+            let err = anyhow::anyhow!("could not reach registry at {}: {e}", self.base_url);
+            // Connection failures and timeouts mean the registry is effectively
+            // unreachable right now; anything else (already connected) may be a
+            // transient hiccup worth retrying.
+            if e.is_connect() || e.is_timeout() {
+                FetchAttemptError::Unreachable(err)
+            } else {
+                FetchAttemptError::Retryable(err)
+            }
+        })?;
 
         let status = resp.status();
         if status == reqwest::StatusCode::NOT_MODIFIED {
@@ -591,17 +629,17 @@ impl RegistryClient {
         }
 
         if status.is_server_error() {
-            anyhow::bail!(
+            return Err(FetchAttemptError::Retryable(anyhow::anyhow!(
                 "registry at {} returned server error: {status}",
                 self.base_url
-            );
+            )));
         }
 
         if !status.is_success() {
-            anyhow::bail!(
+            return Err(FetchAttemptError::Retryable(anyhow::anyhow!(
                 "registry at {} returned unexpected status: {status}",
                 self.base_url
-            );
+            )));
         }
 
         let new_etag = resp
@@ -610,10 +648,12 @@ impl RegistryClient {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
-        let packages: Vec<KnownPackage> = resp
-            .json()
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to parse response from {}: {e}", self.base_url))?;
+        let packages: Vec<KnownPackage> = resp.json().await.map_err(|e| {
+            FetchAttemptError::Retryable(anyhow::anyhow!(
+                "failed to parse response from {}: {e}",
+                self.base_url
+            ))
+        })?;
 
         Ok(FetchResult::Updated {
             packages,
@@ -749,6 +789,32 @@ mod tests {
         assert!(
             msg.contains("boom"),
             "error should include response body for debugging"
+        );
+    }
+
+    /// An unreachable registry must fail fast rather than burning through the
+    /// exponential-backoff retries — otherwise every `component install` pays
+    /// the full backoff (~750ms of sleeps) on the blocking sync step.
+    #[cfg(not(all(target_os = "wasi", target_env = "p2")))]
+    #[tokio::test]
+    async fn fetch_packages_fails_fast_when_registry_unreachable() {
+        // Bind then immediately drop the listener to obtain an address that
+        // nothing is listening on, so a connect attempt is refused at once.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let addr = listener.local_addr().expect("get listener addr");
+        drop(listener);
+
+        let client = RegistryClient::new(format!("http://{addr}"));
+        let start = std::time::Instant::now();
+        let result = client.fetch_packages(None, 10).await;
+        let elapsed = start.elapsed();
+
+        assert!(result.is_err(), "unreachable registry should error");
+        // Three retries would sleep at least 250ms + 500ms = 750ms. Failing
+        // fast on connection errors must skip those backoff sleeps entirely.
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "fetch should fail fast without retrying, took {elapsed:?}"
         );
     }
 }

--- a/crates/component-package-manager/src/manager/errors.rs
+++ b/crates/component-package-manager/src/manager/errors.rs
@@ -35,6 +35,17 @@ pub enum ManagerError {
     )]
     OfflinePull,
 
+    /// An install was requested in offline mode for a package that is not
+    /// present in the local cache.
+    #[diagnostic(
+        code(component::manager::offline_not_cached),
+        help("run without `--offline` to fetch '{reference}' from the registry")
+    )]
+    OfflineNotCached {
+        /// The reference that could not be served from the local cache.
+        reference: String,
+    },
+
     /// An attempt was made to index a package while in offline mode.
     #[diagnostic(
         code(component::manager::offline_index),
@@ -110,6 +121,9 @@ impl std::fmt::Display for ManagerError {
             ManagerError::OfflinePull => {
                 write!(f, "cannot pull packages in offline mode")
             }
+            ManagerError::OfflineNotCached { reference } => {
+                write!(f, "'{reference}' is not in the local cache")
+            }
             ManagerError::OfflineIndex => {
                 write!(f, "cannot index packages in offline mode")
             }
@@ -170,6 +184,21 @@ mod tests {
         assert!(
             offline_pull.help().is_some(),
             "OfflinePull must have a help message"
+        );
+
+        let offline_not_cached = ManagerError::OfflineNotCached {
+            reference: "ghcr.io/example/comp:1.2.3".to_string(),
+        };
+        assert_eq!(
+            offline_not_cached
+                .code()
+                .expect("OfflineNotCached must have a diagnostic code")
+                .to_string(),
+            "component::manager::offline_not_cached",
+        );
+        assert!(
+            offline_not_cached.help().is_some(),
+            "OfflineNotCached must have a help message"
         );
 
         let offline_index = ManagerError::OfflineIndex;

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -188,12 +188,17 @@ impl Manager {
             )
             .await?;
 
-        self.store_related_tags(&reference).await?;
+        // Enrichment (tag listing + referrer discovery) hits the network and
+        // only matters when we stored a new manifest. Skip it on cache hits so
+        // re-pulling an already-present version stays local.
+        if result == InsertResult::Inserted {
+            self.store_related_tags(&reference).await?;
 
-        // Best-effort: discover and store referrers (signatures, SBOMs, etc.)
-        if let (Some(manifest_id), Some(digest)) = (manifest_id, &digest) {
-            self.try_store_referrers(&reference, digest, manifest_id)
-                .await;
+            // Best-effort: discover and store referrers (signatures, SBOMs, etc.)
+            if let (Some(manifest_id), Some(digest)) = (manifest_id, &digest) {
+                self.try_store_referrers(&reference, digest, manifest_id)
+                    .await;
+            }
         }
 
         Ok(PullResult {
@@ -354,12 +359,17 @@ impl Manager {
             )
             .await?;
 
-        self.store_related_tags(&reference).await?;
+        // Enrichment (tag listing + referrer discovery) hits the network and
+        // only matters when we stored a new manifest. Skip it on cache hits so
+        // re-pulling an already-present version stays local.
+        if result == InsertResult::Inserted {
+            self.store_related_tags(&reference).await?;
 
-        // Best-effort: discover and store referrers (signatures, SBOMs, etc.)
-        if let Some(manifest_id) = image_id {
-            self.try_store_referrers(&reference, &digest, manifest_id)
-                .await;
+            // Best-effort: discover and store referrers (signatures, SBOMs, etc.)
+            if let Some(manifest_id) = image_id {
+                self.try_store_referrers(&reference, &digest, manifest_id)
+                    .await;
+            }
         }
 
         Ok(PullResult {
@@ -444,8 +454,27 @@ impl Manager {
         vendor_dir: &Path,
         progress_tx: Option<&tokio::sync::mpsc::Sender<ProgressEvent>>,
     ) -> anyhow::Result<InstallResult> {
-        use crate::oci::filter_wasm_layers;
+        // Fast path: a fully-cached concrete version is served by reflinking
+        // from the local store with zero network round-trips.
+        if let Some(result) = self
+            .try_install_from_cache(&reference, vendor_dir, progress_tx)
+            .await?
+        {
+            return Ok(result);
+        }
 
+        // Offline mode can only serve packages already in the cache; if the
+        // fast path missed there is nothing more we can do without network.
+        if self.offline {
+            return Err(ManagerError::OfflineNotCached {
+                reference: reference.to_string(),
+            }
+            .into());
+        }
+
+        // Network path: pull the manifest (and any missing layers) from the
+        // registry, then vendor exactly as the cache path does.
+        //
         // `Box::pin` keeps the (large) pull futures on the heap so this shared
         // method's own future stays small enough to satisfy `clippy::large_futures`.
         let pull_result = match progress_tx {
@@ -453,52 +482,168 @@ impl Manager {
             None => Box::pin(self.pull(reference.clone())).await?,
         };
 
-        let mut vendored_files = Vec::new();
-        let mut package_name = None;
-        let mut is_component = true; // Default to component
-        let mut dependencies = Vec::new();
-
-        // Extract the OCI image.title annotation from the manifest.
-        let oci_title = pull_result
-            .manifest
-            .as_ref()
-            .and_then(|m| m.annotations.as_ref())
-            .and_then(|a| a.get("org.opencontainers.image.title").cloned());
-
-        if let Some(ref manifest) = pull_result.manifest {
-            let wasm_layers = filter_wasm_layers(&manifest.layers);
-
-            let inspected = self.inspect_wasm_layers(&wasm_layers).await;
-            package_name = inspected.0;
-            is_component = inspected.1;
-            dependencies = inspected.2;
-
-            if !wasm_layers.is_empty() {
-                let name = package_name.as_deref().ok_or_else(|| {
-                    anyhow::anyhow!("could not determine WIT package name from `{reference}`")
-                })?;
-                let filename = vendor_filename(name, reference.tag());
-                vendored_files = self
-                    .vendor_wasm_layers(&wasm_layers, vendor_dir, &filename)
-                    .await?;
+        let result = match pull_result.manifest {
+            Some(ref manifest) => {
+                self.vendor_manifest(&reference, vendor_dir, manifest, pull_result.digest)
+                    .await?
             }
-        }
+            // A wasm artifact always carries a manifest; the `None` case is
+            // purely defensive and yields an otherwise-empty result.
+            None => InstallResult {
+                registry: reference.registry().to_string(),
+                repository: reference.repository().to_string(),
+                tag: reference.tag().map(str::to_string),
+                digest: pull_result.digest,
+                package_name: None,
+                oci_title: None,
+                vendored_files: Vec::new(),
+                is_component: true,
+                dependencies: Vec::new(),
+            },
+        };
 
         if let Some(tx) = progress_tx {
             let _ = tx.send(ProgressEvent::InstallComplete).await;
+        }
+
+        Ok(result)
+    }
+
+    /// Attempt to install `reference` entirely from the local cache, without
+    /// any network I/O.
+    ///
+    /// Returns `Ok(Some(result))` on a full cache hit — a concrete version tag
+    /// whose manifest and every layer are already stored locally. Returns
+    /// `Ok(None)` when the caller should fall back to the network: the
+    /// reference has no tag or a floating `latest` tag, the manifest is not
+    /// cached, or some layer blob is missing.
+    async fn try_install_from_cache(
+        &self,
+        reference: &Reference,
+        vendor_dir: &Path,
+        progress_tx: Option<&tokio::sync::mpsc::Sender<ProgressEvent>>,
+    ) -> anyhow::Result<Option<InstallResult>> {
+        // Only trust the cache for concrete version tags. `latest` (and the
+        // no-tag case, which OCI treats as `latest`) is mutable, so we must
+        // re-check the registry for freshness.
+        let tag = match reference.tag() {
+            Some(tag) if tag != "latest" => tag,
+            _ => return Ok(None),
+        };
+
+        let Some((digest, manifest)) = self
+            .store
+            .cached_manifest_for_reference(reference.registry(), reference.repository(), tag)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        // Every referenced layer blob must be present locally, otherwise we
+        // cannot vendor without the network — fall back to the pull path.
+        if !self.store.all_layers_cached(&manifest).await {
+            return Ok(None);
+        }
+
+        // Drive the progress display from cached metadata so the CLI renders
+        // the same phases as a network install, just instantly.
+        Self::emit_cached_progress(progress_tx, &manifest, &digest).await;
+
+        let result = self
+            .vendor_manifest(reference, vendor_dir, &manifest, Some(digest))
+            .await?;
+
+        if let Some(tx) = progress_tx {
+            let _ = tx.send(ProgressEvent::InstallComplete).await;
+        }
+
+        Ok(Some(result))
+    }
+
+    /// Build an [`InstallResult`] by vendoring the wasm layer(s) of an
+    /// already-available manifest — whether just pulled from the registry or
+    /// loaded from the local cache.
+    ///
+    /// Inspects the (cached) wasm layers for their WIT package name, kind, and
+    /// dependencies, then reflinks them into `vendor_dir`. Performs no network
+    /// I/O; both the fast path and the network path share it so their results
+    /// are constructed identically.
+    async fn vendor_manifest(
+        &self,
+        reference: &Reference,
+        vendor_dir: &Path,
+        manifest: &oci_client::manifest::OciImageManifest,
+        digest: Option<String>,
+    ) -> anyhow::Result<InstallResult> {
+        use crate::oci::filter_wasm_layers;
+
+        let oci_title = manifest
+            .annotations
+            .as_ref()
+            .and_then(|a| a.get("org.opencontainers.image.title").cloned());
+
+        let wasm_layers = filter_wasm_layers(&manifest.layers);
+        let (package_name, is_component, dependencies) =
+            self.inspect_wasm_layers(&wasm_layers).await;
+
+        let mut vendored_files = Vec::new();
+        if !wasm_layers.is_empty() {
+            let name = package_name.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("could not determine WIT package name from `{reference}`")
+            })?;
+            let filename = vendor_filename(name, reference.tag());
+            vendored_files = self
+                .vendor_wasm_layers(&wasm_layers, vendor_dir, &filename)
+                .await?;
         }
 
         Ok(InstallResult {
             registry: reference.registry().to_string(),
             repository: reference.repository().to_string(),
             tag: reference.tag().map(str::to_string),
-            digest: pull_result.digest,
+            digest,
             package_name,
             oci_title,
             vendored_files,
             is_component,
             dependencies,
         })
+    }
+
+    /// Emit synthetic progress events for a cache hit so the CLI progress bars
+    /// advance through the manifest and per-layer phases before completing.
+    async fn emit_cached_progress(
+        progress_tx: Option<&tokio::sync::mpsc::Sender<ProgressEvent>>,
+        manifest: &oci_client::manifest::OciImageManifest,
+        digest: &str,
+    ) {
+        let Some(tx) = progress_tx else { return };
+        let _ = tx
+            .send(ProgressEvent::ManifestFetched {
+                layer_count: manifest.layers.len(),
+                image_digest: digest.to_string(),
+            })
+            .await;
+        for (index, layer) in manifest.layers.iter().enumerate() {
+            let total_bytes = if layer.size > 0 {
+                u64::try_from(layer.size).ok()
+            } else {
+                None
+            };
+            let _ = tx
+                .send(ProgressEvent::LayerStarted {
+                    index,
+                    digest: layer.digest.clone(),
+                    total_bytes,
+                    title: layer
+                        .annotations
+                        .as_ref()
+                        .and_then(|a| a.get("org.opencontainers.image.title").cloned()),
+                    media_type: layer.media_type.clone(),
+                })
+                .await;
+            let _ = tx.send(ProgressEvent::LayerStored { index }).await;
+        }
     }
 
     /// Inspect cached wasm layers up-front to learn the WIT package name; this

--- a/crates/component-package-manager/src/storage/store.rs
+++ b/crates/component-package-manager/src/storage/store.rs
@@ -2358,6 +2358,71 @@ impl Store {
         Ok(())
     }
 
+    /// Look up a fully-described cached manifest for a concrete reference.
+    ///
+    /// Reconstructs the [`OciImageManifest`] from the stored `raw_json` for
+    /// the `(registry, repository, tag)` triple, returning it together with
+    /// the manifest digest. Returns `None` when the repository, tag, or
+    /// manifest row is absent, or when the stored manifest has no `raw_json`
+    /// payload to deserialize.
+    ///
+    /// This performs no network I/O — it is the basis of the local-cache
+    /// fast-path in [`Manager::install`](crate::manager::Manager::install).
+    pub(crate) async fn cached_manifest_for_reference(
+        &self,
+        registry: &str,
+        repository: &str,
+        tag: &str,
+    ) -> anyhow::Result<Option<(String, OciImageManifest)>> {
+        let Some(repo) = oci_repository::Entity::find()
+            .filter(oci_repository::Column::Registry.eq(registry))
+            .filter(oci_repository::Column::Repository.eq(repository))
+            .one(&self.db)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let Some(tag_row) = oci_tag::Entity::find()
+            .filter(oci_tag::Column::OciRepositoryId.eq(repo.id))
+            .filter(oci_tag::Column::Tag.eq(tag))
+            .one(&self.db)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let Some(manifest_row) = oci_manifest::Entity::find()
+            .filter(oci_manifest::Column::OciRepositoryId.eq(repo.id))
+            .filter(oci_manifest::Column::Digest.eq(&tag_row.manifest_digest))
+            .one(&self.db)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let Some(raw_json) = manifest_row.raw_json else {
+            return Ok(None);
+        };
+        let manifest: OciImageManifest = serde_json::from_str(&raw_json)?;
+        Ok(Some((tag_row.manifest_digest, manifest)))
+    }
+
+    /// Return `true` when every layer referenced by `manifest` has its
+    /// content blob present in the local content-addressable store.
+    ///
+    /// Used to confirm a cache hit is complete before serving an install
+    /// without touching the network.
+    pub(crate) async fn all_layers_cached(&self, manifest: &OciImageManifest) -> bool {
+        let cache = self.state_info.store_dir();
+        for layer in &manifest.layers {
+            if !matches!(cacache::metadata(cache, &layer.digest).await, Ok(Some(_))) {
+                return false;
+            }
+        }
+        true
+    }
+
     pub(crate) async fn reindex_wit_packages(&self) -> anyhow::Result<u64> {
         // Re-derive WIT metadata for every wit_package that has a cached
         // layer. The legacy implementation considered two sources:
@@ -3854,6 +3919,7 @@ mod smoke_tests {
 mod component_tests {
     use super::*;
     use component_meta_registry_types::{ComponentSummary, WitInterfaceRef};
+    use oci_client::manifest::OciDescriptor;
 
     #[test]
     fn parse_component_extern_name_full() {
@@ -4084,5 +4150,98 @@ mod component_tests {
             .await
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    // ── local-cache fast-path lookups ───────────────────────────────────
+
+    /// A concrete `(registry, repository, tag)` triple resolves back to the
+    /// stored manifest (deserialized from `raw_json`) together with its
+    /// digest, and an unknown tag misses.
+    #[tokio::test]
+    async fn cached_manifest_for_reference_round_trips_and_misses() {
+        let store = Store::open_in_memory().await.unwrap();
+        let reference: Reference = "ghcr.io/example/comp:1.2.3".parse().unwrap();
+        let layer_digest =
+            "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+        let manifest_digest =
+            "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+        let manifest = OciImageManifest {
+            layers: vec![OciDescriptor {
+                media_type: "application/wasm".to_string(),
+                digest: layer_digest.to_string(),
+                size: 4,
+                urls: None,
+                annotations: None,
+            }],
+            ..Default::default()
+        };
+
+        let (result, _manifest_id) = store
+            .insert_metadata(&reference, Some(manifest_digest), &manifest, 4)
+            .await
+            .unwrap();
+        assert_eq!(result, InsertResult::Inserted);
+
+        let (digest, got) = store
+            .cached_manifest_for_reference("ghcr.io", "example/comp", "1.2.3")
+            .await
+            .unwrap()
+            .expect("stored manifest should be found");
+        assert_eq!(digest, manifest_digest);
+        assert_eq!(got.layers.len(), 1);
+        assert_eq!(got.layers[0].digest, layer_digest);
+
+        // An unknown tag on the same repository misses.
+        assert!(
+            store
+                .cached_manifest_for_reference("ghcr.io", "example/comp", "9.9.9")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        // An unknown repository misses.
+        assert!(
+            store
+                .cached_manifest_for_reference("ghcr.io", "other/comp", "1.2.3")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// `all_layers_cached` is false until every referenced layer blob has been
+    /// written to the content store, then true.
+    #[tokio::test]
+    async fn all_layers_cached_reflects_blob_presence() {
+        let store = Store::open_in_memory().await.unwrap();
+        let layer_digest =
+            "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+        let manifest = OciImageManifest {
+            layers: vec![OciDescriptor {
+                media_type: "application/wasm".to_string(),
+                digest: layer_digest.to_string(),
+                size: 3,
+                urls: None,
+                annotations: None,
+            }],
+            ..Default::default()
+        };
+
+        // Nothing written yet: a missing blob means the cache is incomplete.
+        assert!(!store.all_layers_cached(&manifest).await);
+
+        // Write the layer blob into the content store keyed by its digest.
+        store
+            .insert_layer(
+                layer_digest,
+                b"abc",
+                None,
+                Some("application/wasm"),
+                0,
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(store.all_layers_cached(&manifest).await);
     }
 }


### PR DESCRIPTION
## Why

`component install` took roughly 1 to 3 seconds even when the requested component was already fully cached locally, where the realistic cost should be a few milliseconds to reflink a stored layer. Profiling showed about 98% of the wall time was network wait with the CPU idle: every install unconditionally hit the OCI registry (auth token exchange, manifest + config fetch, an unconditional `list_tags`, and `pull_referrers`), even when nothing had changed. On top of that, `--offline install` was broken and errored out even for fully cached packages.

## What this does

Adds a local-cache fast path and stops the redundant network work:

- **Store lookups** (`storage/store.rs`): `cached_manifest_for_reference` reconstructs a stored manifest from the persisted `raw_json` for a concrete `(registry, repository, tag)` triple, and `all_layers_cached` confirms every referenced layer blob is present in the content store.
- **Manager fast path** (`manager/mod.rs`): `try_install_from_cache` reflinks the wasm layer(s) from the local store and builds a fully populated `InstallResult` with zero network I/O for concrete version tags (Cargo-like: a pinned version is trusted once cached). It emits the same synthetic progress events the CLI renders for a network install, so the UX is unchanged. `latest`, floating, and no-tag references still fall through to the network for freshness.
- **Gated enrichment**: `store_related_tags` and `try_store_referrers` now run only when a new manifest is actually inserted, so cache hits on the network path make zero extra round-trips.
- **Offline fixed**: offline install now serves from the cache, and on a genuine miss returns a clear `OfflineNotCached` diagnostic instead of a blanket "cannot pull in offline mode" error.

## Resilient meta-registry sync

The blocking meta-registry sync (which correctly runs when a resync is due and is skipped once fresh) previously retried an unreachable registry three times with exponential backoff, costing about 800ms on the install hot path every time the registry was down. The registry client now fails fast on connection errors with bounded connect/request timeouts (no backoff for an unreachable host), so a down registry costs about 30ms instead. The sync still blocks when genuinely due and re-syncs immediately once the registry is reachable again.

## Results

Measured against a cached `ba:sample-wasi-http-rust@0.1.6` (component plus 7 transitive WIT deps):

| Scenario | Before | After |
| --- | --- | --- |
| Online cached install | ~2.1s | ~0.08 to 0.10s |
| Offline cached install | broken | ~0.05s |

The remaining ~80ms online is process startup, DB open, planning, reflink, and one fast-failed sync connect, not network round-trips.

## Notes for reviewers

- The freshness policy is intentional: concrete version tags are trusted from cache without any network check, while `latest`/floating tags always re-check the registry.
- Gating enrichment behind `InsertResult::Inserted` means re-pulling an already-stored version no longer refreshes sibling tags on that path; the hourly meta-registry sync remains the primary index-freshness mechanism.

## Validation

`cargo xtask test` passes end to end: 593 tests (including 3 new hermetic tests covering the store lookups and the client fail-fast behavior), clippy with `-D warnings`, fmt, sql check, and readme check.