### PR TITLE
Decode OCI build-metadata tags on the discovery path

### DIFF
--- a/crates/component-package-manager/src/manager/logic.rs
+++ b/crates/component-package-manager/src/manager/logic.rs
@@ -191,9 +191,9 @@ pub fn derive_component_name<S: std::hash::BuildHasher>(
 /// Try to parse a tag as a semantic version, accepting an optional leading
 /// `v` prefix (e.g. `v1.2.3`) while leaving the original tag string untouched.
 ///
-/// Also reverses the `+`->`_` OCI-tag mapping applied on publish by
-/// [`crate::publish::oci_tag`]: OCI tags cannot contain `+`, so a SemVer with
-/// build metadata such as `0.1.0+2022-11-15` is stored under the tag
+/// Also reverses the `+`->`_` OCI-tag mapping that [`crate::publish::oci_tag`]
+/// applies on publish. OCI tags cannot contain `+`, so a SemVer with build
+/// metadata such as `0.1.0+2022-11-15` is stored under the tag
 /// `0.1.0_2022-11-15`. When we read tags back from a registry during indexing
 /// we decode the first `_` to `+` so they round-trip and parse as SemVer,
 /// instead of being discarded as non-semver (which skips the whole package).

--- a/crates/component-package-manager/src/manager/logic.rs
+++ b/crates/component-package-manager/src/manager/logic.rs
@@ -190,12 +190,34 @@ pub fn derive_component_name<S: std::hash::BuildHasher>(
 
 /// Try to parse a tag as a semantic version, accepting an optional leading
 /// `v` prefix (e.g. `v1.2.3`) while leaving the original tag string untouched.
+///
+/// Also reverses the `+`->`_` OCI-tag mapping applied on publish by
+/// [`crate::publish::oci_tag`]: OCI tags cannot contain `+`, so a SemVer with
+/// build metadata such as `0.1.0+2022-11-15` is stored under the tag
+/// `0.1.0_2022-11-15`. When we read tags back from a registry during indexing
+/// we decode the first `_` to `+` so they round-trip and parse as SemVer,
+/// instead of being discarded as non-semver (which skips the whole package).
 pub(crate) fn parse_tag_as_semver(tag: &str) -> Option<semver::Version> {
-    if let Ok(version) = semver::Version::parse(tag) {
+    if let Some(version) = parse_semver_allow_v_prefix(tag) {
         return Some(version);
     }
-    // Accept a leading `v` when followed by a digit.
-    let stripped = tag.strip_prefix('v')?;
+    // Reverse the `+`->`_` OCI-tag mapping (see `publish::oci_tag`). SemVer has
+    // at most one `+` (all build metadata follows it and cannot itself contain
+    // `_`), so `oci_tag` introduces at most one `_`; decode the first `_` back
+    // to `+` and retry.
+    if tag.contains('_') {
+        return parse_semver_allow_v_prefix(&tag.replacen('_', "+", 1));
+    }
+    None
+}
+
+/// Parse `s` as SemVer, accepting a single optional leading `v` when it is
+/// immediately followed by a digit (e.g. `v1.2.3`).
+fn parse_semver_allow_v_prefix(s: &str) -> Option<semver::Version> {
+    if let Ok(version) = semver::Version::parse(s) {
+        return Some(version);
+    }
+    let stripped = s.strip_prefix('v')?;
     if !stripped.starts_with(|c: char| c.is_ascii_digit()) {
         return None;
     }
@@ -670,5 +692,54 @@ mod tests {
         // "v0.3" request should match 0.3.* pre-release tags
         let suggestions = filter_tag_suggestions(&tags, Some("v0.3"));
         assert_eq!(suggestions, vec!["0.2.0", "0.3.0-preview"]);
+    }
+
+    // ── parse_tag_as_semver ─────────────────────────────────────────────
+
+    #[test]
+    fn parse_tag_as_semver_decodes_underscore_build_metadata() {
+        // OCI tags cannot contain `+`, so `publish::oci_tag` maps SemVer build
+        // metadata `0.1.0+2022-11-15` onto `0.1.0_2022-11-15`. The read path
+        // must reverse this so the tag round-trips as SemVer.
+        let cases = [
+            ("0.1.0_2022-11-15", (0, 1, 0), "2022-11-15"),
+            ("0.2.0_stripe-2022-11-15", (0, 2, 0), "stripe-2022-11-15"),
+            ("0.1.0_3.7.1-pre.0", (0, 1, 0), "3.7.1-pre.0"),
+        ];
+        for (tag, (major, minor, patch), build) in cases {
+            let v = parse_tag_as_semver(tag).expect("underscore tag should parse");
+            assert_eq!((v.major, v.minor, v.patch), (major, minor, patch));
+            assert!(v.pre.is_empty(), "{tag} should have no pre-release");
+            assert!(!v.build.is_empty(), "{tag} should have build metadata");
+            assert_eq!(v.build.as_str(), build);
+        }
+    }
+
+    #[test]
+    fn parse_tag_as_semver_plain_and_v_prefixed() {
+        let plain = parse_tag_as_semver("1.2.3").expect("plain should parse");
+        assert_eq!((plain.major, plain.minor, plain.patch), (1, 2, 3));
+        assert!(plain.build.is_empty());
+
+        let prefixed = parse_tag_as_semver("v1.2.3").expect("v-prefixed should parse");
+        assert_eq!((prefixed.major, prefixed.minor, prefixed.patch), (1, 2, 3));
+    }
+
+    #[test]
+    fn parse_tag_as_semver_rejects_non_semver() {
+        assert!(parse_tag_as_semver("latest").is_none());
+        assert!(parse_tag_as_semver("sha256-abc").is_none());
+        assert!(parse_tag_as_semver("not-a-version").is_none());
+    }
+
+    #[test]
+    fn pick_latest_stable_tag_underscore_build_metadata() {
+        let tags = vec!["0.1.0_2022-11-15".into(), "0.2.0_stripe-2022-11-15".into()];
+        // Build metadata is ignored for precedence, and the raw underscore tag
+        // is returned unchanged so it can be used to pull the artifact.
+        assert_eq!(
+            pick_latest_stable_tag(&tags),
+            Some("0.2.0_stripe-2022-11-15".to_string())
+        );
     }
 }

--- a/crates/component-package-manager/src/manager/logic.rs
+++ b/crates/component-package-manager/src/manager/logic.rs
@@ -188,17 +188,16 @@ pub fn derive_component_name<S: std::hash::BuildHasher>(
         .unwrap_or_else(|| repository.to_string())
 }
 
-/// Try to parse a tag as a semantic version, accepting an optional leading
-/// `v` prefix (e.g. `v1.2.3`) while leaving the original tag string untouched.
+/// Try to parse a tag as a semantic version.
 ///
-/// Also reverses the `+`->`_` OCI-tag mapping that [`crate::publish::oci_tag`]
+/// Reverses the `+`->`_` OCI-tag mapping that [`crate::publish::oci_tag`]
 /// applies on publish. OCI tags cannot contain `+`, so a SemVer with build
 /// metadata such as `0.1.0+2022-11-15` is stored under the tag
 /// `0.1.0_2022-11-15`. When we read tags back from a registry during indexing
 /// we decode the first `_` to `+` so they round-trip and parse as SemVer,
 /// instead of being discarded as non-semver (which skips the whole package).
 pub(crate) fn parse_tag_as_semver(tag: &str) -> Option<semver::Version> {
-    if let Some(version) = parse_semver_allow_v_prefix(tag) {
+    if let Ok(version) = semver::Version::parse(tag) {
         return Some(version);
     }
     // Reverse the `+`->`_` OCI-tag mapping (see `publish::oci_tag`). SemVer has
@@ -206,28 +205,15 @@ pub(crate) fn parse_tag_as_semver(tag: &str) -> Option<semver::Version> {
     // `_`), so `oci_tag` introduces at most one `_`; decode the first `_` back
     // to `+` and retry.
     if tag.contains('_') {
-        return parse_semver_allow_v_prefix(&tag.replacen('_', "+", 1));
+        return semver::Version::parse(&tag.replacen('_', "+", 1)).ok();
     }
     None
-}
-
-/// Parse `s` as SemVer, accepting a single optional leading `v` when it is
-/// immediately followed by a digit (e.g. `v1.2.3`).
-fn parse_semver_allow_v_prefix(s: &str) -> Option<semver::Version> {
-    if let Ok(version) = semver::Version::parse(s) {
-        return Some(version);
-    }
-    let stripped = s.strip_prefix('v')?;
-    if !stripped.starts_with(|c: char| c.is_ascii_digit()) {
-        return None;
-    }
-    semver::Version::parse(stripped).ok()
 }
 
 /// Pick the latest stable semver tag from a list of tags.
 ///
 /// Filters out:
-/// - Tags that are not valid semver versions (accepts optional `v` prefix)
+/// - Tags that are not valid semver versions
 /// - Pre-release tags (e.g. `0.3.0-preview-2026-02-20`)
 /// - The literal `latest` tag
 /// - Hash-based tags (e.g. `sha256-abc123.sig`)
@@ -267,7 +253,7 @@ pub fn pick_latest_stable_tag(tags: &[String]) -> Option<String> {
 /// `0.3.0-preview-2026-02-20`) are included.
 ///
 /// In all cases, `latest`, hash-based tags, and non-semver tags are
-/// excluded. Tags with a leading `v` prefix (e.g. `v0.2.0`) are accepted.
+/// excluded.
 ///
 /// # Example
 ///
@@ -582,18 +568,20 @@ mod tests {
     }
 
     #[test]
-    fn pick_latest_stable_tag_v_prefixed() {
+    fn pick_latest_stable_tag_ignores_v_prefixed() {
+        // `v`-prefixed tags are not valid SemVer and are not accepted.
         let tags = vec![
             "v0.2.0".into(),
             "v0.2.10".into(),
             "v0.3.0-preview-2026-02-20".into(),
             "latest".into(),
         ];
-        assert_eq!(pick_latest_stable_tag(&tags), Some("v0.2.10".to_string()));
+        assert_eq!(pick_latest_stable_tag(&tags), None);
     }
 
     #[test]
     fn pick_latest_stable_tag_mixed_v_and_bare() {
+        // Only the bare SemVer tag is considered; `v`-prefixed tags are ignored.
         let tags = vec!["v1.0.0".into(), "2.0.0".into(), "v0.9.0".into()];
         assert_eq!(pick_latest_stable_tag(&tags), Some("2.0.0".to_string()));
     }
@@ -675,7 +663,8 @@ mod tests {
     }
 
     #[test]
-    fn filter_tag_suggestions_v_prefixed_tags() {
+    fn filter_tag_suggestions_excludes_v_prefixed_tags() {
+        // `v`-prefixed tags are not valid SemVer and are excluded.
         let tags = vec![
             "v0.2.0".into(),
             "v0.2.10".into(),
@@ -683,7 +672,7 @@ mod tests {
             "latest".into(),
         ];
         let suggestions = filter_tag_suggestions(&tags, None);
-        assert_eq!(suggestions, vec!["v0.2.0", "v0.2.10"]);
+        assert!(suggestions.is_empty());
     }
 
     #[test]
@@ -716,13 +705,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_tag_as_semver_plain_and_v_prefixed() {
+    fn parse_tag_as_semver_plain_and_rejects_v_prefix() {
         let plain = parse_tag_as_semver("1.2.3").expect("plain should parse");
         assert_eq!((plain.major, plain.minor, plain.patch), (1, 2, 3));
         assert!(plain.build.is_empty());
 
-        let prefixed = parse_tag_as_semver("v1.2.3").expect("v-prefixed should parse");
-        assert_eq!((prefixed.major, prefixed.minor, prefixed.patch), (1, 2, 3));
+        // `v`-prefixed tags are not valid SemVer and are rejected.
+        assert!(parse_tag_as_semver("v1.2.3").is_none());
     }
 
     #[test]

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -1222,9 +1222,8 @@ impl Manager {
             .as_ref()
             .and_then(|a| a.get("org.opencontainers.image.description").cloned());
 
-        // Filter to tags that parse as semver (accepting an optional leading
-        // `v` prefix, e.g. `1.2.3` or `v1.2.3`). Tags like `latest`,
-        // `nightly`, or `sha256-...` are excluded here: they cannot be
+        // Filter to tags that parse as semver (e.g. `1.2.3`). Tags like
+        // `latest`, `nightly`, or `sha256-...` are excluded here: they cannot be
         // resolved by the version solver and cause garbled rendering in the
         // frontend. If no tags are valid, skip indexing this package entirely
         // so it does not pollute search results.

--- a/crates/component-package-manager/src/storage/store.rs
+++ b/crates/component-package-manager/src/storage/store.rs
@@ -235,9 +235,8 @@ async fn known_package_from_repo(
 }
 
 /// Fetch a repository's tags from `oci_tag`, sorted by semver descending.
-/// Only tags that parse as semver are returned (accepting an optional leading
-/// `v` prefix, e.g. `1.2.3` or `v1.2.3`); tags like `latest` or `sha256-...`
-/// are excluded.
+/// Only tags that parse as semver (e.g. `1.2.3`) are returned; tags like
+/// `latest` or `sha256-...` are excluded.
 async fn fetch_repo_tags(db: &DatabaseConnection, repo_id: i64) -> anyhow::Result<Vec<String>> {
     let rows = oci_tag::Entity::find()
         .filter(oci_tag::Column::OciRepositoryId.eq(repo_id))


### PR DESCRIPTION
## Symptom

Packages whose only tags use SemVer build metadata are silently skipped by discovery and never appear in search or list. The entire `autostamp` namespace is affected: every tag it publishes uses build metadata, for example:

- `ghcr.io/autostamp/adobe` -> `0.1.0_3.7.1-pre.0`, `0.2.0_adobe-3.7.1-pre.0`
- `ghcr.io/autostamp/stripe` -> `0.1.0_2022-11-15`, `0.2.0_stripe-2022-11-15`

When all of a package's tags are underscore-form, indexing yields `NoSemverTags`, the indexer demotes it to a debug log, and the package is never stored.

## Root cause

OCI tags cannot contain `+`, so #424 added `publish::oci_tag(version) = version.replace('+', "_")` to map a SemVer such as `0.1.0+2022-11-15` onto the OCI-safe tag `0.1.0_2022-11-15` (Helm's convention). That forward mapping was applied on the publish and install/resolve paths, but the inverse (`_` -> `+`) was never added on the discovery/read path.

During indexing, `parse_tag_as_semver` feeds registry tags straight to `semver::Version::parse`. `_` is illegal in SemVer, so underscore-form tags fail to parse and get filtered out.

## Fix

Reverse the mapping centrally in `parse_tag_as_semver` (the single read-path helper reused by discovery filtering, `pick_latest_stable_tag`, `filter_tag_suggestions`, and tag sorting):

- After the normal parse fails, decode the first `_` back to `+` and retry. SemVer has at most one `+` and build metadata cannot contain `_`, so `replacen('_', "+", 1)` is the exact inverse of `oci_tag`.

Also, per review, dropped the pre-existing `v`-prefix acceptance from `parse_tag_as_semver`: tags are now parsed strictly as SemVer (`v1.2.3` -> `None`), and the call-site docs in `manager/mod.rs` and `storage/store.rs` were updated to match. The separate request-side normalization of a user-supplied `v0.3` in `filter_tag_suggestions` is unchanged.

No change to `publish::oci_tag` or any publish/install code; the forward mapping is correct.

## Tests

Added unit tests covering underscore build-metadata decoding (`0.1.0_2022-11-15`, `0.2.0_stripe-2022-11-15`, `0.1.0_3.7.1-pre.0`), plain SemVer parsing with `v`-prefix rejection, non-semver rejection, and `pick_latest_stable_tag` returning the raw underscore tag unchanged.

`cargo xtask test` passes (fmt, clippy, tests, sql check).

Completes #424 and unblocks indexing for the autostamp registry added in #431.