### PR TITLE
Gray out in-progress footer and navbar links

### DIFF
--- a/crates/component-frontend/src/components/ds/cta_strip.rs
+++ b/crates/component-frontend/src/components/ds/cta_strip.rs
@@ -4,6 +4,7 @@
 //! left, primary + secondary CTA buttons on the right.
 
 use html::content::Section;
+use html::text_content::builders::DivisionBuilder;
 
 /// Configuration for [`render`].
 pub(crate) struct CtaStrip<'a> {
@@ -12,9 +13,13 @@ pub(crate) struct CtaStrip<'a> {
     /// HTML body — callers may include `<code>` spans inline.
     pub body_html: &'a str,
     pub primary_label: &'a str,
-    pub primary_href: &'a str,
+    /// Primary CTA destination. `None` renders a disabled, muted button that
+    /// stays visible but is not navigable.
+    pub primary_href: Option<&'a str>,
     pub secondary_label: &'a str,
-    pub secondary_href: &'a str,
+    /// Secondary CTA destination. `None` renders a disabled, muted button that
+    /// stays visible but is not navigable.
+    pub secondary_href: Option<&'a str>,
 }
 
 const ARROW_RIGHT: &str = r#"<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>"#;
@@ -26,9 +31,9 @@ pub(crate) fn render(cfg: &CtaStrip<'_>) -> String {
     let title = cfg.title.to_owned();
     let body = cfg.body_html.to_owned();
     let plabel = cfg.primary_label.to_owned();
-    let phref = cfg.primary_href.to_owned();
+    let phref = cfg.primary_href.map(ToOwned::to_owned);
     let slabel = cfg.secondary_label.to_owned();
-    let shref = cfg.secondary_href.to_owned();
+    let shref = cfg.secondary_href.map(ToOwned::to_owned);
 
     Section::builder()
         .class("mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8 mt-12 md:mt-16")
@@ -48,22 +53,58 @@ pub(crate) fn render(cfg: &CtaStrip<'_>) -> String {
                     })
                 })
                 .division(|right| {
-                    right.class("flex flex-wrap items-center gap-3 md:justify-end")
-                        .anchor(|a| {
-                            a.href(phref)
-                                .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg bg-ink-900 text-canvas text-[13px] hover:opacity-90 no-underline")
-                                .text(plabel)
-                                .text(format!(" {ARROW_RIGHT}"))
-                        })
-                        .anchor(|a| {
-                            a.href(shref)
-                                .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg border-[1.5px] border-ink-900 bg-canvas text-ink-900 text-[13px] hover:bg-surfaceMuted no-underline")
-                                .text(slabel)
-                        })
+                    let right = right.class("flex flex-wrap items-center gap-3 md:justify-end");
+                    push_primary(right, plabel, phref);
+                    push_secondary(right, slabel, shref);
+                    right
                 })
         })
         .build()
         .to_string()
