### PR TITLE
Fix bind-custom-domains: accept a domain argument, and validate the api cert over HTTP

### DIFF
--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -241,10 +241,11 @@ is automated by `azd provision`:
      backend (ownership validated against the `asuid` / `asuid.api` `TXT`
      records);
    - issues and binds the free managed TLS certificates using **HTTP**
-     validation for both hostnames — temporarily toggling each app's HTTP→HTTPS
-     redirect so DigiCert's probe can reach it. (Container Apps managed-cert
-     `TXT` validation for the `api` subdomain proved unreliable here —
-     certificates got stuck in `Pending` — so both use HTTP validation.)
+     validation for both hostnames — temporarily allowing plain HTTP on each
+     app so DigiCert's probe can reach it, then restoring each app's original
+     ingress setting. (Container Apps managed-cert `TXT` validation for the
+     `api` subdomain proved unreliable here — certificates got stuck in
+     `Pending` — so both use HTTP validation.)
    - verifies each endpoint over HTTPS.
 
    Because delegation (step 1) can only happen after the zone exists, the
@@ -258,7 +259,7 @@ is automated by `azd provision`:
    ```sh
    ./scripts/bind-custom-domains.sh                  # domain from the azd env
    ./scripts/bind-custom-domains.sh wasm.directory   # or pass it explicitly
-   # Windows: pwsh ./scripts/bind-custom-domains.ps1 [wasm.directory]
+   # Windows: pwsh ./scripts/bind-custom-domains.ps1 -Domain wasm.directory
    # equivalently: azd env set CUSTOM_DOMAIN_NAME wasm.directory && azd provision
    ```
 
@@ -300,15 +301,16 @@ is automated by `azd provision`:
    # Backend (api subdomain): the docs say subdomains can validate over the
    # asuid.api TXT record, but managed-cert TXT validation proved unreliable
    # here (the cert stayed stuck in Pending), so bind over HTTP instead. Open
-   # plain HTTP for DigiCert's probe and restore the redirect afterwards, just
-   # like the apex.
+   # plain HTTP for DigiCert's probe. Unlike the apex, the backend keeps
+   # allowInsecure=true afterwards so the in-environment frontend can keep
+   # reaching http://backend (see infra/modules/backend.bicep) — nothing to
+   # restore here.
    az containerapp hostname add \
      --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN"
    az containerapp ingress update -n "$API_APP" -g "$RG" --allow-insecure true
    az containerapp hostname bind \
      --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN" \
      --environment "$ENVNAME" --validation-method HTTP
-   az containerapp ingress update -n "$API_APP" -g "$RG" --allow-insecure false
 
    # Verify
    curl -sS -o /dev/null -w '%{http_code}\n' "https://$DOMAIN/"               # expect 200

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -238,11 +238,13 @@ is automated by `azd provision`:
    (`scripts/bind-custom-domains.ps1` on Windows). It is idempotent and:
 
    - adds the apex hostname to the frontend and the `api` hostname to the
-     backend (validated against the `asuid` / `asuid.api` `TXT` records);
-   - issues and binds the free managed TLS certificates — **HTTP** validation
-     for the apex (temporarily toggling the frontend's HTTP→HTTPS redirect so
-     DigiCert's probe can reach the app) and **TXT** validation for the `api`
-     subdomain;
+     backend (ownership validated against the `asuid` / `asuid.api` `TXT`
+     records);
+   - issues and binds the free managed TLS certificates using **HTTP**
+     validation for both hostnames — temporarily toggling each app's HTTP→HTTPS
+     redirect so DigiCert's probe can reach it. (Container Apps managed-cert
+     `TXT` validation for the `api` subdomain proved unreliable here —
+     certificates got stuck in `Pending` — so both use HTTP validation.)
    - verifies each endpoint over HTTPS.
 
    Because delegation (step 1) can only happen after the zone exists, the
@@ -295,14 +297,18 @@ is automated by `azd provision`:
      --environment "$ENVNAME" --validation-method HTTP
    az containerapp ingress update -n "$APP" -g "$RG" --allow-insecure false
 
