### PR TITLE
Automatically deploy to Azure on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,133 @@ jobs:
           cache-from: type=gha,scope=frontend
           cache-to: type=gha,mode=max,scope=frontend
 
+  deploy:
+    name: Deploy to Azure
+    runs-on: ubuntu-latest
+    needs: [resolve-version, publish-images]
+    permissions:
+      contents: read # checkout
+      id-token: write # OIDC token for azure/login
+      deployments: write # create + update GitHub deployments
+    env:
+      IMAGE_BASE: ghcr.io/${{ github.repository }}
+      VERSION: ${{ needs.resolve-version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      # Record the rollout through the GitHub Deployments API so it shows up in
+      # the repo's Environments tab with a live status. No job-level
+      # `environment:` is used on purpose: that would auto-create a second,
+      # duplicate deployment alongside the ones created here.
+      - name: Create GitHub deployment
+        id: deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deployment = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: 'production',
+              description: `Release ${process.env.VERSION}`,
+              auto_merge: false,
+              required_contexts: [],
+              production_environment: true,
+            });
+            if (!('id' in deployment.data)) {
+              core.setFailed(`Failed to create deployment: ${deployment.data.message}`);
+              return;
+            }
+            core.setOutput('deployment_id', deployment.data.id);
+
+      - name: Mark deployment in progress
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'in_progress',
+              description: 'Deploying to Azure Container Apps',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Log in to Azure (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # Full, idempotent Bicep redeploy: infra/main.bicep stays the single source
+      # of truth. Parameters are supplied through infra/main.bicepparam, which
+      # reads them from the environment via readEnvironmentVariable(...) — the
+      # same wiring `azd provision` uses — so secrets never pass through the
+      # command line (avoiding the az CLI "@file" / quoting pitfalls). Images are
+      # pinned to the exact :$VERSION tag just published, not :latest.
+      - name: Deploy to Azure Container Apps
+        id: azure-deploy
+        env:
+          AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
+          AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+          CUSTOM_DOMAIN_NAME: ${{ vars.CUSTOM_DOMAIN_NAME }}
+          POSTGRES_ADMIN_PASSWORD: ${{ secrets.POSTGRES_ADMIN_PASSWORD }}
+          BACKEND_IMAGE: ${{ env.IMAGE_BASE }}/backend:${{ env.VERSION }}
+          FRONTEND_IMAGE: ${{ env.IMAGE_BASE }}/frontend:${{ env.VERSION }}
+          REGISTRY_SERVER: ghcr.io
+          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_PASSWORD: ${{ secrets.GHCR_PULL_TOKEN }}
+        run: |
+          set -euo pipefail
+          frontend_url=$(az deployment sub create \
+            --name "release-${VERSION}" \
+            --location "${AZURE_LOCATION}" \
+            --parameters infra/main.bicepparam \
+            --query "properties.outputs.SERVICE_FRONTEND_URL.value" \
+            --output tsv \
+            --only-show-errors)
+          echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
+          echo "Deployed release ${VERSION}. Frontend URL: ${frontend_url}"
+
+      - name: Mark deployment successful
+        if: success()
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+          ENVIRONMENT_URL: ${{ steps.azure-deploy.outputs.frontend_url }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'success',
+              description: 'Deployed to Azure Container Apps',
+              environment_url: process.env.ENVIRONMENT_URL,
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
+      - name: Mark deployment failed
+        if: failure() && steps.deployment.outputs.deployment_id != ''
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.deployment_id }}
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: 'failure',
+              description: 'Azure deployment failed',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,34 +279,67 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      # Full, idempotent Bicep redeploy: infra/main.bicep stays the single source
-      # of truth. Parameters are supplied through infra/main.bicepparam, which
-      # reads them from the environment via readEnvironmentVariable(...) — the
-      # same wiring `azd provision` uses — so secrets never pass through the
-      # command line (avoiding the az CLI "@file" / quoting pitfalls). Images are
-      # pinned to the exact :$VERSION tag just published, not :latest.
+      - name: Install the Azure Developer CLI (azd)
+        uses: Azure/setup-azd@v2
+
+      # Deploy with `azd up`, the same entry point as a manual deploy, so CI and
+      # local runs share one path through azure.yaml + infra/main.bicep. azd
+      # reuses the az CLI's OIDC session (auth.useAzCliAuth) — the preprovision
+      # hook shells out to `az`, so `az` must stay authenticated too. azure.yaml
+      # declares no `services:`, so `azd up`'s deploy phase is a no-op: it only
+      # provisions the infra, pointing the Container Apps at the images that
+      # `publish-images` just pushed (pinned to :$VERSION, never :latest).
+      #
+      # Registry credentials are configured only when GHCR_PULL_TOKEN is set. The
+      # Bicep modules treat any non-empty registryServer as "use a private
+      # registry" (useRegistry = !empty(registryServer)), so leaving these unset
+      # lets public images deploy without credentials.
       - name: Deploy to Azure Container Apps
         id: azure-deploy
         env:
           AZURE_ENV_NAME: ${{ vars.AZURE_ENV_NAME }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           CUSTOM_DOMAIN_NAME: ${{ vars.CUSTOM_DOMAIN_NAME }}
           POSTGRES_ADMIN_PASSWORD: ${{ secrets.POSTGRES_ADMIN_PASSWORD }}
           BACKEND_IMAGE: ${{ env.IMAGE_BASE }}/backend:${{ env.VERSION }}
           FRONTEND_IMAGE: ${{ env.IMAGE_BASE }}/frontend:${{ env.VERSION }}
-          REGISTRY_SERVER: ghcr.io
-          REGISTRY_USERNAME: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ secrets.GHCR_PULL_TOKEN }}
+          GHCR_PULL_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
+          REGISTRY_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
-          frontend_url=$(az deployment sub create \
-            --name "release-${VERSION}" \
-            --location "${AZURE_LOCATION}" \
-            --parameters infra/main.bicepparam \
-            --query "properties.outputs.SERVICE_FRONTEND_URL.value" \
-            --output tsv \
-            --only-show-errors)
+
+          # Let azd (and its hooks) reuse the OIDC session from azure/login.
+          azd config set auth.useAzCliAuth true
+
+          # Create + select an ephemeral azd environment for this run, then seed
+          # the parameters infra/main.bicepparam reads via readEnvironmentVariable.
+          azd env new "${AZURE_ENV_NAME}" --no-prompt \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --location "${AZURE_LOCATION}"
+          azd env set POSTGRES_ADMIN_PASSWORD "${POSTGRES_ADMIN_PASSWORD}"
+          azd env set BACKEND_IMAGE "${BACKEND_IMAGE}"
+          azd env set FRONTEND_IMAGE "${FRONTEND_IMAGE}"
+          if [ -n "${AZURE_RESOURCE_GROUP:-}" ]; then
+            azd env set AZURE_RESOURCE_GROUP "${AZURE_RESOURCE_GROUP}"
+          fi
+          if [ -n "${CUSTOM_DOMAIN_NAME:-}" ]; then
+            azd env set CUSTOM_DOMAIN_NAME "${CUSTOM_DOMAIN_NAME}"
+          fi
+          if [ -n "${GHCR_PULL_TOKEN:-}" ]; then
+            azd env set REGISTRY_SERVER "ghcr.io"
+            azd env set REGISTRY_USERNAME "${REGISTRY_ACTOR}"
+            azd env set REGISTRY_PASSWORD "${GHCR_PULL_TOKEN}"
+          fi
+
+          azd up --no-prompt
+
+          frontend_url="$(azd env get-value SERVICE_FRONTEND_URL 2>/dev/null || true)"
+          if [ -z "${frontend_url}" ] || [ "${frontend_url}" = "null" ]; then
+            echo "error: azd up did not produce a SERVICE_FRONTEND_URL output" >&2
+            exit 1
+          fi
           echo "frontend_url=${frontend_url}" >> "$GITHUB_OUTPUT"
           echo "Deployed release ${VERSION}. Frontend URL: ${frontend_url}"
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This directory contains comprehensive guides and documentation to help you get s
 
 - **[Architecture](architecture.md)** - How all parts of the project relate to one another
 - **[Authentication](authentication.md)** - Learn about authentication methods and flows for accessing container registries