+}
+
+/// Append the primary (filled) CTA. A `None` href renders a disabled, muted,
+/// non-navigable button so it stays visible while signalling work in progress.
+fn push_primary(parent: &mut DivisionBuilder, label: String, href: Option<String>) {
+    match href {
+        Some(href) => {
+            parent.anchor(|a| {
+                a.href(href)
+                    .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg bg-ink-900 text-canvas text-[13px] hover:opacity-90 no-underline")
+                    .text(label)
+                    .text(format!(" {ARROW_RIGHT}"))
+            });
+        }
+        None => {
+            parent.span(|s| {
+                s.aria_disabled(true)
+                    .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg bg-surfaceMuted text-ink-400 text-[13px] cursor-not-allowed")
+                    .text(label)
+                    .text(format!(" {ARROW_RIGHT}"))
+            });
+        }
+    }
+}
+
+/// Append the secondary (outline) CTA. A `None` href renders a disabled, muted,
+/// non-navigable button so it stays visible while signalling work in progress.
+fn push_secondary(parent: &mut DivisionBuilder, label: String, href: Option<String>) {
+    match href {
+        Some(href) => {
+            parent.anchor(|a| {
+                a.href(href)
+                    .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg border-[1.5px] border-ink-900 bg-canvas text-ink-900 text-[13px] hover:bg-surfaceMuted no-underline")
+                    .text(label)
+            });
+        }
+        None => {
+            parent.span(|s| {
+                s.aria_disabled(true)
+                    .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg border-[1.5px] border-lineSoft bg-canvas text-ink-400 text-[13px] cursor-not-allowed")
+                    .text(label)
+            });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -77,9 +118,9 @@ mod tests {
             title: "Build with components today.",
             body_html: r#"Install the CLI with <code class="mono text-[12px]">brew install component</code> and start composing."#,
             primary_label: "Get started",
-            primary_href: "/docs",
+            primary_href: Some("/docs"),
             secondary_label: "View on GitHub",
-            secondary_href: "https://github.com/yoshuawuyts/component-cli",
+            secondary_href: Some("https://github.com/yoshuawuyts/component-cli"),
         });
         insta::assert_snapshot!(crate::components::ds::pretty_html(&html));
     }

--- a/crates/component-frontend/src/components/ds/cta_strip.rs
+++ b/crates/component-frontend/src/components/ds/cta_strip.rs
@@ -77,8 +77,7 @@ fn push_primary(parent: &mut DivisionBuilder, label: String, href: Option<String
         }
         None => {
             parent.span(|s| {
-                s.aria_disabled(true)
-                    .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg bg-surfaceMuted text-ink-400 text-[13px] cursor-not-allowed")
+                s.class("h-9 px-4 inline-flex items-center gap-2 rounded-lg bg-surfaceMuted text-ink-400 text-[13px] cursor-not-allowed")
                     .text(label)
                     .text(format!(" {ARROW_RIGHT}"))
             });
@@ -99,8 +98,7 @@ fn push_secondary(parent: &mut DivisionBuilder, label: String, href: Option<Stri
         }
         None => {
             parent.span(|s| {
-                s.aria_disabled(true)
-                    .class("h-9 px-4 inline-flex items-center gap-2 rounded-lg border-[1.5px] border-lineSoft bg-canvas text-ink-400 text-[13px] cursor-not-allowed")
+                s.class("h-9 px-4 inline-flex items-center gap-2 rounded-lg border-[1.5px] border-lineSoft bg-canvas text-ink-400 text-[13px] cursor-not-allowed")
                     .text(label)
             });
         }
@@ -121,6 +119,22 @@ mod tests {
             primary_href: Some("/docs"),
             secondary_label: "View on GitHub",
             secondary_href: Some("https://github.com/yoshuawuyts/component-cli"),
+        });
+        insta::assert_snapshot!(crate::components::ds::pretty_html(&html));
+    }
+
+    #[test]
+    fn snapshot_disabled() {
+        // Both CTAs render as muted, non-navigable spans when their href is
+        // `None`, matching the design system's disabled-control convention.
+        let html = render(&CtaStrip {
+            kicker: "Ship",
+            title: "Build with components today.",
+            body_html: r#"Install the CLI with <code class="mono text-[12px]">brew install component</code> and start composing."#,
+            primary_label: "Get started",
+            primary_href: None,
+            secondary_label: "View on GitHub",
+            secondary_href: None,
         });
         insta::assert_snapshot!(crate::components::ds::pretty_html(&html));
     }

--- a/crates/component-frontend/src/components/ds/footer.rs
+++ b/crates/component-frontend/src/components/ds/footer.rs
@@ -4,8 +4,11 @@ use html::content::Footer as FooterEl;
 
 /// A single link in a footer column.
 pub(crate) struct FooterLink {
+    /// Visible link text.
     pub label: &'static str,
-    pub href: &'static str,
+    /// Destination URL. `None` marks an in-progress placeholder that is
+    /// rendered as a non-navigable, visibly muted label instead of a link.
+    pub href: Option<&'static str>,
 }
 
 /// A column of footer links.