-   # Backend (api subdomain): validates over the asuid.api TXT record; the
-   # backend already allows plain HTTP for the in-environment frontend, so no
-   # redirect dance is needed.
+   # Backend (api subdomain): the docs say subdomains can validate over the
+   # asuid.api TXT record, but managed-cert TXT validation proved unreliable
+   # here (the cert stayed stuck in Pending), so bind over HTTP instead. Open
+   # plain HTTP for DigiCert's probe and restore the redirect afterwards, just
+   # like the apex.
    az containerapp hostname add \
      --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN"
+   az containerapp ingress update -n "$API_APP" -g "$RG" --allow-insecure true
    az containerapp hostname bind \
      --resource-group "$RG" --name "$API_APP" --hostname "$API_DOMAIN" \
-     --environment "$ENVNAME" --validation-method TXT
+     --environment "$ENVNAME" --validation-method HTTP
+   az containerapp ingress update -n "$API_APP" -g "$RG" --allow-insecure false
 
    # Verify
    curl -sS -o /dev/null -w '%{http_code}\n' "https://$DOMAIN/"               # expect 200
@@ -495,10 +501,12 @@ its progress under **Actions**, and the deployment lifecycle (`in_progress` →
 - **Wrong API version.** The `NoRegisteredProviderFound` error includes
   the list of supported API versions for the resource type and region. Pin
   Bicep resources to one of the listed GA versions.
-- **Managed certificate stuck in `Pending` (custom domain).** For an apex
-  domain there are two usual causes. First, the certificate was requested with
-  `--validation-method TXT`; apex domains must use `HTTP`. Delete the pending
-  cert and re-bind with `HTTP`:
+- **Managed certificate stuck in `Pending` (custom domain).** There are two
+  usual causes. First, the certificate was requested with
+  `--validation-method TXT`. Apex domains must use `HTTP`, and TXT validation
+  proved unreliable for the `api` subdomain too (the cert stayed stuck in
+  `Pending`), so bind **both** hostnames with `HTTP`. Delete the pending cert
+  and re-bind with `HTTP`:
 
   ```sh
   RG="$(azd env get-value AZURE_RESOURCE_GROUP)"
@@ -509,9 +517,9 @@ its progress under **Actions**, and the deployment lifecycle (`in_progress` →
     --certificate <pending-cert-name> --yes
   ```
 
-  Second, the frontend redirects HTTP→HTTPS (`allowInsecure: false`), so
-  DigiCert's HTTP validation probe never reaches the app. Bind with
-  `--allow-insecure true` set on the ingress, then restore it — see step 2 of
+  Second, the app redirects HTTP→HTTPS (`allowInsecure: false`), so DigiCert's
+  HTTP validation probe never reaches it. Bind with `--allow-insecure true` set
+  on the ingress, then restore it — see step 2 of
   [§7](#7-optional-bind-a-custom-domain). Note that the per-certificate
-  `validationToken` shown for a `TXT`-validated cert is a dead end for apex
-  domains; don't chase it.
+  `validationToken` shown for a `TXT`-validated cert is a dead end for these
+  hostnames; don't chase it.

--- a/docs/azure-deployment.md
+++ b/docs/azure-deployment.md
@@ -248,11 +248,16 @@ is automated by `azd provision`:
    Because delegation (step 1) can only happen after the zone exists, the
    **first** `azd provision` reports the binds as *deferred* and prints exactly
    what to delegate. Once delegation has propagated, finish the bind by
-   re-running either the provision or the script directly:
+   re-running either the provision or the script directly. The script reads the
+   apex domain from `CUSTOM_DOMAIN_NAME` in the azd environment; pass it as the
+   first argument when running from a checkout whose azd environment does not
+   have it set (a fresh clone, or a CI-managed environment):
 
    ```sh
-   ./scripts/bind-custom-domains.sh      # or: pwsh ./scripts/bind-custom-domains.ps1
-   # equivalently: azd provision
+   ./scripts/bind-custom-domains.sh                  # domain from the azd env
+   ./scripts/bind-custom-domains.sh wasm.directory   # or pass it explicitly
+   # Windows: pwsh ./scripts/bind-custom-domains.ps1 [wasm.directory]
+   # equivalently: azd env set CUSTOM_DOMAIN_NAME wasm.directory && azd provision
    ```
 
    On success it verifies and reports both endpoints:

--- a/scripts/bind-custom-domains.ps1
+++ b/scripts/bind-custom-domains.ps1
@@ -94,7 +94,7 @@ function Test-TxtResolves([string]$Fqdn) {
 
 # Add the hostname (if needed) and bind its managed certificate.
 # Returns $true when bound (or already bound), $false when deferred/failed.
-function Invoke-BindDomain([string]$App, [string]$D, [string]$Method, [bool]$IsApex) {
+function Invoke-BindDomain([string]$App, [string]$D, [string]$Method) {
     $state = Get-BindingState $App $D
     if ($state -eq 'SniEnabled') {
         Write-Host "  $D - already bound (SNI enabled); skipping"
@@ -120,9 +120,11 @@ function Invoke-BindDomain([string]$App, [string]$D, [string]$Method, [bool]$IsA
     }
 
     Write-Host "  $D - binding managed certificate (validation: $Method)"
-    if ($IsApex) {
-        # Apex certificates validate over HTTP; let DigiCert reach the app on
-        # plain HTTP for the probe, then restore the HTTP->HTTPS redirect.
+    if ($Method -eq 'HTTP') {
+        # HTTP (DigiCert) validation must reach the app over plain HTTP; open it
+        # for the probe, then restore the HTTP->HTTPS redirect. Used for both the
+        # apex and the api subdomain: managed-certificate TXT validation proved
+        # unreliable here (certs stuck in 'Pending'), whereas HTTP completes.
         az containerapp ingress update -n $App -g $Rg --allow-insecure true 2>$null | Out-Null
         az containerapp hostname bind --resource-group $Rg --name $App --hostname $D `
             --environment $EnvName --validation-method $Method 2>$null | Out-Null
@@ -154,10 +156,10 @@ function Test-Url([string]$Url) {
 
 $deferred = 0
 
-if (Invoke-BindDomain $FrontendApp $Domain 'HTTP' $true) { Test-Url "https://$Domain/" }
+if (Invoke-BindDomain $FrontendApp $Domain 'HTTP') { Test-Url "https://$Domain/" }
 else { $deferred++ }
 
-if (Invoke-BindDomain $BackendApp $ApiDomain 'TXT' $false) { Test-Url "https://$ApiDomain/v1/health" }
+if (Invoke-BindDomain $BackendApp $ApiDomain 'HTTP') { Test-Url "https://$ApiDomain/v1/health" }
 else { $deferred++ }
 
 if ($deferred -gt 0) {

--- a/scripts/bind-custom-domains.ps1
+++ b/scripts/bind-custom-domains.ps1
@@ -4,7 +4,8 @@
 # PowerShell twin of scripts/bind-custom-domains.sh. Invoked by azd as the
 # Windows `postprovision` hook (see azure.yaml) and safe to run by hand:
 #
-#   ./scripts/bind-custom-domains.ps1
+#   ./scripts/bind-custom-domains.ps1                 # domain from azd env / env
+#   ./scripts/bind-custom-domains.ps1 wasm.directory  # domain given explicitly
 #
 # See the shell script's header and docs/azure-deployment.md section 7 for the
 # full rationale. In short: this automates the mechanical hostname add + managed
@@ -12,6 +13,9 @@
 # Delegating the DNS zone to Azure at your registrar stays manual; when it has
 # not propagated yet the script prints guidance and exits 0 without failing the
 # provision. Re-running is idempotent.
+
+param([string]$Domain)
+
 $ErrorActionPreference = 'Stop'
 # Do not let native command stderr (az warnings) throw; we check $LASTEXITCODE.
 $PSNativeCommandUseErrorActionPreference = $false
@@ -27,9 +31,15 @@ function Resolve-Value([string]$Name) {
     return ($val | Out-String).Trim()
 }
 
-$Domain = Resolve-Value 'CUSTOM_DOMAIN_NAME'
+# Domain resolution order: explicit -Domain argument first, then
+# CUSTOM_DOMAIN_NAME from the environment (azd hook) or the azd env store.
+if (-not $Domain) { $Domain = Resolve-Value 'CUSTOM_DOMAIN_NAME' }
 if (-not $Domain) {
-    Write-Host '==> CUSTOM_DOMAIN_NAME is not set; no custom domain to bind. Skipping.'
+    Write-Host '==> No custom domain to bind (no argument and CUSTOM_DOMAIN_NAME is unset).'
+    Write-Host '    Pass one explicitly to bind by hand, e.g.:'
+    Write-Host '        ./scripts/bind-custom-domains.ps1 wasm.directory'
+    Write-Host '    or set it in the azd environment and re-provision:'
+    Write-Host '        azd env set CUSTOM_DOMAIN_NAME wasm.directory; azd provision'
     exit 0
 }
 

--- a/scripts/bind-custom-domains.ps1
+++ b/scripts/bind-custom-domains.ps1
@@ -5,7 +5,7 @@
 # Windows `postprovision` hook (see azure.yaml) and safe to run by hand:
 #
 #   ./scripts/bind-custom-domains.ps1                 # domain from azd env / env
-#   ./scripts/bind-custom-domains.ps1 wasm.directory  # domain given explicitly
+#   ./scripts/bind-custom-domains.ps1 -Domain wasm.directory  # domain explicit
 #
 # See the shell script's header and docs/azure-deployment.md section 7 for the
 # full rationale. In short: this automates the mechanical hostname add + managed
@@ -37,7 +37,7 @@ if (-not $Domain) { $Domain = Resolve-Value 'CUSTOM_DOMAIN_NAME' }
 if (-not $Domain) {
     Write-Host '==> No custom domain to bind (no argument and CUSTOM_DOMAIN_NAME is unset).'
     Write-Host '    Pass one explicitly to bind by hand, e.g.:'
-    Write-Host '        ./scripts/bind-custom-domains.ps1 wasm.directory'
+    Write-Host '        pwsh ./scripts/bind-custom-domains.ps1 -Domain wasm.directory'
     Write-Host '    or set it in the azd environment and re-provision:'
     Write-Host '        azd env set CUSTOM_DOMAIN_NAME wasm.directory; azd provision'
     exit 0
@@ -121,15 +121,20 @@ function Invoke-BindDomain([string]$App, [string]$D, [string]$Method) {
 
     Write-Host "  $D - binding managed certificate (validation: $Method)"
     if ($Method -eq 'HTTP') {
-        # HTTP (DigiCert) validation must reach the app over plain HTTP; open it
-        # for the probe, then restore the HTTP->HTTPS redirect. Used for both the
-        # apex and the api subdomain: managed-certificate TXT validation proved
-        # unreliable here (certs stuck in 'Pending'), whereas HTTP completes.
+        # HTTP (DigiCert) validation must reach the app over plain HTTP. Capture
+        # the current allowInsecure setting, open HTTP for the probe, then
+        # restore it: the backend intentionally keeps allowInsecure=true so the
+        # in-environment frontend can reach http://backend (see
+        # infra/modules/backend.bicep), while the frontend keeps it false. Both
+        # hostnames use HTTP validation because managed-certificate TXT
+        # validation proved unreliable here (certs stuck in 'Pending').
+        $prev = az containerapp ingress show -n $App -g $Rg --query allowInsecure -o tsv 2>$null
+        if ($prev -ne 'true') { $prev = 'false' }
         az containerapp ingress update -n $App -g $Rg --allow-insecure true 2>$null | Out-Null
         az containerapp hostname bind --resource-group $Rg --name $App --hostname $D `
             --environment $EnvName --validation-method $Method 2>$null | Out-Null
         $rc = $LASTEXITCODE
-        az containerapp ingress update -n $App -g $Rg --allow-insecure false 2>$null | Out-Null
+        az containerapp ingress update -n $App -g $Rg --allow-insecure $prev 2>$null | Out-Null
     }
     else {
         az containerapp hostname bind --resource-group $Rg --name $App --hostname $D `
@@ -178,7 +183,7 @@ if ($deferred -gt 0) {
          dig +short TXT asuid.$Domain
          dig +short TXT asuid.$ApiDomain
     3. Re-run this bind (or 'azd provision' again):
-         ./scripts/bind-custom-domains.ps1
+         pwsh ./scripts/bind-custom-domains.ps1 -Domain $Domain
 
     See docs/azure-deployment.md section 7 for details.
 "@

--- a/scripts/bind-custom-domains.sh
+++ b/scripts/bind-custom-domains.sh
@@ -42,8 +42,9 @@ certificates to the frontend/backend Container Apps.
   DOMAIN   Apex custom domain, e.g. "wasm.directory". When omitted, it is read
            from CUSTOM_DOMAIN_NAME (environment variable or azd env store).
 
-Resource group, Container App names and the api domain are likewise read from
-the environment or the azd env store.
+Resource group and Container App names are likewise read from the environment
+or the azd env store. The api subdomain comes from CUSTOM_API_DOMAIN_NAME,
+defaulting to "api.<DOMAIN>" when that is unset.
 EOF
 }
 
@@ -151,16 +152,23 @@ bind_domain() { # APP DOMAIN VALIDATION_METHOD
   log "  $domain — binding managed certificate (validation: $method)"
   local rc=0
   if [ "$method" = "HTTP" ]; then
-    # HTTP (DigiCert) validation must reach the app over plain HTTP; open it for
-    # the probe, then restore the HTTP->HTTPS redirect afterwards. Used for both
-    # the apex and the api subdomain: Container Apps managed-certificate TXT
-    # validation proved unreliable here (certs stuck in "Pending"), whereas HTTP
-    # validation completes.
+    # HTTP (DigiCert) validation must reach the app over plain HTTP. Capture the
+    # app's current allowInsecure setting, open HTTP for the probe, then restore
+    # exactly what was there — the backend intentionally keeps allowInsecure=true
+    # so the in-environment frontend can reach http://backend (see
+    # infra/modules/backend.bicep), while the frontend keeps it false to force
+    # HTTP->HTTPS. Both hostnames use HTTP validation because Container Apps
+    # managed-certificate TXT validation proved unreliable here (certs stuck in
+    # "Pending").
+    local prev_insecure
+    prev_insecure="$(az containerapp ingress show -n "$app" -g "$RG" \
+      --query allowInsecure -o tsv 2>/dev/null || true)"
+    [ "$prev_insecure" = "true" ] || prev_insecure=false
     az containerapp ingress update -n "$app" -g "$RG" --allow-insecure true >/dev/null 2>&1 || true
     az containerapp hostname bind \
       --resource-group "$RG" --name "$app" --hostname "$domain" \
       --environment "$ENVNAME" --validation-method "$method" >/dev/null 2>&1 || rc=$?
-    az containerapp ingress update -n "$app" -g "$RG" --allow-insecure false >/dev/null 2>&1 || true
+    az containerapp ingress update -n "$app" -g "$RG" --allow-insecure "$prev_insecure" >/dev/null 2>&1 || true
   else
     az containerapp hostname bind \
       --resource-group "$RG" --name "$app" --hostname "$domain" \
@@ -217,7 +225,7 @@ EOF
          dig +short TXT asuid.$DOMAIN
          dig +short TXT asuid.$API_DOMAIN
     3. Re-run this bind (or 'azd provision' again):
-         ./scripts/bind-custom-domains.sh
+         ./scripts/bind-custom-domains.sh $DOMAIN
 
     See docs/azure-deployment.md section 7 for details.
 EOF

--- a/scripts/bind-custom-domains.sh
+++ b/scripts/bind-custom-domains.sh
@@ -121,8 +121,8 @@ txt_resolves() { # FQDN
 
 # Add the hostname (if needed) and bind its managed certificate.
 # Returns 0 when bound (or already bound), 1 when deferred/failed.
-bind_domain() { # APP DOMAIN VALIDATION_METHOD IS_APEX
-  local app="$1" domain="$2" method="$3" is_apex="$4"
+bind_domain() { # APP DOMAIN VALIDATION_METHOD
+  local app="$1" domain="$2" method="$3"
   local state
   state="$(binding_state "$app" "$domain")"
   if [ "$state" = "SniEnabled" ]; then
@@ -150,9 +150,12 @@ bind_domain() { # APP DOMAIN VALIDATION_METHOD IS_APEX
 
   log "  $domain — binding managed certificate (validation: $method)"
   local rc=0
-  if [ "$is_apex" = "true" ]; then
-    # Apex certificates validate over HTTP; let DigiCert reach the app on plain
-    # HTTP for the probe, then restore the HTTP->HTTPS redirect afterwards.
+  if [ "$method" = "HTTP" ]; then
+    # HTTP (DigiCert) validation must reach the app over plain HTTP; open it for
+    # the probe, then restore the HTTP->HTTPS redirect afterwards. Used for both
+    # the apex and the api subdomain: Container Apps managed-certificate TXT
+    # validation proved unreliable here (certs stuck in "Pending"), whereas HTTP
+    # validation completes.
     az containerapp ingress update -n "$app" -g "$RG" --allow-insecure true >/dev/null 2>&1 || true
     az containerapp hostname bind \
       --resource-group "$RG" --name "$app" --hostname "$domain" \
@@ -181,13 +184,13 @@ verify() { # URL
 
 deferred=0
 
-if bind_domain "$FRONTEND_APP" "$DOMAIN" HTTP true; then
+if bind_domain "$FRONTEND_APP" "$DOMAIN" HTTP; then
   verify "https://$DOMAIN/"
 else
   deferred=$((deferred + 1))
 fi
 
-if bind_domain "$BACKEND_APP" "$API_DOMAIN" TXT false; then
+if bind_domain "$BACKEND_APP" "$API_DOMAIN" HTTP; then
   verify "https://$API_DOMAIN/v1/health"
 else
   deferred=$((deferred + 1))

--- a/scripts/bind-custom-domains.sh
+++ b/scripts/bind-custom-domains.sh
@@ -4,9 +4,11 @@
 #
 # This automates the mechanical half of docs/azure-deployment.md section 7. It
 # is invoked by azd as a `postprovision` hook (see azure.yaml) and is also safe
-# to run by hand at any time:
+# to run by hand at any time. The apex domain is taken from the first argument
+# when given, otherwise from CUSTOM_DOMAIN_NAME (environment or azd env store):
 #
-#   ./scripts/bind-custom-domains.sh
+#   ./scripts/bind-custom-domains.sh                 # domain from azd env / env
+#   ./scripts/bind-custom-domains.sh wasm.directory  # domain given explicitly
 #
 # What stays manual: delegating the DNS zone to Azure at your registrar. That
 # depends on your domain registrar and only you can do it. This script detects
@@ -16,8 +18,8 @@
 # live to finish the bind.
 #
 # Design notes:
-#   - No-op when CUSTOM_DOMAIN_NAME is empty (matches the conditional
-#     infra/modules/dns.bicep).
+#   - No-op when no domain is given (no argument and CUSTOM_DOMAIN_NAME empty),
+#     matching the conditional infra/modules/dns.bicep.
 #   - Idempotent: skips `hostname add` when the hostname is already present and
 #     skips `hostname bind` when a managed certificate is already bound
 #     (bindingType == SniEnabled), so re-running is a clean no-op.
@@ -30,6 +32,25 @@ set -euo pipefail
 log()  { printf '%s\n' "$*"; }
 warn() { printf '%s\n' "$*" >&2; }
 
+usage() {
+  cat <<'EOF'
+Usage: bind-custom-domains.sh [DOMAIN]
+
+Bind the apex + `api` subdomain custom hostnames and their managed TLS
+certificates to the frontend/backend Container Apps.
+
+  DOMAIN   Apex custom domain, e.g. "wasm.directory". When omitted, it is read
+           from CUSTOM_DOMAIN_NAME (environment variable or azd env store).
+
+Resource group, Container App names and the api domain are likewise read from
+the environment or the azd env store.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
 # Resolve a provisioning value: environment variable first (present when azd
 # runs this as a hook), then the azd environment store (for manual runs).
 resolve() { # NAME
@@ -41,9 +62,16 @@ resolve() { # NAME
   printf '%s' "$val"
 }
 
-DOMAIN="$(resolve CUSTOM_DOMAIN_NAME)"
+# Domain resolution order: explicit CLI argument first, then CUSTOM_DOMAIN_NAME
+# from the environment (azd sets it during the hook) or the azd env store.
+DOMAIN="${1:-}"
+[ -n "$DOMAIN" ] || DOMAIN="$(resolve CUSTOM_DOMAIN_NAME)"
 if [ -z "$DOMAIN" ]; then
-  log "==> CUSTOM_DOMAIN_NAME is not set; no custom domain to bind. Skipping."
+  log "==> No custom domain to bind (no argument and CUSTOM_DOMAIN_NAME is unset)."
+  log "    Pass one explicitly to bind by hand, e.g.:"
+  log "        ./scripts/bind-custom-domains.sh wasm.directory"
+  log "    or set it in the azd environment and re-provision:"
+  log "        azd env set CUSTOM_DOMAIN_NAME wasm.directory && azd provision"
   exit 0
 fi
 


### PR DESCRIPTION
## Problem

`scripts/bind-custom-domains.sh` (the azd `postprovision` hook added in #455) had two rough edges that surfaced while binding `api.wasm.directory` in production:

1. **No way to pass the domain by hand.** It reads the apex domain solely from `CUSTOM_DOMAIN_NAME` in the environment / azd env store. Run **by hand** from a checkout whose azd environment doesn't have that variable set — a fresh clone, or a CI-managed environment where the value only lives as a repo variable — and it silently no-ops, with no obvious way to tell it which domain to bind.

2. **The `api` subdomain certificate never issued.** The script bound the backend hostname with `--validation-method TXT`. In this Azure Container Apps environment the managed certificate got stuck in `Pending` (with no error) for tens of minutes and never completed, so `https://api.wasm.directory` had no TLS and returned `000`. The apex, which uses `HTTP` validation, always worked.

## Fix

### 1. Accept the apex domain as the first positional argument

```sh
./scripts/bind-custom-domains.sh wasm.directory          # bash
pwsh ./scripts/bind-custom-domains.ps1 wasm.directory    # PowerShell (-Domain)
```

- **Resolution order:** CLI argument, then `CUSTOM_DOMAIN_NAME` from the environment (set by azd during the hook), then the azd env store. Hook behavior is unchanged — hooks pass no args, so it still resolves from the env exactly as before.
- When no domain is found, it prints **actionable guidance** (how to pass it explicitly, or `azd env set ... && azd provision`) instead of a bare "Skipping".
- Adds `-h`/`--help` usage; mirrors the argument in the PowerShell twin via `param([string]$Domain)`.

### 2. Validate the `api` certificate over HTTP too

- Bind the backend hostname with `--validation-method HTTP` instead of `TXT`. HTTP (DigiCert) validation completes reliably where TXT stalls in `Pending` here.
- Key the `--allow-insecure` redirect dance on the **validation method** (`HTTP`) rather than an is-apex flag, so any HTTP-validated hostname gets the brief plain-HTTP window DigiCert's probe needs. (The `asuid` / `asuid.api` TXT *ownership* records are still required and still checked before `hostname add` — that's independent of the cert validation method.)
- Mirrored in the PowerShell twin; docs updated (bind flow, manual commands, and the "stuck in Pending" troubleshooting note).

This matches what was ultimately needed to bind `api.wasm.directory` live: after TXT certs stuck in `Pending` twice, an HTTP-validated bind issued the cert and both custom domains now serve 200.

## Testing

- `bash -n` and `shellcheck` clean.
- Exercised with offline `az`/`azd`/`dig`/`curl` stubs: no-arg no-op with guidance; explicit-domain bind of **both** hostnames over HTTP (the allow-insecure dance fires for frontend **and** backend, no `TXT`); idempotent re-run when already `SniEnabled` (only `hostname list`, no mutations); delegation-not-ready defer (no add/bind, exit 0); and `--help`. All correct.
- `cargo xtask test` green (fmt, clippy, tests, sql check, readme check).
- Verified live: after the HTTP-validated bind, `https://api.wasm.directory/v1/health` and `https://wasm.directory/` both return 200 (SniEnabled).

No Rust changes; no functional change to the provisioning-hook invocation path.
