### PR TITLE
Add favicon

### DIFF
--- a/crates/component-frontend/assets/favicon.svg
+++ b/crates/component-frontend/assets/favicon.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" role="img" aria-label="Wasm Directory">
+  <style>
+    /* Baseline colors live on the presentation attributes below so the mark
+       still renders where favicon CSS is ignored; this only inverts the
+       palette for dark browser chrome. Mirrors the site's --c-ink-900 /
+       --c-canvas tokens (see layout.rs). */
+    @media (prefers-color-scheme: dark) {
+      .tile { fill: #ECECEE; }
+      .mark { fill: #1C1C20; }
+    }
+  </style>
+  <rect class="tile" width="32" height="32" rx="7" fill="#18181B"/>
+  <g class="mark" fill="#F4F4F5">
+    <rect x="6.5" y="6.5" width="8" height="8" rx="2"/>
+    <rect x="17.5" y="6.5" width="8" height="8" rx="2"/>
+    <rect x="6.5" y="17.5" width="8" height="8" rx="2"/>
+    <rect x="17.5" y="17.5" width="8" height="8" rx="2"/>
+  </g>
+</svg>

--- a/crates/component-frontend/src/layout.rs
+++ b/crates/component-frontend/src/layout.rs
@@ -134,6 +134,7 @@ fn render_document(title: &str, body_class: &str, body_children: &str) -> String
   <style>html{{background:#F4F4F5;scrollbar-gutter:stable}}@media(prefers-color-scheme:dark){{html:not([data-theme=light]){{background:#1C1C20}}}}html[data-theme=dark]{{background:#1C1C20}}html[data-theme=light]{{background:#F4F4F5}}</style>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Browse and discover WebAssembly components and WIT interfaces published to OCI registries.">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <title>{escaped_title} — Wasm Directory</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>

--- a/crates/component-frontend/src/lib.rs
+++ b/crates/component-frontend/src/lib.rs
@@ -44,6 +44,8 @@ fn app() -> Router {
         .route("/downloads", get(downloads))
         .route("/status", get(queue_status))
         .route("/health", get(health))
+        .route("/favicon.svg", get(favicon_svg))
+        .route("/favicon.ico", get(favicon_ico))
         .route("/{namespace}/{name}", get(package_redirect))
         .route("/{namespace}/{name}/", get(package_redirect))
         .route("/{namespace}", get(namespace_page))
@@ -101,6 +103,34 @@ async fn health() -> impl IntoResponse {
         [(header::CACHE_CONTROL, "no-cache")],
         Json(serde_json::json!({ "status": "ok" })),
     )
+}
+
+/// Site favicon, embedded in the binary at build time.
+///
+/// A small on-brand SVG mark that adapts to light and dark browser chrome
+/// via `prefers-color-scheme`.
+const FAVICON_SVG: &str = include_str!("../assets/favicon.svg");
+
+/// Long-lived cache policy for immutable static assets (one week).
+const ASSET_CACHE_CONTROL: &str = "public, max-age=604800";
+
+// r[impl frontend.assets.favicon]
+/// Serve the SVG favicon with a long cache lifetime.
+async fn favicon_svg() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "image/svg+xml"),
+            (header::CACHE_CONTROL, ASSET_CACHE_CONTROL),
+        ],
+        FAVICON_SVG,
+    )
+}
+
+// r[impl frontend.assets.favicon]
+/// Redirect the browser's default `/favicon.ico` probe to the SVG favicon so
+/// it doesn't fall through to the 404 handler.
+async fn favicon_ico() -> impl IntoResponse {
+    Redirect::permanent("/favicon.svg")
 }
 
 // r[impl frontend.pages.home]
@@ -875,6 +905,54 @@ mod tests {
             .await
             .expect("health response body should be readable");
         assert_eq!(bytes.as_ref(), br#"{"status":"ok"}"#);
+    }
+
+    // r[verify frontend.assets.favicon]
+    #[tokio::test]
+    async fn favicon_svg_has_svg_content_type_and_long_cache() {
+        let response = favicon_svg().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .expect("content-type header should be set"),
+            "image/svg+xml"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .expect("cache-control header should be set"),
+            "public, max-age=604800"
+        );
+
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("favicon response body should be readable");
+        assert_eq!(bytes.as_ref(), FAVICON_SVG.as_bytes());
+    }
+
+    // r[verify frontend.assets.favicon]
+    #[tokio::test]
+    async fn favicon_ico_redirects_to_svg() {
+        let response = favicon_ico().await.into_response();
+        assert_eq!(response.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::LOCATION)
+                .expect("location header should be set"),
+            "/favicon.svg"
+        );
+    }
+
+    // r[verify frontend.assets.favicon]
+    #[test]
+    fn favicon_svg_asset_is_wellformed() {
+        assert!(FAVICON_SVG.starts_with("<svg"));
+        assert!(FAVICON_SVG.contains("viewBox"));
+        assert!(FAVICON_SVG.trim_end().ends_with("</svg>"));
     }
 
     // r[verify frontend.caching.static-pages]


### PR DESCRIPTION
Fixes #435

The site had no favicon, so browsers requested `/favicon.ico` and got a 404. This adds a small, on-brand SVG favicon and wires it up.

## What changed
- **New asset** `crates/component-frontend/assets/favicon.svg` — a rounded ink tile with a 2×2 grid of rounded squares, reading as a "directory of modular components". Monochrome, matching the brand's `--c-ink-900` / `--c-canvas` tokens, and legible at 16px. It inverts for dark browser chrome via `prefers-color-scheme` (with light-mode colors baked into presentation attributes as a safe fallback where favicon CSS is ignored).
- **`lib.rs`** — embed the SVG with `include_str!`; serve it at `/favicon.svg` with `Content-Type: image/svg+xml` and `Cache-Control: public, max-age=604800`; add `/favicon.ico` that 308-redirects to `/favicon.svg` so the default browser probe no longer 404s.
- **`layout.rs`** — add `<link rel="icon" href="/favicon.svg" type="image/svg+xml">` to the shared `<head>`.

## Notes
- Follows the crate's `r[impl …]` / `r[verify …]` spec-marker + test convention (new `frontend.assets.favicon` marker) and mirrors the existing `health` / `not_found` handler idioms.
- `cargo xtask test` (fmt, clippy, tests, sql check, readme check) passes.