-- **[Azure Deployment](azure-deployment.md)** - Provision the registry's infrastructure on Azure with `azd`
+- **[Azure Deployment](azure-deployment.md)** - Provision and deploy the registry on Azure, manually with `azd` or automatically from CI
 - **[Configuration](configuration.md)** - Understand storage configuration and layout
 - **[Usage](usage.md)** - Basic usage instructions and command reference
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -296,13 +296,21 @@ and `frontend` images to GHCR, the `deploy` job rolls them out to the Container
 Apps and records the rollout through the [GitHub Deployments API][deployments]
 (visible under the repository's **Environments → production** tab).
 
-The `deploy` job performs a full, idempotent Bicep redeploy —
-`az deployment sub create` against [infra/main.bicep](../infra/main.bicep) with
-parameters read from [infra/main.bicepparam](../infra/main.bicepparam), the same
-`readEnvironmentVariable(...)` wiring `azd provision` uses — so the Bicep
-template stays the single source of truth and secrets never touch the command
-line. Images are pinned to the exact released `:X.Y.Z` tag (not `:latest`), and
-the frontend URL is reported back as the deployment's `environment_url`.
+The `deploy` job runs `azd up` — the same entry point as a manual deploy —
+against [azure.yaml](../azure.yaml) + [infra/main.bicep](../infra/main.bicep),
+seeding the parameters that [infra/main.bicepparam](../infra/main.bicepparam)
+reads via `readEnvironmentVariable(...)` into an ephemeral azd environment with
+`azd env set`, so the Bicep template stays the single source of truth and
+secrets never touch the command line. Because `azure.yaml` declares no
+`services:`, the deploy phase is a no-op and only the infrastructure is
+provisioned, pointed at the images that were just published and pinned to the
+exact released `:X.Y.Z` tag (not `:latest`). Provisioning is incremental, so it
+keeps the existing resource group and applies only what changed. The frontend
+URL is reported back as the deployment's `environment_url`.
+
+azd reuses the Azure CLI's OIDC session (`azd config set auth.useAzCliAuth
+true`), which the `preprovision` hook also depends on since it registers the
+required resource providers through `az`.
 
 Deploys are **not gated**: every successful `Release` run deploys to production.
 
@@ -400,12 +408,18 @@ identity is available for GitHub to authenticate as. Do this once:
 
 ### Container image visibility
 
-The `deploy` job wires GHCR pull credentials (`REGISTRY_SERVER=ghcr.io`,
-`REGISTRY_USERNAME` = the release actor, `REGISTRY_PASSWORD=GHCR_PULL_TOKEN`)
-into the Container Apps, so `GHCR_PULL_TOKEN` must belong to an account that can
-read the packages. Alternatively, make the `backend` and `frontend` packages
-**public** (GHCR package → Package settings → Change visibility); Azure then
-pulls them anonymously and `GHCR_PULL_TOKEN` can be any placeholder value.
+If `GHCR_PULL_TOKEN` is set, the `deploy` job wires GHCR pull credentials
+(`REGISTRY_SERVER=ghcr.io`, `REGISTRY_USERNAME` = the release actor,
+`REGISTRY_PASSWORD=GHCR_PULL_TOKEN`) into the Container Apps, so the token must
+belong to an account that can read the packages.
+
+If the `backend` and `frontend` packages are **public** (GHCR package → Package
+settings → Change visibility), leave `GHCR_PULL_TOKEN` **unset**: the job then
+configures no registry credentials and Azure pulls the images anonymously. Do
+not set it to a placeholder value — the Bicep modules treat any non-empty
+`registryServer` as a private registry (`useRegistry = !empty(registryServer)`),
+so a bogus token would configure a registry with an invalid password and break
+image pulls.
 
 ### Running and observing a deploy
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -6,6 +6,11 @@ using the Azure Developer CLI (`azd`). The deployment uses
 Analytics workspace, Container Apps environment, two Container Apps
 (frontend + backend), and an Azure Database for PostgreSQL Flexible Server.
 
+> **Two ways to deploy.** The numbered steps below are the manual `azd`
+> walkthrough. To deploy automatically from CI instead — including GitHub
+> deployment status tracking — see
+> [Automated deployment via GitHub Actions](#automated-deployment-via-github-actions).
+
 ## Prerequisites
 
 Install the following tools:
@@ -246,6 +251,135 @@ azd down --purge --force
 
 `--purge` also removes soft-deleted resources (Key Vault, Log Analytics)
 so the same `AZURE_ENV_NAME` can be reused immediately.
+
+## Automated deployment via GitHub Actions
+
+The [`Release` workflow](../.github/workflows/release.yml) deploys to Azure
+automatically. After its `publish-images` job builds and pushes the `backend`
+and `frontend` images to GHCR, the `deploy` job rolls them out to the Container
+Apps and records the rollout through the [GitHub Deployments API][deployments]
+(visible under the repository's **Environments → production** tab).
+
+The `deploy` job performs a full, idempotent Bicep redeploy —
+`az deployment sub create` against [infra/main.bicep](../infra/main.bicep) with
+parameters read from [infra/main.bicepparam](../infra/main.bicepparam), the same
+`readEnvironmentVariable(...)` wiring `azd provision` uses — so the Bicep
+template stays the single source of truth and secrets never touch the command
+line. Images are pinned to the exact released `:X.Y.Z` tag (not `:latest`), and
+the frontend URL is reported back as the deployment's `environment_url`.
+
+Deploys are **not gated**: every successful `Release` run deploys to production.
+
+### One-time setup
+
+The workflow assumes the infrastructure already exists and that an Entra
+identity is available for GitHub to authenticate as. Do this once:
+
+1. **Provision the infrastructure.** Follow sections 1–6 above so the resource
+   group, Container Apps environment, Postgres server, and the two Container
+   Apps exist. The `deploy` job self-heals drift on later runs, but the first
+   provision uses the interactive `azd`/`az` flow.
+
+2. **Create an OIDC identity for GitHub Actions.** Register an Entra
+   application and add a **federated credential** so GitHub can sign in without
+   a stored secret. Because `release.yml` is triggered by `workflow_dispatch`,
+   the OIDC token's subject is the branch ref, so scope the credential to the
+   branch you release from:
+
+   ```sh
+   # Create the app registration and a service principal for it.
+   appId=$(az ad app create --display-name "component-registry-gha-deploy" \
+     --query appId -o tsv)
+   az ad sp create --id "$appId"
+
+   # Federated credential: GitHub OIDC, subject = the release branch.
+   az ad app federated-credential create --id "$appId" --parameters '{
+     "name": "github-actions-release-main",
+     "issuer": "https://token.actions.githubusercontent.com",
+     "subject": "repo:yoshuawuyts/component-registry:ref:refs/heads/main",
+     "audiences": ["api://AzureADTokenExchange"]
+   }'
+   ```
+
+   > If you later add an approval gate by giving the `deploy` job a
+   > `environment: production`, switch the subject to
+   > `repo:yoshuawuyts/component-registry:environment:production`.
+
+3. **Grant the identity access.** `infra/main.bicep` is subscription-scoped and
+   creates the resource group, so assign **Contributor** at subscription scope:
+
+   ```sh
+   subId=$(az account show --query id -o tsv)
+   az role assignment create --assignee "$appId" \
+     --role Contributor --scope "/subscriptions/$subId"
+   ```
+
+4. **Configure repository secrets and variables** (Settings → Secrets and
+   variables → Actions).
+
+   Secrets:
+
+   | Secret | Description |
+   | ------ | ----------- |
+   | `AZURE_CLIENT_ID`         | `appId` of the app registration above. |
+   | `AZURE_TENANT_ID`         | Directory (tenant) ID. |
+   | `AZURE_SUBSCRIPTION_ID`   | Target subscription ID. |
+   | `POSTGRES_ADMIN_PASSWORD` | Must match the provisioned Postgres server's password (Bicep re-applies it on every deploy). |
+   | `GHCR_PULL_TOKEN`         | PAT with `read:packages` so Azure Container Apps can pull the images. Only needed if the GHCR packages are **private** — see below. |
+
+   Variables:
+
+   | Variable               | Description |
+   | ---------------------- | ----------- |
+   | `AZURE_ENV_NAME`       | Environment name used for resource naming (e.g. `wasm-registry`). Must match what you provisioned. |
+   | `AZURE_LOCATION`       | Azure region (e.g. `centralus`). |
+   | `AZURE_RESOURCE_GROUP` | Optional. Overrides the default `rg-<AZURE_ENV_NAME>`. |
+   | `CUSTOM_DOMAIN_NAME`   | Optional. Apex domain for the frontend (see section 7). |
+
+   The [`scripts/setup-azure-deploy.sh`](../scripts/setup-azure-deploy.sh)
+   helper sets all of these with `gh`, prompting for anything not already in
+   the environment (secret values are read without echo). It **skips any
+   secret or variable that is already set on the repo**, so it's safe to re-run
+   after adding a single new value; pass `-f` to overwrite existing ones:
+
+   ```sh
+   ./scripts/setup-azure-deploy.sh -a   # -a fills tenant + subscription from `az`
+   ./scripts/setup-azure-deploy.sh -f   # overwrite values already set on the repo
+   ```
+
+   Or set them by hand:
+
+   ```sh
+   gh secret set AZURE_CLIENT_ID          # prompts for the value
+   gh secret set AZURE_TENANT_ID
+   gh secret set AZURE_SUBSCRIPTION_ID
+   gh secret set POSTGRES_ADMIN_PASSWORD
+   gh secret set GHCR_PULL_TOKEN          # only if the images are private
+   gh variable set AZURE_ENV_NAME --body wasm-registry
+   gh variable set AZURE_LOCATION --body centralus
+   # optional:
+   gh variable set AZURE_RESOURCE_GROUP --body rg-wasm-registry
+   gh variable set CUSTOM_DOMAIN_NAME --body wasm.directory
+   ```
+
+### Container image visibility
+
+The `deploy` job wires GHCR pull credentials (`REGISTRY_SERVER=ghcr.io`,
+`REGISTRY_USERNAME` = the release actor, `REGISTRY_PASSWORD=GHCR_PULL_TOKEN`)
+into the Container Apps, so `GHCR_PULL_TOKEN` must belong to an account that can
+read the packages. Alternatively, make the `backend` and `frontend` packages
+**public** (GHCR package → Package settings → Change visibility); Azure then
+pulls them anonymously and `GHCR_PULL_TOKEN` can be any placeholder value.
+
+### Running and observing a deploy
+
+Trigger a release as usual (`just release`, or the **Release** workflow's *Run
+workflow* button). The `deploy` job runs after the images are published; watch
+its progress under **Actions**, and the deployment lifecycle (`in_progress` →
+`success`/`failure`, with the live frontend URL) under
+**Environments → production**.
+
+[deployments]: https://docs.github.com/en/rest/deployments/deployments
 
 ## Troubleshooting
 

--- a/scripts/setup-azure-deploy.sh
+++ b/scripts/setup-azure-deploy.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# Configure the GitHub Actions secrets and variables that the `deploy` job in
+# .github/workflows/release.yml needs to deploy to Azure.
+#
+# See docs/azure-deployment.md ("Automated deployment via GitHub Actions") for
+# how these values are produced (OIDC app registration, federated credential,
+# role assignment) and what each one means.
+#
+# Values are read from environment variables when set, otherwise the script
+# prompts for them (secret values are read without echo). Optional values are
+# skipped when left blank. Secrets/variables already set on the repository are
+# left untouched unless you pass -f (force overwrite).
+#
+#   Secrets:    AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID
+#               POSTGRES_ADMIN_PASSWORD  GHCR_PULL_TOKEN (optional)
+#   Variables:  AZURE_ENV_NAME AZURE_LOCATION
+#               AZURE_RESOURCE_GROUP (optional)  CUSTOM_DOMAIN_NAME (optional)
+#
+# Prerequisites:
+#   - GitHub CLI (`gh`) authenticated:  gh auth login
+#   - Azure CLI (`az`) logged in — only needed with -a
+#
+# Usage:
+#   ./scripts/setup-azure-deploy.sh                 # prompt for everything
+#   AZURE_ENV_NAME=wasm-registry AZURE_LOCATION=centralus \
+#     ./scripts/setup-azure-deploy.sh               # take values from the env
+#   ./scripts/setup-azure-deploy.sh -a              # fill tenant+subscription from `az`
+#   ./scripts/setup-azure-deploy.sh -f              # overwrite values already set on the repo
+#   ./scripts/setup-azure-deploy.sh -r owner/repo   # target a specific repo
+#   REPO=owner/repo ./scripts/setup-azure-deploy.sh
+set -euo pipefail
+
+REPO="${REPO:-}"
+FROM_AZ=false
+FORCE=false
+
+usage() {
+  awk 'NR==1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
+}
+
+while getopts "r:afh" opt; do
+  case $opt in
+    r) REPO="$OPTARG" ;;
+    a) FROM_AZ=true ;;
+    f) FORCE=true ;;
+    h) usage; exit 0 ;;
+    *) echo "Usage: $0 [-r owner/repo] [-a] [-f] [-h]" >&2; exit 1 ;;
+  esac
+done
+
+command -v gh >/dev/null || { echo "error: gh (GitHub CLI) is not installed" >&2; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "error: gh is not authenticated; run 'gh auth login'" >&2; exit 1; }
+
+# Resolve the target repository: -r flag / REPO env, else the current checkout.
+if [ -z "$REPO" ]; then
+  REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+[ -n "$REPO" ] || { echo "error: could not determine repository; pass -r owner/repo or set REPO" >&2; exit 1; }
+echo "==> Target repository: $REPO"
+
+# Optionally fill tenant + subscription from the current az session.
+if [ "$FROM_AZ" = true ]; then
+  command -v az >/dev/null || { echo "error: -a requires the Azure CLI (az)" >&2; exit 1; }
+  : "${AZURE_TENANT_ID:=$(az account show --query tenantId -o tsv)}"
+  : "${AZURE_SUBSCRIPTION_ID:=$(az account show --query id -o tsv)}"
+  echo "==> From az: tenant $AZURE_TENANT_ID, subscription $AZURE_SUBSCRIPTION_ID"
+fi
+
+# Names already configured on the repo — used to skip values that are already
+# set, unless -f is given. Empty (everything treated as unset) if a list fails.
+EXISTING_SECRETS="$(gh secret list --repo "$REPO" --json name --jq '.[].name' 2>/dev/null || true)"
+EXISTING_VARIABLES="$(gh variable list --repo "$REPO" --json name --jq '.[].name' 2>/dev/null || true)"
+
+# --- helpers ---------------------------------------------------------------
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# True when the newline-separated list in $1 contains the exact line $2.
+list_has() { printf '%s\n' "$1" | grep -qxF "$2"; }
+
+# Resolve a value from environment variable $1, else prompt when a terminal is
+# available. The prompt is written to stderr so stdout carries only the value.
+resolve_value() { # name silent prompt
+  local name="$1" silent="$2" prompt="$3"
+  local val="${!name:-}"
+  if [ -z "$val" ] && [ -t 0 ]; then
+    if [ "$silent" = true ]; then
+      read -rs -p "$prompt: " val || true; echo >&2
+    else
+      read -r -p "$prompt: " val || true
+    fi
+  fi
+  printf '%s' "$val"
+}
+
+process_secret() { # name prompt required
+  local name="$1" prompt="$2" required="$3" val
+  if [ "$FORCE" != true ] && list_has "$EXISTING_SECRETS" "$name"; then
+    echo "    secret   $name — already set (use -f to overwrite)"
+    return
+  fi
+  val="$(resolve_value "$name" true "$prompt")"
+  if [ -z "$val" ]; then
+    if [ "$required" = true ]; then die "$name is required (set it in the environment or run in a terminal)"; fi
+    echo "    secret   $name — skipped (no value)"
+    return
+  fi
+  # Pipe via stdin so the token never appears in the process table.
+  printf '%s' "$val" | gh secret set "$name" --repo "$REPO"
+  echo "    secret   $name — set"
+}
+
+process_variable() { # name prompt required
+  local name="$1" prompt="$2" required="$3" val
+  if [ "$FORCE" != true ] && list_has "$EXISTING_VARIABLES" "$name"; then
+    echo "    variable $name — already set (use -f to overwrite)"
+    return
+  fi
+  val="$(resolve_value "$name" false "$prompt")"
+  if [ -z "$val" ]; then
+    if [ "$required" = true ]; then die "$name is required (set it in the environment or run in a terminal)"; fi
+    echo "    variable $name — skipped (no value)"
+    return
+  fi
+  gh variable set "$name" --repo "$REPO" --body "$val" >/dev/null
+  echo "    variable $name — set"
+}
+
+# --- configure -------------------------------------------------------------
+
+echo "==> Configuring secrets on $REPO"
+process_secret AZURE_CLIENT_ID         "AZURE_CLIENT_ID (app registration appId)"                        true
+process_secret AZURE_TENANT_ID         "AZURE_TENANT_ID"                                                 true
+process_secret AZURE_SUBSCRIPTION_ID   "AZURE_SUBSCRIPTION_ID"                                           true
+process_secret POSTGRES_ADMIN_PASSWORD "POSTGRES_ADMIN_PASSWORD"                                         true
+process_secret GHCR_PULL_TOKEN         "GHCR_PULL_TOKEN (read:packages PAT; blank if images are public)" false
+
+echo "==> Configuring variables on $REPO"
+process_variable AZURE_ENV_NAME       "AZURE_ENV_NAME (e.g. wasm-registry)" true
+process_variable AZURE_LOCATION       "AZURE_LOCATION (e.g. centralus)"     true
+process_variable AZURE_RESOURCE_GROUP "AZURE_RESOURCE_GROUP (optional)"     false
+process_variable CUSTOM_DOMAIN_NAME   "CUSTOM_DOMAIN_NAME (optional)"       false
+
+echo "==> Done. Trigger a release (\`just release\`) and watch Environments → production."


### PR DESCRIPTION
## Why

Releases already build and push the `backend`/`frontend` images to GHCR, but getting them onto Azure is still a manual `azd provision` step. This wires the deploy into the release pipeline so a release rolls out to Azure on its own, with rollout status visible directly in GitHub.

## What changed

- **New `deploy` job in `release.yml`** that runs after `publish-images`. It authenticates to Azure via OIDC (no long-lived cloud credentials stored in the repo), does a full idempotent Bicep redeploy pinned to the exact release image tags, and tracks rollout through the GitHub Deployments API (`create` -> `in_progress` -> `success`/`failure`). Each release then shows up under the repo's Environments/Deployments.
- **`scripts/setup-azure-deploy.sh`** to configure the required repo secrets and variables via `gh`. It skips any value already set on the repo (pass `-f` to overwrite), reads secret values without echo, and can pull tenant + subscription from `az` with `-a`.
- **Docs**: an "Automated deployment via GitHub Actions" section in `docs/azure-deployment.md` covering the one-time OIDC app registration, federated credential, and role assignment, plus the full list of secrets/variables and the equivalent raw `gh` commands.

## Notes for reviewers

- Deploys on **every release with no approval gate**, as requested. The Bicep redeploy is idempotent (deterministic resource names), so re-running is safe.
- Uses explicit `actions/github-script` Deployments API calls rather than a job-level `environment:`, to avoid auto-creating a duplicate deployment record.
- **Requires one-time setup before the first deploy works**: an Entra app registration with a federated credential for `repo:yoshuawuyts/component-registry:ref:refs/heads/main` and Contributor at subscription scope. The helper script handles the GitHub side; the docs cover the Azure side.
- This branch has `origin/main` merged in and `cargo xtask test` passes, so the PR diff is limited to the workflow, script, and docs.