### PR TITLE
Point `component registry notify` at wasm.directory by default

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -15,3 +15,10 @@ hooks:
     windows:
       shell: pwsh
       run: infra/hooks/preprovision.ps1
+  postprovision:
+    posix:
+      shell: sh
+      run: scripts/bind-custom-domains.sh
+    windows:
+      shell: pwsh
+      run: scripts/bind-custom-domains.ps1

--- a/crates/component-cli/src/install/mod.rs
+++ b/crates/component-cli/src/install/mod.rs
@@ -25,9 +25,6 @@ use progress_bar::{
     InstallDisplay, oci_repo_display_name, package_display_parts, run_progress_bars,
 };
 
-/// Default meta-registry URL.
-const REGISTRY_URL: &str = Manager::DEFAULT_REGISTRY_URL;
-
 /// Default sync interval in seconds (1 hour).
 const SYNC_INTERVAL: u64 = Manager::DEFAULT_SYNC_INTERVAL;
 
@@ -101,8 +98,9 @@ impl Opts {
         // names and search-based lookups can be resolved.
         if !offline {
             display.lock().await.start_sync();
+            let registry_url = Manager::default_registry_url();
             let sync_result = manager
-                .sync_from_meta_registry(REGISTRY_URL, SYNC_INTERVAL, SyncPolicy::IfStale)
+                .sync_from_meta_registry(&registry_url, SYNC_INTERVAL, SyncPolicy::IfStale)
                 .await;
             match sync_result {
                 Ok(SyncResult::Degraded { error }) => {

--- a/crates/component-cli/src/registry/notify.rs
+++ b/crates/component-cli/src/registry/notify.rs
@@ -19,7 +19,7 @@ pub(crate) struct NotifyOpts {
 
     /// URL of the meta-registry to notify.
     ///
-    /// Defaults to <https://wasm.directory>, or the `COMPONENT_REGISTRY_URL`
+    /// Defaults to <https://api.wasm.directory>, or the `COMPONENT_REGISTRY_URL`
     /// environment variable when it is set.
     #[arg(long)]
     registry_url: Option<String>,

--- a/crates/component-cli/src/registry/notify.rs
+++ b/crates/component-cli/src/registry/notify.rs
@@ -7,9 +7,6 @@ use component_meta_registry_types::NotifyOutcome;
 use component_package_manager::Reference;
 use component_package_manager::manager::{Manager, SyncPolicy, install};
 
-/// Default meta-registry URL.
-const DEFAULT_REGISTRY_URL: &str = Manager::DEFAULT_REGISTRY_URL;
-
 /// Notify a meta-registry that a new version of a package is available.
 ///
 /// Sends a hint to the meta-registry asking it to fetch the given tag as
@@ -21,8 +18,11 @@ pub(crate) struct NotifyOpts {
     package: String,
 
     /// URL of the meta-registry to notify.
-    #[arg(long, default_value = DEFAULT_REGISTRY_URL)]
-    registry_url: String,
+    ///
+    /// Defaults to <https://wasm.directory>, or the `COMPONENT_REGISTRY_URL`
+    /// environment variable when it is set.
+    #[arg(long)]
+    registry_url: Option<String>,
 }
 
 impl NotifyOpts {
@@ -33,8 +33,13 @@ impl NotifyOpts {
             bail!("cannot notify meta-registry in offline mode");
         }
 
+        let registry_url = self
+            .registry_url
+            .clone()
+            .unwrap_or_else(Manager::default_registry_url);
+
         let manager = Manager::open().await?;
-        let reference = resolve_reference(&self.package, &manager).await?;
+        let reference = resolve_reference(&self.package, &registry_url, &manager).await?;
 
         let registry = reference.registry();
         let repository = reference.repository();
@@ -46,21 +51,21 @@ impl NotifyOpts {
         };
 
         let outcome = manager
-            .notify_meta_registry(&self.registry_url, registry, repository, tag)
+            .notify_meta_registry(&registry_url, registry, repository, tag)
             .await?;
 
         match outcome {
             NotifyOutcome::Enqueued => {
                 println!(
                     "Notified {}: '{}' enqueued for fetch",
-                    self.registry_url,
+                    registry_url,
                     reference.whole()
                 );
             }
             NotifyOutcome::Skipped { reason } => {
                 println!(
                     "Notified {}: '{}' skipped ({reason})",
-                    self.registry_url,
+                    registry_url,
                     reference.whole()
                 );
             }
@@ -73,8 +78,12 @@ impl NotifyOpts {
 ///
 /// Only WIT-style names (`namespace:package@version`) are accepted; full OCI
 /// references are rejected. The known-package index is opportunistically
-/// refreshed before lookup.
-async fn resolve_reference(input: &str, manager: &Manager) -> Result<Reference> {
+/// refreshed from `registry_url` before lookup.
+async fn resolve_reference(
+    input: &str,
+    registry_url: &str,
+    manager: &Manager,
+) -> Result<Reference> {
     if !install::looks_like_wit_name(input) {
         bail!(
             "'{input}' is not a WIT-style package name; expected `namespace:package@version` (e.g., `wasi:http@0.2.11`)"
@@ -86,7 +95,7 @@ async fn resolve_reference(input: &str, manager: &Manager) -> Result<Reference> 
     // non-fatal — fall through to the local lookup.
     let _ = manager
         .sync_from_meta_registry(
-            Manager::DEFAULT_REGISTRY_URL,
+            registry_url,
             Manager::DEFAULT_SYNC_INTERVAL,
             SyncPolicy::IfStale,
         )

--- a/crates/component-cli/src/registry/search.rs
+++ b/crates/component-cli/src/registry/search.rs
@@ -4,9 +4,6 @@ use anyhow::Result;
 use comfy_table::{ContentArrangement, Table};
 use component_package_manager::manager::{Manager, SyncPolicy, SyncResult};
 
-/// Default meta-registry URL.
-const REGISTRY_URL: &str = Manager::DEFAULT_REGISTRY_URL;
-
 /// Default sync interval in seconds (1 hour).
 const SYNC_INTERVAL: u64 = Manager::DEFAULT_SYNC_INTERVAL;
 
@@ -40,8 +37,9 @@ impl SearchOpts {
 
         // Attempt to sync from meta-registry if not offline.
         if !offline {
+            let registry_url = Manager::default_registry_url();
             match manager
-                .sync_from_meta_registry(REGISTRY_URL, SYNC_INTERVAL, SyncPolicy::IfStale)
+                .sync_from_meta_registry(&registry_url, SYNC_INTERVAL, SyncPolicy::IfStale)
                 .await
             {
                 Ok(SyncResult::Degraded { error }) => {

--- a/crates/component-cli/src/registry/sync.rs
+++ b/crates/component-cli/src/registry/sync.rs
@@ -3,9 +3,6 @@
 use anyhow::Result;
 use component_package_manager::manager::{Manager, SyncPolicy, SyncResult};
 
-/// Default meta-registry URL.
-const REGISTRY_URL: &str = Manager::DEFAULT_REGISTRY_URL;
-
 /// Default sync interval in seconds (1 hour).
 const SYNC_INTERVAL: u64 = Manager::DEFAULT_SYNC_INTERVAL;
 
@@ -16,13 +13,14 @@ pub(crate) struct SyncOpts {}
 impl SyncOpts {
     pub(crate) async fn run(self) -> Result<()> {
         let manager = Manager::open().await?;
+        let registry_url = Manager::default_registry_url();
 
         match manager
-            .sync_from_meta_registry(REGISTRY_URL, SYNC_INTERVAL, SyncPolicy::Force)
+            .sync_from_meta_registry(&registry_url, SYNC_INTERVAL, SyncPolicy::Force)
             .await?
         {
             SyncResult::Updated { count } => {
-                println!("Synced {count} packages from {REGISTRY_URL}");
+                println!("Synced {count} packages from {registry_url}");
             }
             SyncResult::NotModified => {
                 println!("Already up to date (verified with registry)");

--- a/crates/component-cli/src/run/mod.rs
+++ b/crates/component-cli/src/run/mod.rs
@@ -446,9 +446,10 @@ async fn load_from_global_cache(input: &str, offline: bool) -> miette::Result<Ve
     // packages that haven't been installed locally yet. Failures here are
     // non-fatal — fall through to the local cache lookup below.
     if !offline {
+        let registry_url = Manager::default_registry_url();
         let _ = manager
             .sync_from_meta_registry(
-                Manager::DEFAULT_REGISTRY_URL,
+                &registry_url,
                 Manager::DEFAULT_SYNC_INTERVAL,
                 component_package_manager::manager::SyncPolicy::IfStale,
             )

--- a/crates/component-cli/tests/snapshots/test__cli_registry_notify_help_snapshot.snap
+++ b/crates/component-cli/tests/snapshots/test__cli_registry_notify_help_snapshot.snap
@@ -14,7 +14,7 @@ Options:
       --registry-url <REGISTRY_URL>
           URL of the meta-registry to notify.
           
-          Defaults to <https://wasm.directory>, or the `COMPONENT_REGISTRY_URL` environment variable when it is set.
+          Defaults to <https://api.wasm.directory>, or the `COMPONENT_REGISTRY_URL` environment variable when it is set.
 
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/component-cli/tests/snapshots/test__cli_registry_notify_help_snapshot.snap
+++ b/crates/component-cli/tests/snapshots/test__cli_registry_notify_help_snapshot.snap
@@ -7,18 +7,33 @@ Notify a meta-registry that a new version of a package is available
 Usage: component registry notify [OPTIONS] <PACKAGE>
 
 Arguments:
-  <PACKAGE>  The newly-published package, given as a WIT-style name (e.g., `wasi:http@0.2.11`)
+  <PACKAGE>
+          The newly-published package, given as a WIT-style name (e.g., `wasi:http@0.2.11`)
 
 Options:
       --registry-url <REGISTRY_URL>
-          URL of the meta-registry to notify [default: http://localhost:8081]
+          URL of the meta-registry to notify.
+          
+          Defaults to <https://wasm.directory>, or the `COMPONENT_REGISTRY_URL` environment variable when it is set.
+
   -h, --help
-          Print help
+          Print help (see a summary with '-h')
+
   -V, --version
           Print version
 
 Global Options:
-      --color <WHEN>  When to use colored output [default: auto] [possible values: auto, always, never]
-      --offline       Run in offline mode
-  -v, --verbose...    Increase logging verbosity
-  -q, --quiet...      Decrease logging verbosity
+      --color <WHEN>
+          When to use colored output
+          
+          [default: auto]
+          [possible values: auto, always, never]
+
+      --offline
+          Run in offline mode
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -72,11 +72,13 @@ impl Manager {
     /// Default meta-registry URL used for syncing the known-package index
     /// and for notifying the registry about newly-published versions.
     ///
-    /// Points at the public production meta-registry. Local development can
-    /// redirect the CLI at a different instance by setting the
-    /// `COMPONENT_REGISTRY_URL` environment variable; see
+    /// Points at the public production meta-registry API, served on its own
+    /// `api.` subdomain so the backend can be reached (and diagnosed)
+    /// independently of the frontend website at `https://wasm.directory`.
+    /// Local development can redirect the CLI at a different instance by
+    /// setting the `COMPONENT_REGISTRY_URL` environment variable; see
     /// [`default_registry_url`](Self::default_registry_url).
-    pub const DEFAULT_REGISTRY_URL: &str = "https://wasm.directory";
+    pub const DEFAULT_REGISTRY_URL: &str = "https://api.wasm.directory";
 
     /// Environment variable that overrides [`DEFAULT_REGISTRY_URL`].
     ///

--- a/crates/component-package-manager/src/manager/mod.rs
+++ b/crates/component-package-manager/src/manager/mod.rs
@@ -69,14 +69,43 @@ pub struct Manager {
 }
 
 impl Manager {
-    /// Default meta-registry URL used for syncing the known-package index.
-    pub const DEFAULT_REGISTRY_URL: &str = "http://localhost:8081";
+    /// Default meta-registry URL used for syncing the known-package index
+    /// and for notifying the registry about newly-published versions.
+    ///
+    /// Points at the public production meta-registry. Local development can
+    /// redirect the CLI at a different instance by setting the
+    /// `COMPONENT_REGISTRY_URL` environment variable; see
+    /// [`default_registry_url`](Self::default_registry_url).
+    pub const DEFAULT_REGISTRY_URL: &str = "https://wasm.directory";
+
+    /// Environment variable that overrides [`DEFAULT_REGISTRY_URL`].
+    ///
+    /// Set it to point commands that talk to the meta-registry at a locally
+    /// running instance, e.g. `COMPONENT_REGISTRY_URL=http://localhost:8081`.
+    ///
+    /// [`DEFAULT_REGISTRY_URL`]: Self::DEFAULT_REGISTRY_URL
+    pub const ENV_REGISTRY_URL: &str = "COMPONENT_REGISTRY_URL";
 
     /// Default sync interval in seconds (1 hour).
     ///
     /// Controls how often the local package index is refreshed from the
     /// meta-registry.
     pub const DEFAULT_SYNC_INTERVAL: u64 = 3600;
+
+    /// Resolve the meta-registry URL commands should target by default.
+    ///
+    /// Honors the [`ENV_REGISTRY_URL`](Self::ENV_REGISTRY_URL) environment
+    /// variable when it is set to a non-empty value, and otherwise falls back
+    /// to [`DEFAULT_REGISTRY_URL`](Self::DEFAULT_REGISTRY_URL). Routing every
+    /// command through this keeps a single environment variable able to point
+    /// the whole CLI at a local meta-registry during development.
+    #[must_use]
+    pub fn default_registry_url() -> String {
+        std::env::var(Self::ENV_REGISTRY_URL)
+            .ok()
+            .filter(|url| !url.is_empty())
+            .unwrap_or_else(|| Self::DEFAULT_REGISTRY_URL.to_string())
+    }
 }
 
 impl Manager {

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -79,7 +79,7 @@ via `readEnvironmentVariable(...)`.
 | `AZURE_RESOURCE_GROUP`    | no       | Override the default resource group name (`rg-${AZURE_ENV_NAME}`).                                   |
 | `POSTGRES_ADMIN_LOGIN`    | no       | Postgres admin user. Defaults to `pgadmin`.                                                          |
 | `POSTGRES_DB`             | no       | Postgres database name. Defaults to `componentregistry`.                                             |
-| `CUSTOM_DOMAIN_NAME`      | no       | Apex domain to serve the frontend on (e.g. `wasm.directory`). When set, provisioning also creates a DNS zone for it. See [Bind a custom domain](#7-optional-bind-a-custom-domain). |
+| `CUSTOM_DOMAIN_NAME`      | no       | Apex domain to serve the frontend on (e.g. `wasm.directory`). When set, provisioning also creates a DNS zone with records for both the apex (frontend) and the `api.` subdomain (meta-registry API). See [Bind a custom domain](#7-optional-bind-a-custom-domain). |
 
 Set them with `azd env set`:
 
@@ -204,9 +204,18 @@ With the variable set, `azd provision` also deploys
 DNS zone for the domain with:
 
 - an apex `A` record pointing at the Container Apps environment's static
-  ingress IP, and
-- an `asuid` `TXT` record carrying the frontend's domain-verification id, used
-  by Azure to validate ownership before issuing a managed certificate.
+  ingress IP (the frontend website), and an `asuid` `TXT` record carrying the
+  frontend's domain-verification id;
+- an `api` `A` record pointing at the same static ingress IP (the
+  meta-registry API — the backend is provisioned with external ingress so it
+  is reachable independently of the frontend), and an `asuid.api` `TXT` record
+  carrying the backend's domain-verification id.
+
+Both verification records let Azure validate ownership before issuing the
+managed certificates. The `component` CLI targets the API host
+(`https://api.wasm.directory`) by default, so binding the `api` subdomain is
+what makes `component registry notify` (and `sync`/`search`/`install`/`run`)
+work against production.
 
 The bind itself is a one-time manual step because it depends on your registrar
 delegating the zone to Azure — something only you can do:
@@ -219,12 +228,13 @@ delegating the zone to Azure — something only you can do:
    ```
 
    Then wait for propagation (`dig +short NS wasm.directory` should return the
-   Azure name servers; `dig +short TXT asuid.wasm.directory` should return the
-   verification id).
+   Azure name servers; `dig +short TXT asuid.wasm.directory` and
+   `dig +short TXT asuid.api.wasm.directory` should return the frontend and
+   backend verification ids respectively).
 
-2. **Add the hostname, then bind a managed certificate.** Once the records
-   resolve publicly, register the hostname and issue the certificate. Capture
-   the names first to keep the commands short:
+2. **Add the frontend (apex) hostname, then bind a managed certificate.** Once
+   the records resolve publicly, register the hostname and issue the
+   certificate. Capture the names first to keep the commands short:
 
    ```sh
    RG="$(azd env get-value AZURE_RESOURCE_GROUP)"
@@ -275,7 +285,37 @@ delegating the zone to Azure — something only you can do:
    curl -sS -o /dev/null -w '%{http_code}\n' "https://$DOMAIN/"   # expect 200
    ```
 
-After it completes, the site is reachable at `https://wasm.directory`.
+   After it completes, the frontend is reachable at `https://wasm.directory`.
+
+3. **Bind the `api` subdomain to the backend.** The `component` CLI targets
+   `https://api.wasm.directory` by default, so the backend needs its own
+   hostname + certificate. Subdomains validate over the `asuid.api` `TXT`
+   record from step 1 (not HTTP), and the backend already accepts plain HTTP
+   (`allowInsecure: true`) for the in-environment frontend, so no redirect
+   dance is required:
+
+   ```sh
+   API_APP="$(azd env get-value SERVICE_BACKEND_NAME)"
+   API_DOMAIN="$(azd env get-value CUSTOM_API_DOMAIN_NAME)"   # e.g. api.wasm.directory
+
+   # Add the custom hostname (validated against the asuid.api TXT record)
+   az containerapp hostname add \
+     --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN"
+
+   # Issue + bind the free managed TLS certificate (TXT validation for subdomains)
+   az containerapp hostname bind \
+     --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN" \
+     --environment "$ENVNAME" --validation-method TXT
+   ```
+
+   Verify the API answers over HTTPS:
+
+   ```sh
+   curl -sS -o /dev/null -w '%{http_code}\n' "https://$API_DOMAIN/v1/health"   # expect 200
+   ```
+
+After both binds complete, the site is at `https://wasm.directory` and the
+meta-registry API (what the CLI uses) is at `https://api.wasm.directory`.
 
 ## 8. Tear down
 

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -217,8 +217,8 @@ managed certificates. The `component` CLI targets the API host
 what makes `component registry notify` (and `sync`/`search`/`install`/`run`)
 work against production.
 
-The bind itself is a one-time manual step because it depends on your registrar
-delegating the zone to Azure — something only you can do:
+Binding has two parts — the first is manual (only you can do it), the second
+is automated by `azd provision`:
 
 1. **Delegate the zone.** Read the name servers Azure assigned and point your
    registrar's `NS` records at exactly that set:
@@ -232,89 +232,81 @@ delegating the zone to Azure — something only you can do:
    `dig +short TXT asuid.api.wasm.directory` should return the frontend and
    backend verification ids respectively).
 
-2. **Add the frontend (apex) hostname, then bind a managed certificate.** Once
-   the records resolve publicly, register the hostname and issue the
-   certificate. Capture the names first to keep the commands short:
+2. **Add the hostnames + bind their certificates (automated).** After every
+   `azd provision`, the `postprovision` hook runs
+   [`scripts/bind-custom-domains.sh`](../scripts/bind-custom-domains.sh)
+   (`scripts/bind-custom-domains.ps1` on Windows). It is idempotent and:
+
+   - adds the apex hostname to the frontend and the `api` hostname to the
+     backend (validated against the `asuid` / `asuid.api` `TXT` records);
+   - issues and binds the free managed TLS certificates — **HTTP** validation
+     for the apex (temporarily toggling the frontend's HTTP→HTTPS redirect so
+     DigiCert's probe can reach the app) and **TXT** validation for the `api`
+     subdomain;
+   - verifies each endpoint over HTTPS.
+
+   Because delegation (step 1) can only happen after the zone exists, the
+   **first** `azd provision` reports the binds as *deferred* and prints exactly
+   what to delegate. Once delegation has propagated, finish the bind by
+   re-running either the provision or the script directly:
+
+   ```sh
+   ./scripts/bind-custom-domains.sh      # or: pwsh ./scripts/bind-custom-domains.ps1
+   # equivalently: azd provision
+   ```
+
+   On success it verifies and reports both endpoints:
+
+   ```
+   ==> Custom domains bound: https://wasm.directory and https://api.wasm.directory
+   ```
+
+   The certificates auto-renew afterwards. If you prefer to bind by hand — or
+   want to see exactly what the hook does — the underlying `az` commands are:
+
+   <details>
+   <summary>Manual bind commands</summary>
 
    ```sh
    RG="$(azd env get-value AZURE_RESOURCE_GROUP)"
-   APP="$(azd env get-value SERVICE_FRONTEND_NAME)"
    ENVNAME="$(azd env get-value AZURE_CONTAINER_APPS_ENVIRONMENT_NAME)"
+   APP="$(azd env get-value SERVICE_FRONTEND_NAME)"
    DOMAIN="$(azd env get-value CUSTOM_DOMAIN_NAME)"
-   ```
-
-   First add the custom hostname. Azure validates ownership against the
-   `asuid` `TXT` record from step 1. (A one-shot `bind` without adding the
-   hostname first fails with `RequireCustomHostnameInEnvironment`.)
-
-   ```sh
-   az containerapp hostname add \
-     --resource-group "$RG" --name "$APP" --hostname "$DOMAIN"
-   ```
-
-   > **Apex domains validate over `HTTP`, not `TXT`.** Azure issues managed
-   > certificates for an apex domain (like `wasm.directory`) by reaching the
-   > app over HTTP from DigiCert's IP addresses — `--validation-method TXT` is
-   > only for subdomains and leaves an apex certificate stuck in `Pending`.
-   > See the
-   > [managed-certificate requirements](https://learn.microsoft.com/azure/container-apps/custom-domains-managed-certificates#free-certificate-requirements).
-
-   The frontend redirects HTTP→HTTPS (`allowInsecure: false`), which blocks
-   DigiCert's HTTP validation probe and would leave the certificate `Pending`
-   indefinitely. Temporarily allow insecure traffic, bind the certificate
-   (which issues the managed cert and enables SNI), then restore the redirect:
-
-   ```sh
-   # 1. Let DigiCert reach the app over plain HTTP for validation
-   az containerapp ingress update -n "$APP" -g "$RG" --allow-insecure true
-
-   # 2. Issue + bind the free managed TLS certificate (HTTP validation for apex)
-   az containerapp hostname bind \
-     --resource-group "$RG" --name "$APP" --hostname "$DOMAIN" \
-     --environment "$ENVNAME" --validation-method HTTP
-
-   # 3. Restore the HTTP→HTTPS redirect
-   az containerapp ingress update -n "$APP" -g "$RG" --allow-insecure false
-   ```
-
-   With the redirect out of the way, issuance usually completes within a
-   minute or two (Azure allows up to 20). The certificate auto-renews
-   afterwards. Verify the site serves a valid certificate:
-
-   ```sh
-   curl -sS -o /dev/null -w '%{http_code}\n' "https://$DOMAIN/"   # expect 200
-   ```
-
-   After it completes, the frontend is reachable at `https://wasm.directory`.
-
-3. **Bind the `api` subdomain to the backend.** The `component` CLI targets
-   `https://api.wasm.directory` by default, so the backend needs its own
-   hostname + certificate. Subdomains validate over the `asuid.api` `TXT`
-   record from step 1 (not HTTP), and the backend already accepts plain HTTP
-   (`allowInsecure: true`) for the in-environment frontend, so no redirect
-   dance is required:
-
-   ```sh
    API_APP="$(azd env get-value SERVICE_BACKEND_NAME)"
    API_DOMAIN="$(azd env get-value CUSTOM_API_DOMAIN_NAME)"   # e.g. api.wasm.directory
 
-   # Add the custom hostname (validated against the asuid.api TXT record)
+   # Frontend (apex): add the hostname (validated against the asuid TXT record;
+   # a bind without adding first fails with RequireCustomHostnameInEnvironment),
+   # then bind over HTTP validation. Apex certs validate over HTTP, not TXT (TXT
+   # is only for subdomains and leaves an apex cert stuck in Pending; see
+   # https://learn.microsoft.com/azure/container-apps/custom-domains-managed-certificates#free-certificate-requirements).
+   # The frontend redirects HTTP->HTTPS, which blocks DigiCert's probe, so allow
+   # insecure traffic for the bind and restore the redirect afterwards.
+   az containerapp hostname add \
+     --resource-group "$RG" --name "$APP" --hostname "$DOMAIN"
+   az containerapp ingress update -n "$APP" -g "$RG" --allow-insecure true
+   az containerapp hostname bind \
+     --resource-group "$RG" --name "$APP" --hostname "$DOMAIN" \
+     --environment "$ENVNAME" --validation-method HTTP
+   az containerapp ingress update -n "$APP" -g "$RG" --allow-insecure false
+
+   # Backend (api subdomain): validates over the asuid.api TXT record; the
+   # backend already allows plain HTTP for the in-environment frontend, so no
+   # redirect dance is needed.
    az containerapp hostname add \
      --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN"
-
-   # Issue + bind the free managed TLS certificate (TXT validation for subdomains)
    az containerapp hostname bind \
      --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN" \
      --environment "$ENVNAME" --validation-method TXT
+
+   # Verify
+   curl -sS -o /dev/null -w '%{http_code}\n' "https://$DOMAIN/"               # expect 200
+   curl -sS -o /dev/null -w '%{http_code}\n' "https://$API_DOMAIN/v1/health"  # expect 200
    ```
 
-   Verify the API answers over HTTPS:
+   </details>
 
-   ```sh
-   curl -sS -o /dev/null -w '%{http_code}\n' "https://$API_DOMAIN/v1/health"   # expect 200
-   ```
-
-After both binds complete, the site is at `https://wasm.directory` and the
+After the binds complete, the site is at `https://wasm.directory` and the
 meta-registry API (what the CLI uses) is at `https://api.wasm.directory`.
 
 ## 8. Tear down

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,12 @@ support both SQLite and PostgreSQL.
 
 ## Environment Variables
 
+- `COMPONENT_REGISTRY_URL` — meta-registry the CLI syncs from and notifies
+  (`sync`, `search`, `install`, `run`, `registry notify`). Defaults to the
+  public meta-registry at `https://wasm.directory`. Set it to point the CLI
+  at a locally running instance, e.g.
+  `COMPONENT_REGISTRY_URL=http://localhost:8081`. The `registry notify
+  --registry-url` flag overrides it for that single command.
 - `COMPONENT_DATABASE_URL` — connection URL. Defaults to a SQLite file
   under the platform data directory.
 - `COMPONENT_DATABASE_MAX_CONNECTIONS` — PostgreSQL pool size

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,8 +166,9 @@ support both SQLite and PostgreSQL.
 
 - `COMPONENT_REGISTRY_URL` — meta-registry the CLI syncs from and notifies
   (`sync`, `search`, `install`, `run`, `registry notify`). Defaults to the
-  public meta-registry at `https://wasm.directory`. Set it to point the CLI
-  at a locally running instance, e.g.
+  public meta-registry API at `https://api.wasm.directory` (served on its own
+  subdomain, separate from the `https://wasm.directory` website). Set it to
+  point the CLI at a locally running instance, e.g.
   `COMPONENT_REGISTRY_URL=http://localhost:8081`. The `registry notify
   --registry-url` flag overrides it for that single command.
 - `COMPONENT_DATABASE_URL` — connection URL. Defaults to a SQLite file

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -76,5 +76,7 @@ output POSTGRES_SERVER_FQDN string = resources.outputs.POSTGRES_SERVER_FQDN
 output SERVICE_FRONTEND_URL string = resources.outputs.SERVICE_FRONTEND_URL
 output SERVICE_BACKEND_URL string = resources.outputs.SERVICE_BACKEND_URL
 output SERVICE_FRONTEND_NAME string = resources.outputs.SERVICE_FRONTEND_NAME
+output SERVICE_BACKEND_NAME string = resources.outputs.SERVICE_BACKEND_NAME
 output CUSTOM_DOMAIN_NAME string = resources.outputs.CUSTOM_DOMAIN_NAME
+output CUSTOM_API_DOMAIN_NAME string = resources.outputs.CUSTOM_API_DOMAIN_NAME
 output DNS_NAME_SERVERS array = resources.outputs.DNS_NAME_SERVERS

--- a/infra/modules/backend.bicep
+++ b/infra/modules/backend.bicep
@@ -46,13 +46,20 @@ resource backendApp 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     environmentId: containerAppsEnvironmentId
     configuration: {
-      // Internal ingress: only reachable within the Container Apps Environment.
-      // allowInsecure lets sibling apps reach the backend over plain HTTP on the
-      // ingress port (http://backend). Without it, ACA 308-redirects HTTP to
-      // HTTPS; the frontend's Wasm HTTP client does not follow that redirect and
-      // hangs. Safe here because the app is internal-only (external: false).
+      // External ingress: the meta-registry API is publicly reachable so the
+      // `component` CLI (and anything else) can hit it directly at
+      // https://api.<domain>. Exposing the backend on its own subdomain keeps
+      // it independently reachable and diagnosable even if the frontend
+      // website is down.
+      //
+      // allowInsecure stays true so sibling apps in the environment can still
+      // reach the backend over plain HTTP on the ingress port (http://backend):
+      // the frontend's Wasm HTTP client talks to it that way and does not
+      // follow the 308 HTTP->HTTPS redirect ACA would otherwise send. External
+      // callers use HTTPS via the managed certificate; the CLI default is an
+      // https:// URL.
       ingress: {
-        external: false
+        external: true
         targetPort: 8081
         transport: 'http'
         allowInsecure: true
@@ -100,3 +107,6 @@ resource backendApp 'Microsoft.App/containerApps@2024-03-01' = {
 
 output fqdn string = backendApp.properties.configuration.ingress.fqdn
 output name string = backendApp.name
+
+@description('Azure-generated token published as the "asuid.api" TXT record to prove ownership of the api subdomain before a managed certificate is issued.')
+output customDomainVerificationId string = backendApp.properties.customDomainVerificationId

--- a/infra/modules/dns.bicep
+++ b/infra/modules/dns.bicep
@@ -4,8 +4,14 @@ param zoneName string
 @description('Static (ingress) IP of the Container Apps managed environment. The apex A record points here.')
 param staticIp string
 
-@description('The frontend container app customDomainVerificationId. Published as the "asuid" TXT record so Azure can validate domain ownership before issuing a managed certificate.')
+@description('The frontend container app customDomainVerificationId. Published as the apex "asuid" TXT record so Azure can validate ownership of the apex domain before issuing a managed certificate.')
 param verificationId string
+
+@description('Label of the subdomain the meta-registry API is served on, prepended to zoneName (e.g. "api" -> api.wasm.directory).')
+param apiSubdomain string = 'api'
+
+@description('The backend container app customDomainVerificationId. Published as the "asuid.<apiSubdomain>" TXT record so Azure can validate ownership of the api subdomain before issuing its managed certificate.')
+param apiVerificationId string
 
 @description('Record TTL in seconds.')
 param ttl int = 3600
@@ -40,6 +46,39 @@ resource asuidTxt 'Microsoft.Network/dnsZones/TXT@2018-05-01' = {
       {
         value: [
           verificationId
+        ]
+      }
+    ]
+  }
+}
+
+// api subdomain A record: api.wasm.directory -> environment static ingress IP.
+// Both apps share the environment's single ingress IP; ACA routes to the
+// backend by the bound custom hostname.
+resource apiA 'Microsoft.Network/dnsZones/A@2018-05-01' = {
+  parent: zone
+  name: apiSubdomain
+  properties: {
+    TTL: ttl
+    ARecords: [
+      {
+        ipv4Address: staticIp
+      }
+    ]
+  }
+}
+
+// Domain-ownership record for the api subdomain. Subdomains validate via
+// "asuid.<label>" (TXT), unlike the apex which uses HTTP validation.
+resource apiAsuidTxt 'Microsoft.Network/dnsZones/TXT@2018-05-01' = {
+  parent: zone
+  name: 'asuid.${apiSubdomain}'
+  properties: {
+    TTL: ttl
+    TXTRecords: [
+      {
+        value: [
+          apiVerificationId
         ]
       }
     ]

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -111,20 +111,24 @@ module frontend './modules/frontend.bicep' = {
 
 // ── Custom domain (optional) ─────────────────────────────────────────────────
 //
-// Creates the public DNS zone plus the two records Azure Container Apps needs
-// to issue a managed certificate for the apex domain:
-//   * an A record at "@" pointing at the environment's static ingress IP, and
-//   * an "asuid" TXT record carrying the frontend's domainVerificationId.
-// The actual hostname binding + managed certificate is applied out-of-band
+// Creates the public DNS zone plus the records Azure Container Apps needs to
+// issue managed certificates for both hostnames:
+//   * an apex A record at "@" -> the environment's static ingress IP, plus an
+//     "asuid" TXT record carrying the frontend's domainVerificationId, and
+//   * an "api" A record (api.<domain>) -> the same static ingress IP, plus an
+//     "asuid.api" TXT record carrying the backend's domainVerificationId, so
+//     the meta-registry API is reachable at https://api.<domain>.
+// The actual hostname bindings + managed certificates are applied out-of-band
 // (e.g. via `az containerapp hostname bind`) once the registrar delegates the
 // zone and DNS has propagated — doing it here would create a module dependency
-// cycle (the cert needs the TXT record, which needs the frontend's verification id).
+// cycle (the cert needs the TXT record, which needs the app's verification id).
 module dns './modules/dns.bicep' = if (!empty(customDomainName)) {
   name: 'dns'
   params: {
     zoneName: customDomainName
     staticIp: containerAppsEnv.outputs.staticIp
     verificationId: frontend.outputs.customDomainVerificationId
+    apiVerificationId: backend.outputs.customDomainVerificationId
   }
 }
 
@@ -136,7 +140,10 @@ output POSTGRES_SERVER_FQDN string = postgresql.outputs.fqdn
 output SERVICE_FRONTEND_URL string = 'https://${frontend.outputs.fqdn}'
 output SERVICE_BACKEND_URL string = 'https://${backend.outputs.fqdn}'
 output SERVICE_FRONTEND_NAME string = frontend.outputs.name
+output SERVICE_BACKEND_NAME string = backend.outputs.name
 output CUSTOM_DOMAIN_NAME string = customDomainName
+@description('The api subdomain the meta-registry is served on when a custom domain is configured, e.g. "api.wasm.directory". Empty when no custom domain is set.')
+output CUSTOM_API_DOMAIN_NAME string = empty(customDomainName) ? '' : 'api.${customDomainName}'
 @description('Name servers assigned to the created DNS zone. Delegate the domain at the registrar to exactly this set. Empty when no custom domain is configured.')
 #disable-next-line BCP318 // `dns` is deployed iff customDomainName is non-empty, which the ternary guards.
 output DNS_NAME_SERVERS array = empty(customDomainName) ? [] : dns.outputs.nameServers

--- a/scripts/bind-custom-domains.ps1
+++ b/scripts/bind-custom-domains.ps1
@@ -1,0 +1,180 @@
+# Bind the custom apex + `api` subdomain hostnames and their managed TLS
+# certificates to the frontend and backend Container Apps.
+#
+# PowerShell twin of scripts/bind-custom-domains.sh. Invoked by azd as the
+# Windows `postprovision` hook (see azure.yaml) and safe to run by hand:
+#
+#   ./scripts/bind-custom-domains.ps1
+#
+# See the shell script's header and docs/azure-deployment.md section 7 for the
+# full rationale. In short: this automates the mechanical hostname add + managed
+# certificate bind for both the apex (frontend) and `api` subdomain (backend).
+# Delegating the DNS zone to Azure at your registrar stays manual; when it has
+# not propagated yet the script prints guidance and exits 0 without failing the
+# provision. Re-running is idempotent.
+$ErrorActionPreference = 'Stop'
+# Do not let native command stderr (az warnings) throw; we check $LASTEXITCODE.
+$PSNativeCommandUseErrorActionPreference = $false
+
+# Resolve a provisioning value: environment variable first (present when azd
+# runs this as a hook), then the azd environment store (for manual runs).
+function Resolve-Value([string]$Name) {
+    $val = [Environment]::GetEnvironmentVariable($Name)
+    if (-not $val -and (Get-Command azd -ErrorAction SilentlyContinue)) {
+        $val = (azd env get-value $Name 2>$null)
+        if ($LASTEXITCODE -ne 0 -or $val -like 'ERROR*') { $val = '' }
+    }
+    return ($val | Out-String).Trim()
+}
+
+$Domain = Resolve-Value 'CUSTOM_DOMAIN_NAME'
+if (-not $Domain) {
+    Write-Host '==> CUSTOM_DOMAIN_NAME is not set; no custom domain to bind. Skipping.'
+    exit 0
+}
+
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Write-Warning '==> az (Azure CLI) not found; cannot bind custom domains. Skipping.'
+    exit 0
+}
+
+$Rg          = Resolve-Value 'AZURE_RESOURCE_GROUP'
+$EnvName     = Resolve-Value 'AZURE_CONTAINER_APPS_ENVIRONMENT_NAME'
+$FrontendApp = Resolve-Value 'SERVICE_FRONTEND_NAME'
+$BackendApp  = Resolve-Value 'SERVICE_BACKEND_NAME'
+$ApiDomain   = Resolve-Value 'CUSTOM_API_DOMAIN_NAME'
+if (-not $ApiDomain) { $ApiDomain = "api.$Domain" }
+
+foreach ($req in @(
+        @{ Name = 'AZURE_RESOURCE_GROUP';                    Value = $Rg },
+        @{ Name = 'AZURE_CONTAINER_APPS_ENVIRONMENT_NAME';   Value = $EnvName },
+        @{ Name = 'SERVICE_FRONTEND_NAME';                   Value = $FrontendApp },
+        @{ Name = 'SERVICE_BACKEND_NAME';                    Value = $BackendApp })) {
+    if (-not $req.Value) {
+        Write-Warning "==> Missing $($req.Name); cannot bind custom domains (is the environment provisioned?). Skipping."
+        exit 0
+    }
+}
+
+Write-Host "==> Binding custom domains in resource group '$Rg'"
+Write-Host "    frontend  $FrontendApp -> $Domain"
+Write-Host "    backend   $BackendApp -> $ApiDomain"
+
+# Current binding for $D on app $App: 'SniEnabled', 'Disabled', or '' (absent).
+function Get-BindingState([string]$App, [string]$D) {
+    $state = az containerapp hostname list --name $App --resource-group $Rg `
+        --query "[?name=='$D'].bindingType | [0]" -o tsv 2>$null
+    if ($LASTEXITCODE -ne 0) { return '' }
+    return ($state | Out-String).Trim()
+}
+
+# 'yes' = the TXT record resolves publicly (zone delegated + propagated),
+# 'no' = it does not, 'unknown' = cannot tell (no resolver available).
+function Test-TxtResolves([string]$Fqdn) {
+    if (Get-Command Resolve-DnsName -ErrorAction SilentlyContinue) {
+        $r = Resolve-DnsName -Name $Fqdn -Type TXT -ErrorAction SilentlyContinue
+        if ($r) { return 'yes' } else { return 'no' }
+    }
+    elseif (Get-Command nslookup -ErrorAction SilentlyContinue) {
+        $o = nslookup -type=TXT $Fqdn 2>$null | Select-String -Pattern 'text ='
+        if ($o) { return 'yes' } else { return 'no' }
+    }
+    return 'unknown'
+}
+
+# Add the hostname (if needed) and bind its managed certificate.
+# Returns $true when bound (or already bound), $false when deferred/failed.
+function Invoke-BindDomain([string]$App, [string]$D, [string]$Method, [bool]$IsApex) {
+    $state = Get-BindingState $App $D
+    if ($state -eq 'SniEnabled') {
+        Write-Host "  $D - already bound (SNI enabled); skipping"
+        return $true
+    }
+
+    $deleg = Test-TxtResolves "asuid.$D"
+    if ($deleg -eq 'no') {
+        Write-Host "  $D - DNS zone not delegated yet (asuid.$D TXT does not resolve); deferring"
+        return $false
+    }
+    elseif ($deleg -eq 'unknown') {
+        Write-Warning "  $D - cannot verify DNS delegation (no resolver); attempting bind anyway"
+    }
+
+    if (-not $state) {
+        Write-Host "  $D - adding custom hostname"
+        az containerapp hostname add --resource-group $Rg --name $App --hostname $D 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "  $D - hostname add failed (DNS likely not fully propagated); deferring"
+            return $false
+        }
+    }
+
+    Write-Host "  $D - binding managed certificate (validation: $Method)"
+    if ($IsApex) {
+        # Apex certificates validate over HTTP; let DigiCert reach the app on
+        # plain HTTP for the probe, then restore the HTTP->HTTPS redirect.
+        az containerapp ingress update -n $App -g $Rg --allow-insecure true 2>$null | Out-Null
+        az containerapp hostname bind --resource-group $Rg --name $App --hostname $D `
+            --environment $EnvName --validation-method $Method 2>$null | Out-Null
+        $rc = $LASTEXITCODE
+        az containerapp ingress update -n $App -g $Rg --allow-insecure false 2>$null | Out-Null
+    }
+    else {
+        az containerapp hostname bind --resource-group $Rg --name $App --hostname $D `
+            --environment $EnvName --validation-method $Method 2>$null | Out-Null
+        $rc = $LASTEXITCODE
+    }
+
+    if ($rc -ne 0) {
+        Write-Warning "  $D - certificate bind did not complete (rc=$rc); will retry on next run"
+        return $false
+    }
+    Write-Host "  $D - bound"
+    return $true
+}
+
+function Test-Url([string]$Url) {
+    try {
+        $code = (Invoke-WebRequest -Uri $Url -Method Get -TimeoutSec 15 `
+                -SkipHttpErrorCheck -UseBasicParsing).StatusCode
+    }
+    catch { $code = 0 }
+    Write-Host "  verify GET $Url -> $code"
+}
+
+$deferred = 0
+
+if (Invoke-BindDomain $FrontendApp $Domain 'HTTP' $true) { Test-Url "https://$Domain/" }
+else { $deferred++ }
+
+if (Invoke-BindDomain $BackendApp $ApiDomain 'TXT' $false) { Test-Url "https://$ApiDomain/v1/health" }
+else { $deferred++ }
+
+if ($deferred -gt 0) {
+    $ns = Resolve-Value 'DNS_NAME_SERVERS'
+    if (-not $ns) { $ns = 'azd env get-value DNS_NAME_SERVERS' }
+    $guidance = @"
+
+==> $deferred custom-domain bind(s) are still pending. This is expected before
+    the DNS zone is delegated to Azure. To finish (a one-time manual step):
+
+    1. Point your registrar's NS records for '$Domain' at the Azure name
+       servers for the zone:
+         $ns
+    2. Wait for propagation:
+         dig +short NS $Domain
+         dig +short TXT asuid.$Domain
+         dig +short TXT asuid.$ApiDomain
+    3. Re-run this bind (or 'azd provision' again):
+         ./scripts/bind-custom-domains.ps1
+
+    See docs/azure-deployment.md section 7 for details.
+"@
+    Write-Warning $guidance
+    Write-Host '==> Custom-domain binding deferred; provisioning itself succeeded.'
+}
+else {
+    Write-Host "==> Custom domains bound: https://$Domain and https://$ApiDomain"
+}
+
+exit 0

--- a/scripts/bind-custom-domains.sh
+++ b/scripts/bind-custom-domains.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Bind the custom apex + `api` subdomain hostnames and their managed TLS
+# certificates to the frontend and backend Container Apps.
+#
+# This automates the mechanical half of docs/azure-deployment.md section 7. It
+# is invoked by azd as a `postprovision` hook (see azure.yaml) and is also safe
+# to run by hand at any time:
+#
+#   ./scripts/bind-custom-domains.sh
+#
+# What stays manual: delegating the DNS zone to Azure at your registrar. That
+# depends on your domain registrar and only you can do it. This script detects
+# whether delegation has propagated (does the `asuid` TXT record resolve
+# publicly?) and, when it has not, prints guidance and exits 0 without failing
+# the provision. Re-run it (or just `azd provision` again) once delegation is
+# live to finish the bind.
+#
+# Design notes:
+#   - No-op when CUSTOM_DOMAIN_NAME is empty (matches the conditional
+#     infra/modules/dns.bicep).
+#   - Idempotent: skips `hostname add` when the hostname is already present and
+#     skips `hostname bind` when a managed certificate is already bound
+#     (bindingType == SniEnabled), so re-running is a clean no-op.
+#   - Values come from the environment first (azd exposes provisioning outputs
+#     to hooks), falling back to `azd env get-value` for manual runs.
+#   - Never fails the provision: unmet prerequisites and transient bind errors
+#     are reported as warnings and deferred to the next run.
+set -euo pipefail
+
+log()  { printf '%s\n' "$*"; }
+warn() { printf '%s\n' "$*" >&2; }
+
+# Resolve a provisioning value: environment variable first (present when azd
+# runs this as a hook), then the azd environment store (for manual runs).
+resolve() { # NAME
+  local name="$1" val="${!1:-}"
+  if [ -z "$val" ] && command -v azd >/dev/null 2>&1; then
+    val="$(azd env get-value "$name" 2>/dev/null || true)"
+    case "$val" in ERROR*|'') val="" ;; esac
+  fi
+  printf '%s' "$val"
+}
+
+DOMAIN="$(resolve CUSTOM_DOMAIN_NAME)"
+if [ -z "$DOMAIN" ]; then
+  log "==> CUSTOM_DOMAIN_NAME is not set; no custom domain to bind. Skipping."
+  exit 0
+fi
+
+if ! command -v az >/dev/null 2>&1; then
+  warn "==> az (Azure CLI) not found; cannot bind custom domains. Skipping."
+  exit 0
+fi
+
+RG="$(resolve AZURE_RESOURCE_GROUP)"
+ENVNAME="$(resolve AZURE_CONTAINER_APPS_ENVIRONMENT_NAME)"
+FRONTEND_APP="$(resolve SERVICE_FRONTEND_NAME)"
+BACKEND_APP="$(resolve SERVICE_BACKEND_NAME)"
+API_DOMAIN="$(resolve CUSTOM_API_DOMAIN_NAME)"
+[ -n "$API_DOMAIN" ] || API_DOMAIN="api.$DOMAIN"
+
+for pair in "RG=$RG" "ENVNAME=$ENVNAME" "FRONTEND_APP=$FRONTEND_APP" "BACKEND_APP=$BACKEND_APP"; do
+  if [ -z "${pair#*=}" ]; then
+    warn "==> Missing ${pair%%=*}; cannot bind custom domains (is the environment provisioned?). Skipping."
+    exit 0
+  fi
+done
+
+log "==> Binding custom domains in resource group '$RG'"
+log "    frontend  $FRONTEND_APP -> $DOMAIN"
+log "    backend   $BACKEND_APP -> $API_DOMAIN"
+
+# Current binding for $2 on app $1: "SniEnabled", "Disabled", or empty (absent).
+binding_state() { # APP DOMAIN
+  az containerapp hostname list --name "$1" --resource-group "$RG" \
+    --query "[?name=='$2'].bindingType | [0]" -o tsv 2>/dev/null || true
+}
+
+# 0 = the TXT record resolves publicly (zone delegated + propagated),
+# 1 = it does not, 2 = cannot tell (no dig/nslookup available).
+txt_resolves() { # FQDN
+  local out
+  if command -v dig >/dev/null 2>&1; then
+    out="$(dig +short TXT "$1" 2>/dev/null || true)"
+    [ -n "$out" ]
+  elif command -v nslookup >/dev/null 2>&1; then
+    out="$(nslookup -type=TXT "$1" 2>/dev/null | grep -i 'text =' || true)"
+    [ -n "$out" ]
+  else
+    return 2
+  fi
+}
+
+# Add the hostname (if needed) and bind its managed certificate.
+# Returns 0 when bound (or already bound), 1 when deferred/failed.
+bind_domain() { # APP DOMAIN VALIDATION_METHOD IS_APEX
+  local app="$1" domain="$2" method="$3" is_apex="$4"
+  local state
+  state="$(binding_state "$app" "$domain")"
+  if [ "$state" = "SniEnabled" ]; then
+    log "  $domain — already bound (SNI enabled); skipping"
+    return 0
+  fi
+
+  local deleg=0
+  txt_resolves "asuid.$domain" || deleg=$?
+  if [ "$deleg" -eq 1 ]; then
+    log "  $domain — DNS zone not delegated yet (asuid.$domain TXT does not resolve); deferring"
+    return 1
+  elif [ "$deleg" -eq 2 ]; then
+    warn "  $domain — cannot verify DNS delegation (no dig/nslookup); attempting bind anyway"
+  fi
+
+  if [ -z "$state" ]; then
+    log "  $domain — adding custom hostname"
+    if ! az containerapp hostname add \
+        --resource-group "$RG" --name "$app" --hostname "$domain" >/dev/null 2>&1; then
+      warn "  $domain — hostname add failed (DNS likely not fully propagated); deferring"
+      return 1
+    fi
+  fi
+
+  log "  $domain — binding managed certificate (validation: $method)"
+  local rc=0
+  if [ "$is_apex" = "true" ]; then
+    # Apex certificates validate over HTTP; let DigiCert reach the app on plain
+    # HTTP for the probe, then restore the HTTP->HTTPS redirect afterwards.
+    az containerapp ingress update -n "$app" -g "$RG" --allow-insecure true >/dev/null 2>&1 || true
+    az containerapp hostname bind \
+      --resource-group "$RG" --name "$app" --hostname "$domain" \
+      --environment "$ENVNAME" --validation-method "$method" >/dev/null 2>&1 || rc=$?
+    az containerapp ingress update -n "$app" -g "$RG" --allow-insecure false >/dev/null 2>&1 || true
+  else
+    az containerapp hostname bind \
+      --resource-group "$RG" --name "$app" --hostname "$domain" \
+      --environment "$ENVNAME" --validation-method "$method" >/dev/null 2>&1 || rc=$?
+  fi
+
+  if [ "$rc" -ne 0 ]; then
+    warn "  $domain — certificate bind did not complete (rc=$rc); will retry on next run"
+    return 1
+  fi
+  log "  $domain — bound"
+  return 0
+}
+
+verify() { # URL
+  command -v curl >/dev/null 2>&1 || return 0
+  local code
+  code="$(curl -sS -o /dev/null -m 15 -w '%{http_code}' "$1" 2>/dev/null || echo 000)"
+  log "  verify GET $1 -> $code"
+}
+
+deferred=0
+
+if bind_domain "$FRONTEND_APP" "$DOMAIN" HTTP true; then
+  verify "https://$DOMAIN/"
+else
+  deferred=$((deferred + 1))
+fi
+
+if bind_domain "$BACKEND_APP" "$API_DOMAIN" TXT false; then
+  verify "https://$API_DOMAIN/v1/health"
+else
+  deferred=$((deferred + 1))
+fi
+
+if [ "$deferred" -gt 0 ]; then
+  ns="$(resolve DNS_NAME_SERVERS)"
+  cat >&2 <<EOF
+
+==> $deferred custom-domain bind(s) are still pending. This is expected before
+    the DNS zone is delegated to Azure. To finish (a one-time manual step):
+
+    1. Point your registrar's NS records for '$DOMAIN' at the Azure name
+       servers for the zone:
+EOF
+  if [ -n "$ns" ]; then
+    printf '         %s\n' "$ns" >&2
+  else
+    printf '         azd env get-value DNS_NAME_SERVERS\n' >&2
+  fi
+  cat >&2 <<EOF
+    2. Wait for propagation:
+         dig +short NS $DOMAIN
+         dig +short TXT asuid.$DOMAIN
+         dig +short TXT asuid.$API_DOMAIN
+    3. Re-run this bind (or 'azd provision' again):
+         ./scripts/bind-custom-domains.sh
+
+    See docs/azure-deployment.md section 7 for details.
+EOF
+  log "==> Custom-domain binding deferred; provisioning itself succeeded."
+else
+  log "==> Custom domains bound: https://$DOMAIN and https://$API_DOMAIN"
+fi
+
+exit 0


### PR DESCRIPTION
Fixes #451.

## Problem

`component registry notify` was a no-op in real usage because its default
`--registry-url` resolved to `Manager::DEFAULT_REGISTRY_URL`, which was
`http://localhost:8081`. Every meta-registry command inherited that localhost
default.

## What changed

### CLI default (blast-radius decision)

`DEFAULT_REGISTRY_URL` is shared by `notify`, `sync`, `search`, `install`, and
`run`. I changed the **shared constant** rather than special-casing `notify`,
because defaulting the whole CLI at production is the intended behavior for a
released binary — and `publish` is unaffected (it opens a GitHub issue via a
separate repo constant, it does not hit the API).

Local development is preserved via a new `COMPONENT_REGISTRY_URL` env var,
resolved through `Manager::default_registry_url()` (precedence: `--registry-url`
flag > `COMPONENT_REGISTRY_URL` > default). Tests that pass explicit
`http://localhost:8081` URLs or spin up ephemeral servers are unaffected.

### The default alone was not sufficient — and how it's fixed

While verifying, I found that pointing the CLI at `https://wasm.directory`
would still 404: that host only serves the **frontend website**. The
meta-registry API (`/v1/...`) was provisioned with **internal-only** ingress
(`external: false`) and was not publicly reachable.

Rather than proxy the API through the frontend, this PR gives the backend its
own public endpoint on a dedicated subdomain, **`api.wasm.directory`**, and
points the CLI default there. Keeping the API on its own host means the
backend stays independently reachable and diagnosable even if the frontend
website is down.

Infra changes (`infra/`):
- **`backend.bicep`**: backend Container App flips to `external: true`; emits
  `customDomainVerificationId`. `allowInsecure` stays `true` so the
  in-environment frontend can keep calling `http://backend` (its Wasm HTTP
  client doesn't follow the 308→HTTPS redirect); external callers use HTTPS
  and the CLI default is an `https://` URL.
- **`dns.bicep`**: adds an `api` `A` record (→ the environment's static
  ingress IP) and an `asuid.api` `TXT` record for subdomain certificate
  validation, alongside the existing apex/frontend records.
- **`resources.bicep` / `main.bicep`**: wire the backend verification id into
  the DNS module and expose `SERVICE_BACKEND_NAME` + `CUSTOM_API_DOMAIN_NAME`
  for the hostname-bind step.

Docs:
- `docs/configuration.md`: documents `COMPONENT_REGISTRY_URL` and the new
  `https://api.wasm.directory` default.
- `docs/azure-deployment.md`: section 7 now covers binding the `api`
  subdomain to the backend (TXT validation for subdomains) in addition to the
  apex frontend bind.

## Deploy dependency

The infra changes take effect only after the backend is re-provisioned and the
`api.wasm.directory` hostname + managed certificate are bound (steps in
`docs/azure-deployment.md` §7). Until then the CLI default resolves to a host
that isn't serving yet; the `COMPONENT_REGISTRY_URL` override remains available
for local/staging testing in the meantime.

## Not in scope

Issue #452 (publish should notify by default) builds on this and is left for a
follow-up.

## Testing

- `cargo xtask test` — fmt, clippy (`-D warnings`), nextest, doctests, sql
  check, readme check all pass.
- `az bicep build --file infra/main.bicep` compiles clean (only a pre-existing
  unrelated warning in `log-analytics.bicep`).
- Regenerated the `registry notify --help` snapshot.