### PR TITLE
Fix package redirect 404 for build-metadata OCI tags

### DIFF
--- a/crates/component-frontend/src/lib.rs
+++ b/crates/component-frontend/src/lib.rs
@@ -772,13 +772,30 @@ fn pick_latest_semver(
 ) -> Option<String> {
     tags.iter()
         .filter_map(|tag| {
-            semver::Version::parse(tag)
-                .ok()
+            parse_tag_as_semver(tag)
                 .filter(|version| predicate(version))
                 .map(|version| (version, tag))
         })
         .max_by(|(acc_version, _), (candidate_version, _)| acc_version.cmp(candidate_version))
         .map(|(_, tag)| tag.clone())
+}
+
+/// Parse an OCI tag as a semantic version, reversing the `+`->`_` mapping that
+/// publishing applies. OCI tags cannot contain `+`, so a SemVer with build
+/// metadata such as `0.2.0+circleci-v1` is stored under the tag
+/// `0.2.0_circleci-v1`. SemVer has at most one `+` and build metadata cannot
+/// contain `_`, so decoding the first `_` back to `+` round-trips the tag and
+/// lets it parse as semver instead of being discarded (which would leave the
+/// package with no redirectable version). Mirrors
+/// `component_package_manager::manager::parse_tag_as_semver`.
+fn parse_tag_as_semver(tag: &str) -> Option<semver::Version> {
+    if let Ok(version) = semver::Version::parse(tag) {
+        return Some(version);
+    }
+    if tag.contains('_') {
+        return semver::Version::parse(&tag.replacen('_', "+", 1)).ok();
+    }
+    None
 }
 
 #[cfg(test)]
@@ -1028,6 +1045,20 @@ mod tests {
     fn pick_redirect_version_returns_none_for_unusable_tags() {
         let tags = vec!["sha256-deadbeef".to_string()];
         assert_eq!(pick_redirect_version(&tags), None);
+    }
+
+    // r[verify frontend.pages.package-redirect]
+    #[test]
+    fn pick_redirect_version_decodes_build_metadata_tags() {
+        // OCI tags cannot contain `+`, so a SemVer with build metadata like
+        // `0.2.0+circleci-v1` is published as `0.2.0_circleci-v1`. The redirect
+        // MUST decode the first `_` back to `+`, pick the highest version, and
+        // preserve the original tag string so the detail page resolves.
+        let tags = vec!["0.2.0_circleci-v1".to_string(), "0.1.0_v1".to_string()];
+        assert_eq!(
+            pick_redirect_version(&tags),
+            Some("0.2.0_circleci-v1".to_string())
+        );
     }
 
     /// Trailing-slash URLs must be handled: the router must register


### PR DESCRIPTION
## Why

The `/{namespace}/{name}` page returned a 404 for packages whose tags encode SemVer build metadata. Concretely, `http://localhost:8080/autostamp/circleci` did not render, even though the package is indexed and its versioned detail pages work fine.

## Root cause

`/{namespace}/{name}` is a redirect route: it looks up the package and forwards to its latest version. OCI tags cannot contain `+`, so publishing maps the `+` of a build-metadata SemVer (`0.2.0+circleci-v1`) to `_`, producing tags like `0.2.0_circleci-v1` and `0.1.0_v1`. The frontend's `pick_latest_semver` parsed tags with `semver::Version::parse` directly, which rejects `_`. No redirectable version was found, so the redirect 404'd. Packages with plain semver tags were unaffected, which is why only compound-tag packages like `autostamp:circleci` broke.

The package-manager crate already solved this with `parse_tag_as_semver` (decoding the first `_` back to `+`); the frontend had duplicated the semver logic without that step.

## Change

- `pick_latest_semver` now decodes tags via a small `parse_tag_as_semver` helper before comparing, mirroring `component_package_manager::manager::parse_tag_as_semver`.
- The original tag string is preserved as the redirect target, so `/autostamp/circleci` now forwards to `/autostamp/circleci/0.2.0_circleci-v1`, which already rendered correctly.
- Added a regression test (`pick_redirect_version_decodes_build_metadata_tags`).

Scoped to the version picker only; detail-page rendering was already correct. `cargo xtask test` passes (fmt, clippy, test, sql, readme).