### PR TITLE
Rename product to "Wasm Directory" in UI chrome

### DIFF
--- a/crates/component-frontend/src/components/ds/navbar.rs
+++ b/crates/component-frontend/src/components/ds/navbar.rs
@@ -98,7 +98,7 @@ pub(crate) struct NavLink {
 
 /// Inline "alpha" badge rendered next to the brand mark in the navbar.
 ///
-/// The Component Registry is in its alpha phase — not yet beta — so every
+/// Wasm Directory is in its alpha phase — not yet beta — so every
 /// page advertises that fact in the header. Orange is used to draw the eye
 /// without competing with the purple accent reserved for primary actions.
 const ALPHA_BADGE: &str = r#"<span class="inline-flex items-center h-5 px-1.5 rounded text-[10px] font-semibold uppercase tracking-wider text-orange-700 bg-orange-100 border border-orange-200 whitespace-nowrap" title="This service is in alpha — expect breaking changes." aria-label="Alpha release">alpha</span>"#;
@@ -150,7 +150,7 @@ pub(crate) fn render_bar(crumbs: &[Crumb], links: &[NavLink]) -> String {
         .anchor(|a| {
             a.href("/")
                 .class("text-[13px] font-semibold text-ink-900 no-underline hover:text-ink-700 transition-colors whitespace-nowrap")
-                .text("Component Registry")
+                .text("Wasm Directory")
         })
         .text(ALPHA_BADGE)
         .division(|d| d.class("w-px h-4 bg-line flex-shrink-0"))
@@ -206,7 +206,7 @@ pub(crate) fn render_bar_grid(crumbs: &[Crumb], links: &[NavLink]) -> String {
         .anchor(|a| {
             a.href("/")
                 .class("text-[13px] font-semibold text-ink-900 no-underline hover:text-ink-700 transition-colors whitespace-nowrap")
-                .text("Component Registry")
+                .text("Wasm Directory")
         })
         .text(ALPHA_BADGE)
         .division(|d| d.class("w-px h-4 bg-line flex-shrink-0"))

--- a/crates/component-frontend/src/footer.rs
+++ b/crates/component-frontend/src/footer.rs
@@ -67,7 +67,7 @@ const COLUMNS: &[FooterColumn] = &[
 #[must_use]
 pub(crate) fn render() -> String {
     crate::components::ds::footer::render(&Footer {
-        brand: "component",
+        brand: "Wasm Directory",
         lede: "A meta-registry and package manager for WebAssembly components. Made by Yosh Wuyts and contributors. To be donated to the Bytecode Alliance.",
         status: "All systems operational",
         columns: COLUMNS,

--- a/crates/component-frontend/src/layout.rs
+++ b/crates/component-frontend/src/layout.rs
@@ -134,7 +134,7 @@ fn render_document(title: &str, body_class: &str, body_children: &str) -> String
   <style>html{{background:#F4F4F5;scrollbar-gutter:stable}}@media(prefers-color-scheme:dark){{html:not([data-theme=light]){{background:#1C1C20}}}}html[data-theme=dark]{{background:#1C1C20}}html[data-theme=light]{{background:#F4F4F5}}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Browse and discover WebAssembly components and WIT interfaces published to OCI registries.">
-  <title>{escaped_title} — component registry</title>
+  <title>{escaped_title} — Wasm Directory</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
     /* Early theme init — prevent flash of wrong theme */


### PR DESCRIPTION
Rebrands the site from "Component Registry" / "component registry" to **"Wasm Directory"** so the user-facing name is consistent across the chrome.

The change touches the three places the old name was shown to users:

- **Page title** (`layout.rs`): the `<title>` suffix is now `— Wasm Directory`.
- **Navbar brand** (`navbar.rs`): both production variants (`render_bar` and `render_bar_grid`) render "Wasm Directory"; the adjacent doc comment was updated to match.
- **Footer brand** (`footer.rs`): the site footer wrapper's brand is now "Wasm Directory" (was "component").

**Deliberately left untouched:** CLI subcommand references such as `component registry publish` / `component registry sync` (in code, docs, and the README) are real commands, not branding, so they stay as-is. The `item_list.rs` design-system demo label that documents those subcommands, and the `ds/footer.rs` test fixture (sample data for the reusable component), are also unchanged. The README needed no branding edits; its title is `component-cli` and its only "component registry" occurrence is the CLI command.

No snapshots referenced the title or brand text, so none required regenerating. `cargo xtask test` passes (fmt, clippy, tests, sql check, readme check).