@@ -71,21 +74,41 @@ fn push_column(parent: &mut html::text_content::builders::DivisionBuilder, col: 
                 .text(kicker)
         });
         d.unordered_list(|ul| {
-            let mut ul = ul.class("mt-3 space-y-2 text-ink-700");
+            let ul = ul.class("mt-3 space-y-2 text-ink-700");
             for link in col.links {
-                let label = link.label.to_owned();
-                let href = link.href.to_owned();
-                ul = ul.list_item(|li| {
-                    li.anchor(|a| {
-                        a.href(href)
-                            .class("hover:text-ink-900 no-underline")
-                            .text(label)
-                    })
-                });
+                push_link(ul, link);
             }
             ul
         })
     });
+}
+
+/// Append a single footer link. A link with `href: None` renders as a
+/// non-navigable, muted span so it stays visible while signalling that the
+/// destination is still in progress.
+fn push_link(ul: &mut html::text_content::builders::UnorderedListBuilder, link: &FooterLink) {
+    let label = link.label.to_owned();
+    match link.href {
+        Some(href) => {
+            let href = href.to_owned();
+            ul.list_item(|li| {
+                li.anchor(|a| {
+                    a.href(href)
+                        .class("hover:text-ink-900 no-underline")
+                        .text(label)
+                })
+            });
+        }
+        None => {
+            ul.list_item(|li| {
+                li.span(|s| {
+                    s.aria_disabled(true)
+                        .class("text-ink-400 cursor-not-allowed")
+                        .text(label)
+                })
+            });
+        }
+    }
 }
 
 #[cfg(test)]
