### PR TITLE
docs: remove cargo install instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ curl --proto '=https' --tlsv1.2 -LsSf https://github.com/yoshuawuyts/component-c
 irm https://github.com/yoshuawuyts/component-cli/releases/latest/download/install.ps1 | iex
 ```
 
-### Cargo (Rust)
-
-```sh
-cargo install component
-```
-
 ## Local development
 
 To stand up the full stack (frontend, backend, and Postgres) locally using Docker:


### PR DESCRIPTION
Drops the "Cargo (Rust)" subsection from the README's Installation section. The `cargo install component` path isn't the recommended way to install the CLI, so pointing users at it alongside the release installers was misleading.

Installation now lists just the Bash (Linux/macOS) and PowerShell (Windows) release installers.