### PR TITLE
pulseengine: point the falcon components at their nested repositories

### DIFF
--- a/registry/pulseengine.toml
+++ b/registry/pulseengine.toml
@@ -4,11 +4,11 @@ registry = "ghcr.io/pulseengine"
 
 [[component]]
 name = "falcon-flight"
-repository = "falcon-flight"
+repository = "falcon/flight"
 
 [[component]]
 name = "falcon-position"
-repository = "falcon-position"
+repository = "falcon/position"
 
 [[component]]
 name = "gale-nano"
@@ -16,16 +16,16 @@ repository = "gale-nano"
 
 [[component]]
 name = "falcon-rate"
-repository = "falcon-rate"
+repository = "falcon/rate"
 
 [[component]]
 name = "falcon-attitude"
-repository = "falcon-attitude"
+repository = "falcon/attitude"
 
 [[component]]
 name = "falcon-iekf"
-repository = "falcon-iekf"
+repository = "falcon/iekf"
 
 [[component]]
 name = "falcon-mixer"
-repository = "falcon-mixer"
+repository = "falcon/mixer"


### PR DESCRIPTION
The six `falcon` cascade components moved from flat repositories to nested ones as of `falcon-v1.133.0`, matching the `wasi/io` style already used in `registry/wasi.toml`.

```diff
-repository = "falcon-attitude"
+repository = "falcon/attitude"
```

…and the same for `flight`, `position`, `rate`, `iekf`, `mixer`. `gale-nano` is unrelated and untouched.

## Why

The flat repositories are **frozen at 1.131.1** — publishing now goes to the nested paths, so the current listings show a stale version and will not pick up any future release. e.g. <https://wasm.directory/pulseengine/falcon-attitude/1.131.1> is the newest indexed, while `1.133.0` has been published for a while.

**Component `name`s are unchanged on purpose**, so existing `wasm.directory/pulseengine/<name>` URLs keep working and simply start resolving to current versions.

## Verified before opening this

All six nested repositories resolve anonymously:

| repository | tags |
|---|---|
| `falcon/flight` | 1.133.0, latest |
| `falcon/position` | 1.133.0, latest |
| `falcon/rate` | 1.133.0, latest |
| `falcon/attitude` | 1.133.0, latest |
| `falcon/iekf` | 1.133.0, latest |
| `falcon/mixer` | 1.133.0, latest |

Each is a real Component-Model component (header `0061736d0d000100`), cosign-signed by digest, and carries the nine `org.opencontainers.image.*` annotations.

Thanks for wasm.directory — it is the thing that surfaced this gap for us.