### PR TITLE
Add wasmCloud's current interface packages to the wasmcloud namespace

### DIFF
--- a/registry/wasmcloud.toml
+++ b/registry/wasmcloud.toml
@@ -15,3 +15,23 @@ repository = "components/blobby-ui"
 [[interface]]
 name = "secrets"
 repository = "interfaces/wasmcloud/secrets"
+
+[[interface]]
+name = "messaging"
+repository = "interfaces/wasmcloud/messaging"
+
+[[interface]]
+name = "keyvalue"
+repository = "interfaces/wasmcloud/keyvalue"
+
+[[interface]]
+name = "blobstore"
+repository = "interfaces/wasmcloud/blobstore"
+
+[[interface]]
+name = "postgres"
+repository = "interfaces/wasmcloud/postgres"
+
+[[interface]]
+name = "host"
+repository = "interfaces/wasmcloud/host"


### PR DESCRIPTION
Adds the five interface packages wasmCloud currently publishes to ghcr.io/wasmcloud/interfaces/wasmcloud/ (messaging, keyvalue, blobstore, postgres, host) alongside the existing secrets entry. These are built and attested from the wit/ directory of wasmCloud/wasmCloud by its WIT CI.