### PR TITLE
Add 'fastly' namespace

### DIFF
--- a/registry/fastly.toml
+++ b/registry/fastly.toml
@@ -1,0 +1,7 @@
+[namespace]
+name = "fastly"
+registry = "ghcr.io/fastly"
+
+[[interface]]
+name = "compute"
+repository = "viceroy/fastly-compute"


### PR DESCRIPTION
This PR (attempts to, if I'm doing this right) add [this OCI package](https://github.com/fastly/Viceroy/pkgs/container/viceroy%2Ffastly-compute) which contains the `fastly:compute/service` world and a number of supporting interfaces.