@@ -97,31 +120,31 @@ mod tests {
         const BROWSE: &[FooterLink] = &[
             FooterLink {
                 label: "Packages",
-                href: "/packages",
+                href: Some("/packages"),
             },
             FooterLink {
                 label: "Categories",
-                href: "/categories",
+                href: Some("/categories"),
             },
         ];
         const COMMUNITY: &[FooterLink] = &[
             FooterLink {
                 label: "GitHub",
-                href: "https://github.com/yoshuawuyts/component-cli",
+                href: Some("https://github.com/yoshuawuyts/component-cli"),
             },
             FooterLink {
                 label: "Spec",
-                href: "/spec",
+                href: None,
             },
         ];
         const LEGAL: &[FooterLink] = &[
             FooterLink {
                 label: "Privacy",
-                href: "/privacy",
+                href: Some("/privacy"),
             },
             FooterLink {
                 label: "Terms",
-                href: "/terms",
+                href: Some("/terms"),
             },
         ];
         let html = render(&Footer {

--- a/crates/component-frontend/src/components/ds/footer.rs
+++ b/crates/component-frontend/src/components/ds/footer.rs
@@ -85,7 +85,9 @@ fn push_column(parent: &mut html::text_content::builders::DivisionBuilder, col: 
 
 /// Append a single footer link. A link with `href: None` renders as a
 /// non-navigable, muted span so it stays visible while signalling that the
-/// destination is still in progress.
+/// destination is still in progress. This mirrors the design system's
+/// disabled-control convention (see `PAGINATION_DISABLED_CLASS`): a plain
+/// muted span with no interactive semantics.
 fn push_link(ul: &mut html::text_content::builders::UnorderedListBuilder, link: &FooterLink) {
     let label = link.label.to_owned();
     match link.href {
@@ -100,13 +102,7 @@ fn push_link(ul: &mut html::text_content::builders::UnorderedListBuilder, link: 
             });
         }
         None => {
-            ul.list_item(|li| {
-                li.span(|s| {
-                    s.aria_disabled(true)
-                        .class("text-ink-400 cursor-not-allowed")
-                        .text(label)
-                })
-            });
+            ul.list_item(|li| li.span(|s| s.class("text-ink-400 cursor-not-allowed").text(label)));
         }
     }
 }

--- a/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__cta_strip__tests__snapshot_disabled.snap
+++ b/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__cta_strip__tests__snapshot_disabled.snap
@@ -1,0 +1,35 @@
+---
+source: crates/component-frontend/src/components/ds/cta_strip.rs
+expression: "crate::components::ds::pretty_html(&html)"
+---
+<section class="mx-auto mx-auto max-w-[1280px] w-full px-4 md:px-8 mt-12 md:mt-16">
+  <div class="grid md:grid-cols-[1fr_auto] gap-6 items-center border-t border-lineSoft pt-10 md:pt-12">
+    <div>
+      <div class="text-[12px] mono uppercase tracking-wider text-ink-500">
+        Ship
+      </div>
+      <h3 class="mt-2 text-[24px] font-semibold tracking-tight">
+        Build with components today.
+      </h3>
+      <p class="mt-2 max-w-xl text-[13px] text-ink-700 leading-relaxed">
+        Install the CLI with
+        <code class="mono text-[12px]">
+          brew install component
+        </code>
+        and start composing.
+      </p>
+    </div>
+    <div class="flex flex-wrap items-center gap-3 md:justify-end">
+      <span class="h-9 px-4 inline-flex items-center gap-2 rounded-lg bg-surfaceMuted text-ink-400 text-[13px] cursor-not-allowed">
+        Get started
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M5 12h14"/>
+          <path d="m12 5 7 7-7 7"/>
+        </svg>
+      </span>
+      <span class="h-9 px-4 inline-flex items-center gap-2 rounded-lg border-[1.5px] border-lineSoft bg-canvas text-ink-400 text-[13px] cursor-not-allowed">
+        View on GitHub
+      </span>
+    </div>
+  </div>
+</section>

--- a/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__footer__tests__snapshot.snap
+++ b/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__footer__tests__snapshot.snap
@@ -45,7 +45,7 @@ expression: "crate::components::ds::pretty_html(&html)"
           </a>
         </li>
         <li>
-          <span aria-disabled class="text-ink-400 cursor-not-allowed">
+          <span class="text-ink-400 cursor-not-allowed">
             Spec
           </span>
         </li>

--- a/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__footer__tests__snapshot.snap
+++ b/crates/component-frontend/src/components/ds/snapshots/component_frontend__components__ds__footer__tests__snapshot.snap
@@ -45,9 +45,9 @@ expression: "crate::components::ds::pretty_html(&html)"
           </a>
         </li>
         <li>
-          <a href="/spec" class="hover:text-ink-900 no-underline">
+          <span aria-disabled class="text-ink-400 cursor-not-allowed">
             Spec
-          </a>
+          </span>
         </li>
       </ul>
     </div>

--- a/crates/component-frontend/src/components/page_shell.rs
+++ b/crates/component-frontend/src/components/page_shell.rs
@@ -71,16 +71,10 @@ pub(crate) fn render_page_with_crumbs(
     }
 
     #[allow(clippy::items_after_statements)]
-    const LINKS: &[NavLink] = &[
-        NavLink {
-            label: "Docs",
-            href: "/docs",
-        },
-        NavLink {
-            label: "Downloads",
-            href: "/downloads",
-        },
-    ];
+    const LINKS: &[NavLink] = &[NavLink {
+        label: "Downloads",
+        href: "/downloads",
+    }];
     let nav = navbar::render_bar_grid(&crumbs, LINKS);
 
     // Sidebar navigation (interfaces/worlds tree) — already an <aside> with

--- a/crates/component-frontend/src/footer.rs
+++ b/crates/component-frontend/src/footer.rs
@@ -6,49 +6,45 @@ use crate::components::ds::footer::{Footer, FooterColumn, FooterLink};
 const BROWSE: &[FooterLink] = &[
     FooterLink {
         label: "Packages",
-        href: "/all",
+        href: Some("/all"),
     },
     FooterLink {
         label: "Authors",
-        href: "/all",
+        href: None,
     },
     FooterLink {
         label: "Registries",
-        href: "/about",
+        href: None,
     },
     FooterLink {
         label: "Changelog",
-        href: "/about",
+        href: None,
     },
 ];
 
 const DEVELOP: &[FooterLink] = &[
     FooterLink {
         label: "Documentation",
-        href: "/docs",
+        href: None,
     },
     FooterLink {
         label: "CLI reference",
-        href: "/docs",
+        href: None,
     },
     FooterLink {
         label: "Spec",
-        href: "/docs",
-    },
-    FooterLink {
-        label: "Design system",
-        href: "/design-system",
+        href: None,
     },
 ];
 
 const COMMUNITY: &[FooterLink] = &[
     FooterLink {
         label: "GitHub",
-        href: "https://github.com/yoshuawuyts/component-cli",
+        href: Some("https://github.com/yoshuawuyts/component-cli"),
     },
     FooterLink {
         label: "Status",
-        href: "/health",
+        href: Some("/status"),
     },
 ];
 
@@ -72,7 +68,7 @@ const COLUMNS: &[FooterColumn] = &[
 pub(crate) fn render() -> String {
     crate::components::ds::footer::render(&Footer {
         brand: "component",
-        lede: "A package manager and registry for WebAssembly components. Made by Yosh Wuyts and contributors. To be donated to the Bytecode Alliance.",
+        lede: "A meta-registry and package manager for WebAssembly components. Made by Yosh Wuyts and contributors. To be donated to the Bytecode Alliance.",
         status: "All systems operational",
         columns: COLUMNS,
     })

--- a/crates/component-frontend/src/layout.rs
+++ b/crates/component-frontend/src/layout.rs
@@ -28,16 +28,10 @@ pub(crate) fn document(title: &str, body_content: &str) -> String {
 #[must_use]
 pub(crate) fn document_with_nav(title: &str, body_content: &str) -> String {
     use crate::components::ds::navbar::{self, NavLink};
-    const LINKS: &[NavLink] = &[
-        NavLink {
-            label: "Docs",
-            href: "/docs",
-        },
-        NavLink {
-            label: "Downloads",
-            href: "/downloads",
-        },
-    ];
+    const LINKS: &[NavLink] = &[NavLink {
+        label: "Downloads",
+        href: "/downloads",
+    }];
     let nav = navbar::render_bar_grid(&[], LINKS);
     document_inner(title, body_content, &nav, MAIN_CLASS_CENTERED, true)
 }
@@ -65,16 +59,10 @@ pub(crate) fn document_design_system(title: &str, body_content: &str) -> String 
 #[must_use]
 pub(crate) fn document_landing(title: &str, body_content: &str) -> String {
     use crate::components::ds::navbar::{self, NavLink};
-    const LINKS: &[NavLink] = &[
-        NavLink {
-            label: "Packages",
-            href: "/all",
-        },
-        NavLink {
-            label: "Docs",
-            href: "/docs",
-        },
-    ];
+    const LINKS: &[NavLink] = &[NavLink {
+        label: "Packages",
+        href: "/all",
+    }];
     let nav = navbar::render_bar_grid(&[], LINKS);
     document_inner(title, body_content, &nav, MAIN_CLASS_FULL, true)
 }

--- a/crates/component-frontend/src/pages/design_system.rs
+++ b/crates/component-frontend/src/pages/design_system.rs
@@ -556,9 +556,9 @@ fn render_landing_components() -> String {
         title: "Publish your component.",
         body_html: "Add your namespace and run <code class=\"px-1 py-0.5 rounded-sm bg-surfaceMuted text-ink-900 mono text-[0.875em]\">component publish</code>.",
         primary_label: "Publishing guide",
-        primary_href: "#",
+        primary_href: Some("#"),
         secondary_label: "Read the spec",
-        secondary_href: "#",
+        secondary_href: Some("#"),
     });
     html.push_str(RULE_MT);
     html.push_str(&ds::section(
@@ -572,7 +572,7 @@ fn render_landing_components() -> String {
     // C13 — Footer
     let footer_demo = footer::render(&Footer {
         brand: "component",
-        lede: "A package manager and registry for WebAssembly components.",
+        lede: "A meta-registry and package manager for WebAssembly components.",
         status: "All systems operational",
         columns: &[
             FooterColumn {
@@ -580,11 +580,11 @@ fn render_landing_components() -> String {
                 links: &[
                     FooterLink {
                         label: "Packages",
-                        href: "#",
+                        href: Some("#"),
                     },
                     FooterLink {
                         label: "Authors",
-                        href: "#",
+                        href: Some("#"),
                     },
                 ],
             },
@@ -593,11 +593,11 @@ fn render_landing_components() -> String {
                 links: &[
                     FooterLink {
                         label: "Docs",
-                        href: "#",
+                        href: Some("#"),
                     },
                     FooterLink {
                         label: "Spec",
-                        href: "#",
+                        href: Some("#"),
                     },
                 ],
             },
@@ -605,7 +605,7 @@ fn render_landing_components() -> String {
                 kicker: "Community",
                 links: &[FooterLink {
                     label: "GitHub",
-                    href: "#",
+                    href: Some("#"),
                 }],
             },
         ],

--- a/crates/component-frontend/src/pages/home.rs
+++ b/crates/component-frontend/src/pages/home.rs
@@ -135,9 +135,9 @@ fn compose_body(stats: &Stats, notice_html: Option<&str>) -> String {
                     <code class=\"px-1 py-0.5 rounded-sm bg-surfaceMuted text-ink-900 mono text-[0.875em]\">component publish</code>. \
                     Every release is signed end-to-end.",
         primary_label: "Open the publishing guide",
-        primary_href: "/docs",
+        primary_href: None,
         secondary_label: "Read the spec",
-        secondary_href: "/docs",
+        secondary_href: None,
     });
 
     let notice_html = notice_html.unwrap_or("");

--- a/crates/component-frontend/src/pages/package_shell.rs
+++ b/crates/component-frontend/src/pages/package_shell.rs
@@ -106,10 +106,6 @@ fn render_page_inner(
     #[allow(clippy::items_after_statements)]
     const LINKS: &[NavLink] = &[
         NavLink {
-            label: "Docs",
-            href: "/docs",
-        },
-        NavLink {
             label: "Downloads",
             href: "/downloads",
         },


### PR DESCRIPTION
The footer and navbar advertised several destinations that don't exist yet, so clicking them led nowhere. Rather than hide these entirely, this marks them as clearly in-progress while keeping the real links working and fixing one that pointed at the wrong route.

## What changed

**Footer**
- Status now links to `/status` instead of `/health`.
- Placeholder links (Authors, Registries, Changelog, Documentation, CLI reference, Spec) are "blacked out" as non-navigable, muted labels so they stay visible but signal work in progress.
- Removed the Design system link entirely.
- Reworded the lede to "A meta-registry and package manager for WebAssembly components...".

**"Publish your component" CTA (home page)**
- Grayed out the "Open the publishing guide" and "Read the spec" buttons.

**Navbar**
- Removed the Docs link across all layouts (`layout.rs`, `page_shell.rs`, `package_shell.rs`).

## Approach

`FooterLink.href` and the `CtaStrip` primary/secondary hrefs are now `Option`. A `None` href renders a muted, `aria-disabled` `<span>` (`text-ink-400 cursor-not-allowed`) instead of an anchor, reusing the same disabled-control convention already used elsewhere in the design system. Rendering was refactored into small `push_link` / `push_primary` / `push_secondary` helpers.

The design-system showcase demos keep their enabled (`Some`) state so the components still document the normal appearance; the footer snapshot test was updated to also exercise the new disabled path.

All checks pass via `cargo xtask test` (nextest, doc tests, clippy `-D warnings`, fmt, sql check, readme check).